### PR TITLE
Add .NET Core support.

### DIFF
--- a/Nuget/AngleSharp.nuspec
+++ b/Nuget/AngleSharp.nuspec
@@ -1,4 +1,4 @@
-<?xml version="1.0"?>
+<?xml version="1.0" encoding="utf-8"?>
 <package>
   <metadata>
     <id>AngleSharp</id>
@@ -14,16 +14,35 @@
     <copyright>Copyright 2015, AngleSharp.</copyright>
     <tags>html html5 css css3 xml dom dom4 parser engine hypertext markup language query selector attributes linq angle bracket web internet text headless browser</tags>
     <dependencies>
-        <group targetFramework="portable-windows8+net45+windowsphone8+wpa">
-        </group>
-        <group targetFramework="net45">
-        </group>
-        <group targetFramework="net40">
-            <dependency id="Microsoft.Bcl.Async" version="1.0.168" />
-        </group>
-        <group targetFramework="sl50">
-            <dependency id="Microsoft.Bcl.Async" version="1.0.168" />
-        </group>
+      <group targetFramework="dotnet">
+        <dependency id="System.Collections" version="4.0.0" />
+        <dependency id="System.Diagnostics.Debug" version="4.0.0" />
+        <dependency id="System.Dynamic.Runtime" version="4.0.0" />
+        <dependency id="System.Globalization" version="4.0.0" />
+        <dependency id="System.IO" version="4.0.0" />
+        <dependency id="System.Linq" version="4.0.0" />
+        <dependency id="System.Net.Primitives" version="3.9.0" />
+        <dependency id="System.Net.Requests" version="3.9.0" />
+        <dependency id="System.Reflection" version="4.0.0" />
+        <dependency id="System.Reflection.Extensions" version="4.0.0" />
+        <dependency id="System.Runtime" version="4.0.0" />
+        <dependency id="System.Runtime.Extensions" version="4.0.0" />
+        <dependency id="System.Text.Encoding" version="4.0.0" />
+        <dependency id="System.Text.Encoding.Extensions" version="4.0.0" />
+        <dependency id="System.Text.RegularExpressions" version="4.0.0" />
+        <dependency id="System.Threading" version="4.0.0" />
+        <dependency id="System.Threading.Tasks" version="4.0.0" />
+      </group>
+      <group targetFramework="portable-windows8+net45+windowsphone8+wpa">
+	  </group>
+      <group targetFramework="net45">
+	  </group>
+      <group targetFramework="net40">
+        <dependency id="Microsoft.Bcl.Async" version="1.0.168" />
+      </group>
+      <group targetFramework="sl50">
+        <dependency id="Microsoft.Bcl.Async" version="1.0.168" />
+      </group>
     </dependencies>
   </metadata>
 </package>

--- a/Package.ps1
+++ b/Package.ps1
@@ -27,6 +27,7 @@ Update-Content "net40" "AngleSharp.Legacy"
 Update-Content "sl50" "AngleSharp.Silverlight"
 Update-Content "net45" "AngleSharp"
 Update-Content "portable-windows8+net45+windowsphone8+wpa" "AngleSharp"
+Update-Content "dotnet" "AngleSharp"
 
 $version = Update-Version "Nuget\lib\net40\AngleSharp.dll"
 $success = Publish-Package $version


### PR DESCRIPTION
Fixes #271. 
- Add .NET Core support by duplicating PCL profile 259 output to dotnet folder.

~~\- Use NuSpec.ReferenceGenerator to manage the dependencies for dotnet group.~~
