### PR TITLE
Fix Node.CompareDocumentPosition

### DIFF
--- a/AngleSharp.Core.Tests/AngleSharp.Core.Tests.csproj
+++ b/AngleSharp.Core.Tests/AngleSharp.Core.Tests.csproj
@@ -113,6 +113,7 @@
     <Compile Include="Html\Adoption.cs" />
     <Compile Include="Html\BasicRuleSet.cs" />
     <Compile Include="Html\CData.cs" />
+    <Compile Include="Html\CompareDocumentPosition.cs" />
     <Compile Include="Html\Doctype.cs" />
     <Compile Include="Html\DomManipulation.cs" />
     <Compile Include="Html\HtmlConstruction.cs" />

--- a/AngleSharp.Core.Tests/Html/CompareDocumentPosition.cs
+++ b/AngleSharp.Core.Tests/Html/CompareDocumentPosition.cs
@@ -1,0 +1,56 @@
+﻿using AngleSharp.Dom;
+using NUnit.Framework;
+
+namespace AngleSharp.Core.Tests
+{
+    [TestFixture]
+    public class CompareDocumentPositionTests
+    {
+        IDocument doc;
+
+        IElement parent1, parent2, child1, child2;
+
+        [SetUp]
+        public void SetUp()
+        {
+            doc = "<!DOCTYPE html><html><head><title>Title</title></head><body><div id='parent-1'><span id='child-1'>1</span></div><div id='parent-2'><span id='child-2'>2</span></div></body></html>".ToHtmlDocument();
+
+            parent1 = doc.QuerySelector("#parent-1");
+            parent2 = doc.QuerySelector("#parent-2");
+            child1 = doc.QuerySelector("#child-1");
+            child2 = doc.QuerySelector("#child-2");
+
+        }
+
+        [Test]
+        public void SameParent()
+        {
+            Assert.AreEqual(DocumentPositions.Following, parent1.CompareDocumentPosition(parent2), "Parent 2 follows parent 1.");
+            Assert.AreEqual(DocumentPositions.Preceding, parent2.CompareDocumentPosition(parent1), "Parent 1 precedes parent 2.");
+        }
+
+        [Test]
+        public void NestedChildren()
+        {
+            Assert.AreEqual(DocumentPositions.Following, child1.CompareDocumentPosition(child2), "Child 2 follows child 1.");
+            Assert.AreEqual(DocumentPositions.Preceding, child2.CompareDocumentPosition(child1), "Child 1 precedes child 2.");
+        }
+
+        [Test]
+        public void Containing()
+        {
+            Assert.AreEqual(DocumentPositions.ContainedBy | DocumentPositions.Following, parent1.CompareDocumentPosition(child1), "Child 1 is contained by and follows parent 1.");
+            Assert.AreEqual(DocumentPositions.Contains | DocumentPositions.Preceding, child1.CompareDocumentPosition(parent1), "Parent 1 contains and precedes child 1.");
+        }
+
+        [Test]
+        public void DifferentLevels()
+        {
+            Assert.AreEqual(DocumentPositions.Following, parent1.CompareDocumentPosition(child2), "Child 2 follows parent 1.");
+            Assert.AreEqual(DocumentPositions.Preceding, child2.CompareDocumentPosition(parent1), "Parent 1 precedes child 2.");
+
+            Assert.AreEqual(DocumentPositions.Following, child1.CompareDocumentPosition(parent2), "Parent 2 follows child 1.");
+            Assert.AreEqual(DocumentPositions.Preceding, parent2.CompareDocumentPosition(child1), "Child 1 precedes parent 2.");
+        }
+    }
+}

--- a/AngleSharp/Extensions/NodeExtensions.cs
+++ b/AngleSharp/Extensions/NodeExtensions.cs
@@ -203,37 +203,6 @@
         }
 
         /// <summary>
-        /// Checks if the context node is before the provided node.
-        /// </summary>
-        /// <param name="before">The context node.</param>
-        /// <param name="after">The provided reference node.</param>
-        /// <returns>True if the context node is preceding the reference node in tree order.</returns>
-        public static Boolean IsPreceding(this INode before, INode after)
-        {
-            var parent = before.Parent;
-
-            if (parent == null)
-                return false;
-            else if (parent == after)
-                return true;
-            else if (parent == after.Parent)
-                return parent.IndexOf(before) < parent.IndexOf(after);
-
-            return parent.IsPreceding(after);
-        }
-
-        /// <summary>
-        /// Checks if the context node is after the provided node.
-        /// </summary>
-        /// <param name="after">The context node.</param>
-        /// <param name="before">The provided reference node.</param>
-        /// <returns>True if the context node is following the reference node in tree order.</returns>
-        public static Boolean IsFollowing(this INode after, INode before)
-        {
-            return before.IsPreceding(after);
-        }
-
-        /// <summary>
         /// Gets the associated host object, if any. This is mostly interesting for the HTML5 template tag.
         /// </summary>
         /// <param name="node">The node that probably has an host object</param>


### PR DESCRIPTION
Same as #167 but on a different branch.

---

`Node.CompareDocumentPosition` didn't handle nested elements correctly. Example:

```
<div id='parent-1'>
    <span id='child-1'>1</span>
</div>
<div id='parent-2'>
    <span id='child-2'>2</span>
</div>
```

Both `child1.CompareDocumentPosition(child2)` and `child2.CompareDocumentPosition(child1)` would result in `DocumentPositions.Following`.

I added a few test cases as well though they're probably not comprehensive.
