### PR TITLE
Fix #210 - Specify char array range to create string

### DIFF
--- a/AngleSharp/TextSource.cs
+++ b/AngleSharp/TextSource.cs
@@ -127,8 +127,8 @@
 
                 var raw = _raw.ToArray();
                 var raw_chars = new Char[_encoding.GetMaxCharCount(raw.Length)];
-                _decoder.GetChars(raw, 0, raw.Length, raw_chars, 0);
-                var content = new String(raw_chars);
+                var charLength = _decoder.GetChars(raw, 0, raw.Length, raw_chars, 0);
+                var content = new String(raw_chars, 0, charLength);
                 var index = Math.Min(_index, content.Length);
 
                 if (content.Substring(0, index).Equals(_content.ToString(0, index)))


### PR DESCRIPTION
Sorry, I noticed that created incorrect string.

```
[ 'a', 'b', 'c', '\0', '\0', '\0'... ]
```

It shoud be

```
[ 'a', 'b', 'c' ]
```

Please merge again.
