### PR TITLE
Fix thread synchronization bug

### DIFF
--- a/AngleSharp/Foundation/Pool.cs
+++ b/AngleSharp/Foundation/Pool.cs
@@ -72,12 +72,14 @@
         /// <returns>The string that is contained in the stringbuilder.</returns>
         public static String ToPool(this StringBuilder sb)
         {
+            var result = sb.ToString();
+
             lock (_lock)
             {
                 _builder.Push(sb);
             }
 
-            return sb.ToString();
+            return result;
         }
 
 		/// <summary>


### PR DESCRIPTION
In the `Pool.ToPool` extension method, `StringBuilder` objects were being pushed to the common pool before their results were retrieved outside the lock. This could lead to `Clear` and `ToString` being called on the same `StringBuilder` object across two different threads (by `Pool.NewStringBuilder` and `Pool.ToPool`, respectively), resulting in a corrupted return value containing a bunch of `\0` characters.
