### PR TITLE
Element ToHtml method should be standard when it is selfclosing.

### DIFF
--- a/AngleSharp/DOM/Element.cs
+++ b/AngleSharp/DOM/Element.cs
@@ -677,9 +677,15 @@
             foreach (var attribute in _attributes)
                 sb.Append(Specification.Space).Append(attribute.ToString());
 
+            bool isSelfClosing = Flags.HasFlag(NodeFlags.SelfClosing);
+            if (isSelfClosing)
+            {
+                sb.Append(Specification.Solidus);
+            }
+
             sb.Append(Specification.GreaterThan);
 
-            if (!Flags.HasFlag(NodeFlags.SelfClosing))
+            if (!isSelfClosing)
             {
                 if (Flags.HasFlag(NodeFlags.LineTolerance) && FirstChild is IText)
                 {


### PR DESCRIPTION
before ToHtml example:
&lt;p&gt;&lt;img src="xxx"&gt;&lt;/p&gt;

after ToHtml example:
&lt;p&gt;&lt;img src="xxx"<span style="color:red;">/<span>&gt;&lt;/p&gt;

I think now will better.
