### PR TITLE
Fix HTML entity conversion bug

### DIFF
--- a/AngleSharp/DOM/CharacterData.cs
+++ b/AngleSharp/DOM/CharacterData.cs
@@ -257,8 +257,8 @@
                 {
                     case Specification.Ampersand: temp.Append("&amp;"); break;
                     case Specification.NoBreakSpace: temp.Append("&nbsp;"); break;
-                    case Specification.GreaterThan: temp.Append("&lt;"); break;
-                    case Specification.LessThan: temp.Append("&gt;"); break;
+                    case Specification.GreaterThan: temp.Append("&gt;"); break;
+                    case Specification.LessThan: temp.Append("&lt;"); break;
                     default: temp.Append(_content[i]); break;
                 }
             }


### PR DESCRIPTION
&gt; and &lt; were mixed up in CharacterData.ToHtml
