### PR TITLE
resolved issue that prevented storing multiple cookies in the jar

### DIFF
--- a/AngleSharp/Services/Default/MemoryCookieService.cs
+++ b/AngleSharp/Services/Default/MemoryCookieService.cs
@@ -32,12 +32,18 @@
             set
             {
                 var domain = new Uri(origin);
-                var cookies = _container.GetCookies(domain);
+                var existingCookies = _container.GetCookies(domain);
 
-                foreach (Cookie cookie in cookies)
+                foreach (Cookie cookie in existingCookies)
+                {
                     cookie.Expired = true;
+                }
 
-                _container.SetCookies(domain, value); 
+                var cookies = value.Split(new[] { ';' });
+                foreach (var cookie in cookies)
+                {
+                    _container.SetCookies(domain, cookie);
+                }
             }
         }
     }


### PR DESCRIPTION
Howdy @FlorianRappl
# Problem

`Context.Active.Cookies` only ever shows one cookie (i.e. cookies are truncated). After getting to know the code base, was able to track it back to the current `MemoryCookieService` implementation.
# Resolution

https://msdn.microsoft.com/en-us/library/system.net.cookiecontainer.setcookies(v=vs.110).aspx

> Adds Cookie instances for one or more cookies from an HTTP cookie header to the CookieContainer for a specific URI.

Whilst the documentation mentions that it sets one or more cookies, in reality it's not happening. This pull-request splits cookies up and adds them one by one.
