### PR TITLE
Feature #126

### DIFF
--- a/AngleSharp/AngleSharp.Core.csproj
+++ b/AngleSharp/AngleSharp.Core.csproj
@@ -23,6 +23,7 @@
     <DefineConstants>DEBUG;TRACE</DefineConstants>
     <ErrorReport>prompt</ErrorReport>
     <WarningLevel>4</WarningLevel>
+    <LangVersion>5</LangVersion>
   </PropertyGroup>
   <PropertyGroup Condition=" '$(Configuration)|$(Platform)' == 'Release|AnyCPU' ">
     <DebugType>pdbonly</DebugType>

--- a/AngleSharp/Html/FormDataSet.cs
+++ b/AngleSharp/Html/FormDataSet.cs
@@ -883,7 +883,12 @@
 
         class JsonObject : JsonElement
         {
-            public Dictionary<string, JsonElement> Properties { get; set; } = new Dictionary<string, JsonElement>();
+            public Dictionary<string, JsonElement> Properties { get; set; }
+
+            public JsonObject()
+            {
+                Properties = new Dictionary<string, JsonElement>();
+            }
 
             public override JsonElement this[object key]
             {
@@ -934,7 +939,12 @@
 
         class JsonArray : JsonElement
         {
-            public List<JsonElement> Elements { get; set; } = new List<JsonElement>();
+            public List<JsonElement> Elements { get; set; }
+
+            public JsonArray()
+            {
+                Elements = new List<JsonElement>();
+            }
 
             public override JsonElement this[object key]
             {
@@ -966,7 +976,7 @@
                         needsComma = true;
                     }
 
-                    writer.Write(element?.ToString() ?? "null");
+                    writer.Write(element != null ? element.ToString() : "null");
                 }
                 writer.Write(']');
             }
@@ -976,7 +986,7 @@
                 StringBuilder sb = new StringBuilder("[");
                 foreach (JsonElement element in Elements)
                 {
-                    sb.Append(element?.ToString() ?? "null").Append(",");
+                    sb.Append(element != null ? element.ToString() : "null").Append(",");
                 }
 
                 if (sb.Length > 1)

--- a/AngleSharp/Html/FormDataSet.cs
+++ b/AngleSharp/Html/FormDataSet.cs
@@ -319,12 +319,12 @@
 
             public abstract Boolean Contains(String boundary, Encoding encoding);
 
-            protected static List<Step> ParseJSONPath(string path)
+            protected static List<Step> ParseJSONPath(String path)
             {
                 //1. Let path be the path we are to parse.
 
                 //2. Let original be a copy of path.
-                string original = path;
+                String original = path;
 
                 try
                 {
@@ -493,7 +493,7 @@
                 return new List<Step> { new Step { Key = original, Last = true, Type = StepType.Object } };
             }
 
-            protected static JsonElement JsonEncodeValue(JsonElement context, Step step, JsonElement currentValue, JsonElement entryValue, bool isFile)
+            protected static JsonElement JsonEncodeValue(JsonElement context, Step step, JsonElement currentValue, JsonElement entryValue, Boolean isFile)
             {
                 //1. Let context be the context this algorithm is called with.
                 //2. Let step be the step of the path this algorithm is called with.
@@ -872,22 +872,22 @@
 
             public override void WriteTo(StreamWriter writer)
             {
-                writer.Write(Value is string ? "\"" + Value + "\"" : Value.ToString());
+                writer.Write(Value is String ? "\"" + Value + "\"" : Value.ToString());
             }
 
-            public override string ToString()
+            public override String ToString()
             {
-                return Value is string ? "\"" + Value + "\"" : Value.ToString();
+                return Value is String ? "\"" + Value + "\"" : Value.ToString();
             }
         }
 
         class JsonObject : JsonElement
         {
-            public Dictionary<string, JsonElement> Properties { get; set; }
+            public Dictionary<String, JsonElement> Properties { get; set; }
 
             public JsonObject()
             {
-                Properties = new Dictionary<string, JsonElement>();
+                Properties = new Dictionary<String, JsonElement>();
             }
 
             public override JsonElement this[object key]
@@ -900,8 +900,8 @@
             public override void WriteTo(StreamWriter writer)
             {
                 writer.Write('{');
-                bool needsComma = false;
-                foreach (KeyValuePair<string, JsonElement> property in Properties)
+                Boolean needsComma = false;
+                foreach (KeyValuePair<String, JsonElement> property in Properties)
                 {
                     if (needsComma)
                     {
@@ -921,10 +921,10 @@
                 writer.Write('}');
             }
 
-            public override string ToString()
+            public override String ToString()
             {
                 StringBuilder sb = new StringBuilder("{");
-                foreach (KeyValuePair<string, JsonElement> property in Properties)
+                foreach (KeyValuePair<String, JsonElement> property in Properties)
                 {
                     sb.Append("\"").Append(property.Key).Append("\"").Append(":").Append(property.Value.ToString()).Append(",");
                 }
@@ -981,7 +981,7 @@
                 writer.Write(']');
             }
 
-            public override string ToString()
+            public override String ToString()
             {
                 StringBuilder sb = new StringBuilder("[");
                 foreach (JsonElement element in Elements)
@@ -999,13 +999,13 @@
 
         class Step
         {
-            public bool Append { get; internal set; }
+            public Boolean Append { get; internal set; }
             public object Key { get; internal set; }
-            public bool Last { get; internal set; }
+            public Boolean Last { get; internal set; }
             public StepType NextType { get; internal set; }
             public StepType Type { get; internal set; }
 
-            public override string ToString()
+            public override String ToString()
             {
                 return String.Format("{0} [{1}]", Key, Type);
             }


### PR DESCRIPTION
Removes C# 6 features which i forgot to remove previously and adjusts type naming to AngleSharps.
Also sets language features version in AngleSharp.Core project to C# 5 so no C# 6 is used accidentally unless you decide otherwise.
Refs #126
