### PR TITLE
XmlMarkupFormatter: escape less-than (<) and ampersand (&) in attributes

### DIFF
--- a/AngleSharp/Xml/XmlMarkupFormatter.cs
+++ b/AngleSharp/Xml/XmlMarkupFormatter.cs
@@ -101,6 +101,8 @@
                 {
                     case Symbols.SingleQuote: temp.Append("&apos;"); break;
                     case Symbols.DoubleQuote: temp.Append("&quot;"); break;
+                    case Symbols.Ampersand: temp.Append("&amp;"); break;
+                    case Symbols.LessThan: temp.Append("&lt;"); break;
                     default: temp.Append(value[i]); break;
                 }
             }


### PR DESCRIPTION
This issue was mentioned in #128
