### PR TITLE
Pool fixes for #300

### DIFF
--- a/AngleSharp/Parser/BaseTokenizer.cs
+++ b/AngleSharp/Parser/BaseTokenizer.cs
@@ -15,7 +15,6 @@
     {
         #region Fields
 
-        protected readonly StringBuilder _stringBuffer;
         protected readonly IEventAggregator _events;
         readonly Stack<UInt16> _columns;
         readonly TextSource _source;
@@ -30,7 +29,7 @@
 
         public BaseTokenizer(TextSource source, IEventAggregator events)
         {
-            _stringBuffer = Pool.NewStringBuilder();
+            StringBuffer = Pool.NewStringBuilder();
             _events = events;
             _columns = new Stack<UInt16>();
             _source = source;
@@ -42,6 +41,8 @@
         #endregion
 
         #region Properties
+
+        protected StringBuilder StringBuffer { get; private set; }
 
         public TextSource Source
         {
@@ -95,13 +96,19 @@
 
         public String FlushBuffer()
         {
-            var content = _stringBuffer.ToString();
-            _stringBuffer.Clear();
+            var content = StringBuffer.ToString();
+            StringBuffer.Clear();
             return content;
         }
 
         public void Dispose()
         {
+            var isDisposed = StringBuffer == null;
+            if (isDisposed)
+            {
+                return;
+            }
+
             var disposable = _source as IDisposable;
 
             if (disposable != null)
@@ -109,7 +116,8 @@
                 disposable.Dispose();
             }
 
-            _stringBuffer.ToPool();
+            StringBuffer.ToPool();
+            StringBuffer = null;
         }
 
         public TextPosition GetCurrentPosition()

--- a/AngleSharp/Parser/Css/CssBuilder.cs
+++ b/AngleSharp/Parser/Css/CssBuilder.cs
@@ -1120,6 +1120,7 @@
                 token = NextToken();
             }
 
+            var selectorIsValid = selector.IsValid;
             var result = selector.ToPool();
             var node = result as CssNode;
 
@@ -1129,7 +1130,7 @@
                 node.SourceCode = CreateView(start, end);
             }
 
-            if (!selector.IsValid && !_parser.Options.IsToleratingInvalidValues)
+            if (!selectorIsValid && !_parser.Options.IsToleratingInvalidValues)
             {
                 RaiseErrorOccurred(CssParseError.InvalidSelector, start);
                 result = null;
@@ -1153,6 +1154,7 @@
 
             important = value.IsImportant;
             _tokenizer.IsInValue = false;
+            var valueIsValid = value.IsValid;
             var result = value.ToPool();
             var node = result as CssNode;
 
@@ -1162,7 +1164,7 @@
                 node.SourceCode = CreateView(start, end);
             }
 
-            if (!value.IsValid && !_parser.Options.IsToleratingInvalidValues)
+            if (!valueIsValid && !_parser.Options.IsToleratingInvalidValues)
             {
                 RaiseErrorOccurred(CssParseError.InvalidValue, start);
                 result = null;

--- a/AngleSharp/Parser/Css/CssTokenizer.cs
+++ b/AngleSharp/Parser/Css/CssTokenizer.cs
@@ -386,11 +386,11 @@
 
                         if (current.IsLineBreak())
                         {
-                            _stringBuffer.AppendLine();
+                            StringBuffer.AppendLine();
                         }
                         else if (current != Symbols.EndOfFile)
                         {
-                            _stringBuffer.Append(ConsumeEscape(current));
+                            StringBuffer.Append(ConsumeEscape(current));
                         }
                         else
                         {
@@ -402,7 +402,7 @@
                         break;
 
                     default:
-                        _stringBuffer.Append(current);
+                        StringBuffer.Append(current);
                         break;
                 }
             }
@@ -434,11 +434,11 @@
 
                         if (current.IsLineBreak())
                         {
-                            _stringBuffer.AppendLine();
+                            StringBuffer.AppendLine();
                         }
                         else if (current != Symbols.EndOfFile)
                         {
-                            _stringBuffer.Append(ConsumeEscape(current));
+                            StringBuffer.Append(ConsumeEscape(current));
                         }
                         else
                         {
@@ -450,7 +450,7 @@
                         break;
 
                     default:
-                        _stringBuffer.Append(current);
+                        StringBuffer.Append(current);
                         break;
                 }
             }
@@ -465,7 +465,7 @@
 
             while (current.IsHex())
             {
-                _stringBuffer.Append(current);
+                StringBuffer.Append(current);
                 current = GetNext();
             }
 
@@ -482,13 +482,13 @@
 
             if (current.IsNameStart())
             {
-                _stringBuffer.Append(current);
+                StringBuffer.Append(current);
                 return HashRest();
             }
             else if (IsValidEscape(current))
             {
                 current = GetNext();
-                _stringBuffer.Append(ConsumeEscape(current));
+                StringBuffer.Append(ConsumeEscape(current));
                 return HashRest();
             }
             else if (current == Symbols.ReverseSolidus)
@@ -515,12 +515,12 @@
 
                 if (current.IsName())
                 {
-                    _stringBuffer.Append(current);
+                    StringBuffer.Append(current);
                 }
                 else if (IsValidEscape(current))
                 {
                     current = GetNext();
-                    _stringBuffer.Append(ConsumeEscape(current));
+                    StringBuffer.Append(ConsumeEscape(current));
                 }
                 else if (current == Symbols.ReverseSolidus)
                 {
@@ -554,11 +554,11 @@
                         return NewComment(FlushBuffer());
                     }
 
-                    _stringBuffer.Append(Symbols.Asterisk);
+                    StringBuffer.Append(Symbols.Asterisk);
                 }
                 else
                 {
-                    _stringBuffer.Append(current);
+                    StringBuffer.Append(current);
                     current = GetNext();
                 }
             }
@@ -580,7 +580,7 @@
 
                 if (current.IsNameStart() || IsValidEscape(current))
                 {
-                    _stringBuffer.Append(Symbols.Minus);
+                    StringBuffer.Append(Symbols.Minus);
                     return AtKeywordRest(current);
                 }
 
@@ -589,13 +589,13 @@
             }
             else if (current.IsNameStart())
             {
-                _stringBuffer.Append(current);
+                StringBuffer.Append(current);
                 return AtKeywordRest(GetNext());
             }
             else if (IsValidEscape(current))
             {
                 current = GetNext();
-                _stringBuffer.Append(ConsumeEscape(current));
+                StringBuffer.Append(ConsumeEscape(current));
                 return AtKeywordRest(GetNext());
             }
             else
@@ -614,12 +614,12 @@
             {
                 if (current.IsName())
                 {
-                    _stringBuffer.Append(current);
+                    StringBuffer.Append(current);
                 }
                 else if (IsValidEscape(current))
                 {
                     current = GetNext();
-                    _stringBuffer.Append(ConsumeEscape(current));
+                    StringBuffer.Append(ConsumeEscape(current));
                 }
                 else
                 {
@@ -642,7 +642,7 @@
 
                 if (current.IsNameStart() || IsValidEscape(current))
                 {
-                    _stringBuffer.Append(Symbols.Minus);
+                    StringBuffer.Append(Symbols.Minus);
                     return IdentRest(current);
                 }
 
@@ -651,13 +651,13 @@
             }
             else if (current.IsNameStart())
             {
-                _stringBuffer.Append(current);
+                StringBuffer.Append(current);
                 return IdentRest(GetNext());
             }
             else if (current == Symbols.ReverseSolidus && IsValidEscape(current))
             {
                 current = GetNext();
-                _stringBuffer.Append(ConsumeEscape(current));
+                StringBuffer.Append(ConsumeEscape(current));
                 return IdentRest(GetNext());
             }
 
@@ -673,12 +673,12 @@
             {
                 if (current.IsName())
                 {
-                    _stringBuffer.Append(current);
+                    StringBuffer.Append(current);
                 }
                 else if (IsValidEscape(current))
                 {
                     current = GetNext();
-                    _stringBuffer.Append(ConsumeEscape(current));
+                    StringBuffer.Append(ConsumeEscape(current));
                 }
                 else if (current == Symbols.RoundBracketOpen)
                 {
@@ -727,28 +727,28 @@
             {
                 if (current.IsOneOf(Symbols.Plus, Symbols.Minus))
                 {
-                    _stringBuffer.Append(current);
+                    StringBuffer.Append(current);
                     current = GetNext();
 
                     if (current == Symbols.Dot)
                     {
-                        _stringBuffer.Append(current);
-                        _stringBuffer.Append(GetNext());
+                        StringBuffer.Append(current);
+                        StringBuffer.Append(GetNext());
                         return NumberFraction();
                     }
 
-                    _stringBuffer.Append(current);
+                    StringBuffer.Append(current);
                     return NumberRest();
                 }
                 else if (current == Symbols.Dot)
                 {
-                    _stringBuffer.Append(current);
-                    _stringBuffer.Append(GetNext());
+                    StringBuffer.Append(current);
+                    StringBuffer.Append(GetNext());
                     return NumberFraction();
                 }
                 else if (current.IsDigit())
                 {
-                    _stringBuffer.Append(current);
+                    StringBuffer.Append(current);
                     return NumberRest();
                 }
 
@@ -768,19 +768,19 @@
 
                 if (current.IsDigit())
                 {
-                    _stringBuffer.Append(current);
+                    StringBuffer.Append(current);
                 }
                 else if (current.IsNameStart())
                 {
                     var number = FlushBuffer();
-                    _stringBuffer.Append(current);
+                    StringBuffer.Append(current);
                     return Dimension(number);
                 }
                 else if (IsValidEscape(current))
                 {
                     current = GetNext();
                     var number = FlushBuffer();
-                    _stringBuffer.Append(ConsumeEscape(current));
+                    StringBuffer.Append(ConsumeEscape(current));
                     return Dimension(number);
                 }
                 else
@@ -798,7 +798,7 @@
 
                     if (current.IsDigit())
                     {
-                        _stringBuffer.Append(Symbols.Dot).Append(current);
+                        StringBuffer.Append(Symbols.Dot).Append(current);
                         return NumberFraction();
                     }
 
@@ -832,19 +832,19 @@
             {
                 if (current.IsDigit())
                 {
-                    _stringBuffer.Append(current);
+                    StringBuffer.Append(current);
                 }
                 else if (current.IsNameStart())
                 {
                     var number = FlushBuffer();
-                    _stringBuffer.Append(current);
+                    StringBuffer.Append(current);
                     return Dimension(number);
                 }
                 else if (IsValidEscape(current))
                 {
                     current = GetNext();
                     var number = FlushBuffer();
-                    _stringBuffer.Append(ConsumeEscape(current));
+                    StringBuffer.Append(ConsumeEscape(current));
                     return Dimension(number);
                 }
                 else
@@ -884,12 +884,12 @@
 
                 if (current.IsLetter())
                 {
-                    _stringBuffer.Append(current);
+                    StringBuffer.Append(current);
                 }
                 else if (IsValidEscape(current))
                 {
                     current = GetNext();
-                    _stringBuffer.Append(ConsumeEscape(current));
+                    StringBuffer.Append(ConsumeEscape(current));
                 }
                 else
                 {
@@ -910,7 +910,7 @@
 
                 if (current.IsDigit())
                 {
-                    _stringBuffer.Append(current);
+                    StringBuffer.Append(current);
                 }
                 else
                 {
@@ -971,7 +971,7 @@
                 }
                 else if (current != Symbols.ReverseSolidus)
                 {
-                    _stringBuffer.Append(current);
+                    StringBuffer.Append(current);
                 }
                 else
                 {
@@ -985,11 +985,11 @@
                     }
                     else if (current.IsLineBreak())
                     {
-                        _stringBuffer.AppendLine();
+                        StringBuffer.AppendLine();
                     }
                     else
                     {
-                        _stringBuffer.Append(ConsumeEscape(current));
+                        StringBuffer.Append(ConsumeEscape(current));
                     }
                 }
             }
@@ -1019,7 +1019,7 @@
                 }
                 else if (current != Symbols.ReverseSolidus)
                 {
-                    _stringBuffer.Append(current);
+                    StringBuffer.Append(current);
                 }
                 else
                 {
@@ -1033,11 +1033,11 @@
                     }
                     else if (current.IsLineBreak())
                     {
-                        _stringBuffer.AppendLine();
+                        StringBuffer.AppendLine();
                     }
                     else
                     {
-                        _stringBuffer.Append(ConsumeEscape(current));
+                        StringBuffer.Append(ConsumeEscape(current));
                     }
                 }
             }
@@ -1065,12 +1065,12 @@
                 }
                 else if (current != Symbols.ReverseSolidus)
                 {
-                    _stringBuffer.Append(current);
+                    StringBuffer.Append(current);
                 }
                 else if (IsValidEscape(current))
                 {
                     current = GetNext();
-                    _stringBuffer.Append(ConsumeEscape(current));
+                    StringBuffer.Append(ConsumeEscape(current));
                 }
                 else
                 {
@@ -1132,7 +1132,7 @@
                 else if (IsValidEscape(current))
                 {
                     current = GetNext();
-                    _stringBuffer.Append(ConsumeEscape(current));
+                    StringBuffer.Append(ConsumeEscape(current));
                 }
                 else
                 {
@@ -1145,7 +1145,7 @@
                         ++curly;
                     }
 
-                    _stringBuffer.Append(current);
+                    StringBuffer.Append(current);
                 }
 
                 current = GetNext();
@@ -1162,13 +1162,13 @@
         {
             for (var i = 0; i < 6 && current.IsHex(); i++)
             {
-                _stringBuffer.Append(current);
+                StringBuffer.Append(current);
                 current = GetNext();
             }
 
-            if (_stringBuffer.Length != 6)
+            if (StringBuffer.Length != 6)
             {
-                for (var i = 0; i < 6 - _stringBuffer.Length; i++)
+                for (var i = 0; i < 6 - StringBuffer.Length; i++)
                 {
                     if (current != Symbols.QuestionMark)
                     {
@@ -1176,7 +1176,7 @@
                         break;
                     }
 
-                    _stringBuffer.Append(current);
+                    StringBuffer.Append(current);
                     current = GetNext();
                 }
 
@@ -1198,7 +1198,7 @@
                             break;
                         }
 
-                        _stringBuffer.Append(current);
+                        StringBuffer.Append(current);
                         current = GetNext();
                     }
 
@@ -1393,7 +1393,7 @@
 
             if (current.IsDigit())
             {
-                _stringBuffer.Append(letter).Append(current);
+                StringBuffer.Append(letter).Append(current);
                 return SciNotation();
             }
             else if (current == Symbols.Plus || current == Symbols.Minus)
@@ -1403,7 +1403,7 @@
 
                 if (current.IsDigit())
                 {
-                    _stringBuffer.Append(letter).Append(op).Append(current);
+                    StringBuffer.Append(letter).Append(op).Append(current);
                     return SciNotation();
                 }
 
@@ -1411,7 +1411,7 @@
             }
 
             var number = FlushBuffer();
-            _stringBuffer.Append(letter);
+            StringBuffer.Append(letter);
             Back();
             return Dimension(number);
         }
@@ -1426,14 +1426,14 @@
             if (current.IsNameStart())
             {
                 var number = FlushBuffer();
-                _stringBuffer.Append(Symbols.Minus).Append(current);
+                StringBuffer.Append(Symbols.Minus).Append(current);
                 return Dimension(number);
             }
             else if (IsValidEscape(current))
             {
                 current = GetNext();
                 var number = FlushBuffer();
-                _stringBuffer.Append(Symbols.Minus).Append(ConsumeEscape(current));
+                StringBuffer.Append(Symbols.Minus).Append(ConsumeEscape(current));
                 return Dimension(number);
             }
             else

--- a/AngleSharp/Parser/Html/HtmlTokenizer.cs
+++ b/AngleSharp/Parser/Html/HtmlTokenizer.cs
@@ -153,7 +153,7 @@
                         break;
 
                     default:
-                        _stringBuffer.Append(c);
+                        StringBuffer.Append(c);
                         break;
                 }
 
@@ -177,7 +177,7 @@
                 {
                     case Symbols.Null:
                         RaiseErrorOccurred(HtmlParseError.Null);
-                        _stringBuffer.Append(Symbols.Replacement);
+                        StringBuffer.Append(Symbols.Replacement);
                         break;
 
                     case Symbols.EndOfFile:
@@ -185,7 +185,7 @@
                         return NewCharacter();
 
                     default:
-                        _stringBuffer.Append(c);
+                        StringBuffer.Append(c);
                         break;
                 }
 
@@ -223,11 +223,11 @@
 
                     case Symbols.Null:
                         RaiseErrorOccurred(HtmlParseError.Null);
-                        _stringBuffer.Append(Symbols.Replacement);
+                        StringBuffer.Append(Symbols.Replacement);
                         break;
 
                     default:
-                        _stringBuffer.Append(c);
+                        StringBuffer.Append(c);
                         break;
                 }
 
@@ -248,23 +248,23 @@
 
                 if (c.IsUppercaseAscii())
                 {
-                    _stringBuffer.Append(Char.ToLower(c));
+                    StringBuffer.Append(Char.ToLower(c));
                     return RCDataNameEndTag(GetNext());
                 }
                 else if (c.IsLowercaseAscii())
                 {
-                    _stringBuffer.Append(c);
+                    StringBuffer.Append(c);
                     return RCDataNameEndTag(GetNext());
                 }
                 else
                 {
-                    _stringBuffer.Append(Symbols.LessThan).Append(Symbols.Solidus);
+                    StringBuffer.Append(Symbols.LessThan).Append(Symbols.Solidus);
                     return RCDataText(c);
                 }
             }
             else
             {
-                _stringBuffer.Append(Symbols.LessThan);
+                StringBuffer.Append(Symbols.LessThan);
                 return RCDataText(c);
             }
         }
@@ -285,15 +285,15 @@
                 }
                 else if (c.IsUppercaseAscii())
                 {
-                    _stringBuffer.Append(Char.ToLower(c));
+                    StringBuffer.Append(Char.ToLower(c));
                 }
                 else if (c.IsLowercaseAscii())
                 {
-                    _stringBuffer.Append(c);
+                    StringBuffer.Append(c);
                 }
                 else
                 {
-                    _stringBuffer.Insert(0, Symbols.LessThan).Insert(1, Symbols.Solidus);
+                    StringBuffer.Insert(0, Symbols.LessThan).Insert(1, Symbols.Solidus);
                     return RCDataText(c);
                 }
 
@@ -327,11 +327,11 @@
 
                     case Symbols.Null:
                         RaiseErrorOccurred(HtmlParseError.Null);
-                        _stringBuffer.Append(Symbols.Replacement);
+                        StringBuffer.Append(Symbols.Replacement);
                         break;
 
                     default:
-                        _stringBuffer.Append(c);
+                        StringBuffer.Append(c);
                         break;
                 }
 
@@ -352,23 +352,23 @@
 
                 if (c.IsUppercaseAscii())
                 {
-                    _stringBuffer.Append(Char.ToLower(c));
+                    StringBuffer.Append(Char.ToLower(c));
                     return RawtextNameEndTag(GetNext());
                 }
                 else if (c.IsLowercaseAscii())
                 {
-                    _stringBuffer.Append(c);
+                    StringBuffer.Append(c);
                     return RawtextNameEndTag(GetNext());
                 }
                 else
                 {
-                    _stringBuffer.Append(Symbols.LessThan).Append(Symbols.Solidus);
+                    StringBuffer.Append(Symbols.LessThan).Append(Symbols.Solidus);
                     return RawtextText(c);
                 }
             }
             else
             {
-                _stringBuffer.Append(Symbols.LessThan);
+                StringBuffer.Append(Symbols.LessThan);
                 return RawtextText(c);
             }
         }
@@ -389,15 +389,15 @@
                 }
                 else if (c.IsUppercaseAscii())
                 {
-                    _stringBuffer.Append(Char.ToLower(c));
+                    StringBuffer.Append(Char.ToLower(c));
                 }
                 else if (c.IsLowercaseAscii())
                 {
-                    _stringBuffer.Append(c);
+                    StringBuffer.Append(c);
                 }
                 else
                 {
-                    _stringBuffer.Insert(0, Symbols.LessThan).Insert(1, Symbols.Solidus);
+                    StringBuffer.Insert(0, Symbols.LessThan).Insert(1, Symbols.Solidus);
                     return RawtextText(c);
                 }
 
@@ -429,7 +429,7 @@
                 }
                 else
                 {
-                    _stringBuffer.Append(c);
+                    StringBuffer.Append(c);
                     c = GetNext();
                 }
             }
@@ -447,7 +447,7 @@
             if (c.IsSpaceCharacter() || c == Symbols.LessThan || c == Symbols.EndOfFile || c == Symbols.Ampersand || c == allowedCharacter)
             {
                 Back();
-                _stringBuffer.Append(Symbols.Ampersand);
+                StringBuffer.Append(Symbols.Ampersand);
                 return;
             }
 
@@ -496,7 +496,7 @@
                     }
 
                     RaiseErrorOccurred(HtmlParseError.CharacterReferenceWrongNumber);
-                    _stringBuffer.Append(Symbols.Ampersand);
+                    StringBuffer.Append(Symbols.Ampersand);
                     return;
                 }
 
@@ -582,7 +582,7 @@
                         }
 
                         InsertionPoint = start;
-                        _stringBuffer.Append(Symbols.Ampersand);
+                        StringBuffer.Append(Symbols.Ampersand);
                         return;
                     }
 
@@ -592,12 +592,12 @@
 
                 if (entity == null)
                 {
-                    _stringBuffer.Append(Symbols.Ampersand);
+                    StringBuffer.Append(Symbols.Ampersand);
                     return;
                 }
             }
 
-            _stringBuffer.Append(entity);
+            StringBuffer.Append(entity);
         }
 
         #endregion
@@ -616,12 +616,12 @@
             }
             else if (c.IsLowercaseAscii())
             {
-                _stringBuffer.Append(c);
+                StringBuffer.Append(c);
                 return TagName(NewTagOpen());
             }
             else if (c.IsUppercaseAscii())
             {
-                _stringBuffer.Append(Char.ToLower(c));
+                StringBuffer.Append(Char.ToLower(c));
                 return TagName(NewTagOpen());
             }
             else if (c == Symbols.ExclamationMark)
@@ -632,7 +632,7 @@
             {
                 _state = HtmlParseMode.PCData;
                 RaiseErrorOccurred(HtmlParseError.AmbiguousOpenTag);
-                _stringBuffer.Append(Symbols.LessThan);
+                StringBuffer.Append(Symbols.LessThan);
                 return DataText(c);
             }
             else
@@ -650,12 +650,12 @@
         {
             if (c.IsLowercaseAscii())
             {
-                _stringBuffer.Append(c);
+                StringBuffer.Append(c);
                 return TagName(NewTagClose());
             }
             else if (c.IsUppercaseAscii())
             {
-                _stringBuffer.Append(Char.ToLower(c));
+                StringBuffer.Append(Char.ToLower(c));
                 return TagName(NewTagClose());
             }
             else if (c == Symbols.GreaterThan)
@@ -668,7 +668,7 @@
             {
                 Back();
                 RaiseErrorOccurred(HtmlParseError.EOF);
-                _stringBuffer.Append(Symbols.LessThan).Append(Symbols.Solidus);
+                StringBuffer.Append(Symbols.LessThan).Append(Symbols.Solidus);
                 return NewCharacter();
             }
             else
@@ -705,16 +705,16 @@
                 }
                 else if (c.IsUppercaseAscii())
                 {
-                    _stringBuffer.Append(Char.ToLower(c));
+                    StringBuffer.Append(Char.ToLower(c));
                 }
                 else if (c == Symbols.Null)
                 {
                     RaiseErrorOccurred(HtmlParseError.Null);
-                    _stringBuffer.Append(Symbols.Replacement);
+                    StringBuffer.Append(Symbols.Replacement);
                 }
                 else if (c != Symbols.EndOfFile)
                 {
-                    _stringBuffer.Append(c);
+                    StringBuffer.Append(c);
                 }
                 else
                 {
@@ -783,7 +783,7 @@
         /// <param name="c">The current character.</param>
         HtmlToken BogusComment(Char c)
         {
-            _stringBuffer.Clear();
+            StringBuffer.Clear();
 
             while(true)
             {
@@ -795,11 +795,11 @@
                         Back();
                         break;
                     case Symbols.Null:
-                        _stringBuffer.Append(Symbols.Replacement);
+                        StringBuffer.Append(Symbols.Replacement);
                         c = GetNext();
                         continue;
                     default:
-                        _stringBuffer.Append(c);
+                        StringBuffer.Append(c);
                         c = GetNext();
                         continue;
                 }
@@ -815,7 +815,7 @@
         /// <param name="c">The next input character.</param>
         HtmlToken CommentStart(Char c)
         {
-            _stringBuffer.Clear();
+            StringBuffer.Clear();
 
             switch (c)
             {
@@ -823,7 +823,7 @@
                     return CommentDashStart(GetNext()) ?? Comment(GetNext());
                 case Symbols.Null:
                     RaiseErrorOccurred(HtmlParseError.Null);
-                    _stringBuffer.Append(Symbols.Replacement);
+                    StringBuffer.Append(Symbols.Replacement);
                     return Comment(GetNext());
                 case Symbols.GreaterThan:
                     _state = HtmlParseMode.PCData;
@@ -834,7 +834,7 @@
                     Back();
                     break;
                 default:
-                    _stringBuffer.Append(c);
+                    StringBuffer.Append(c);
                     return Comment(GetNext());
             }
 
@@ -853,7 +853,7 @@
                     return CommentEnd(GetNext());
                 case Symbols.Null:
                     RaiseErrorOccurred(HtmlParseError.Null);
-                    _stringBuffer.Append(Symbols.Minus).Append(Symbols.Replacement);
+                    StringBuffer.Append(Symbols.Minus).Append(Symbols.Replacement);
                     return Comment(GetNext());
                 case Symbols.GreaterThan:
                     _state = HtmlParseMode.PCData;
@@ -864,7 +864,7 @@
                     Back();
                     break;
                 default:
-                    _stringBuffer.Append(Symbols.Minus).Append(c);
+                    StringBuffer.Append(Symbols.Minus).Append(c);
                     return Comment(GetNext());
             }
 
@@ -894,10 +894,10 @@
                         return NewComment();
                     case Symbols.Null:
                         RaiseErrorOccurred(HtmlParseError.Null);
-                        _stringBuffer.Append(Symbols.Replacement);
+                        StringBuffer.Append(Symbols.Replacement);
                         break;
                     default:
-                        _stringBuffer.Append(c);
+                        StringBuffer.Append(c);
                         break;
                 }
 
@@ -925,7 +925,7 @@
                     break;
             }
 
-            _stringBuffer.Append(Symbols.Minus).Append(c);
+            StringBuffer.Append(Symbols.Minus).Append(c);
             return null;
         }
 
@@ -944,14 +944,14 @@
                         return NewComment();
                     case Symbols.Null:
                         RaiseErrorOccurred(HtmlParseError.Null);
-                        _stringBuffer.Append(Symbols.Minus).Append(Symbols.Replacement);
+                        StringBuffer.Append(Symbols.Minus).Append(Symbols.Replacement);
                         return null;
                     case Symbols.ExclamationMark:
                         RaiseErrorOccurred(HtmlParseError.CommentEndedWithEM);
                         return CommentBangEnd(GetNext());
                     case Symbols.Minus:
                         RaiseErrorOccurred(HtmlParseError.CommentEndedWithDash);
-                        _stringBuffer.Append(Symbols.Minus);
+                        StringBuffer.Append(Symbols.Minus);
                         break;
                     case Symbols.EndOfFile:
                         RaiseErrorOccurred(HtmlParseError.EOF);
@@ -959,7 +959,7 @@
                         return NewComment();
                     default:
                         RaiseErrorOccurred(HtmlParseError.CommentEndedUnexpected);
-                        _stringBuffer.Append(Symbols.Minus).Append(Symbols.Minus).Append(c);
+                        StringBuffer.Append(Symbols.Minus).Append(Symbols.Minus).Append(c);
                         return null;
                 }
 
@@ -976,21 +976,21 @@
             switch (c)
             {
                 case Symbols.Minus:
-                    _stringBuffer.Append(Symbols.Minus).Append(Symbols.Minus).Append(Symbols.ExclamationMark);
+                    StringBuffer.Append(Symbols.Minus).Append(Symbols.Minus).Append(Symbols.ExclamationMark);
                     return CommentDashEnd(GetNext());
                 case Symbols.GreaterThan:
                     _state = HtmlParseMode.PCData;
                     break;
                 case Symbols.Null:
                     RaiseErrorOccurred(HtmlParseError.Null);
-                    _stringBuffer.Append(Symbols.Minus).Append(Symbols.Minus).Append(Symbols.ExclamationMark).Append(Symbols.Replacement);
+                    StringBuffer.Append(Symbols.Minus).Append(Symbols.Minus).Append(Symbols.ExclamationMark).Append(Symbols.Replacement);
                     return null;
                 case Symbols.EndOfFile:
                     RaiseErrorOccurred(HtmlParseError.EOF);
                     Back();
                     break;
                 default:
-                    _stringBuffer.Append(Symbols.Minus).Append(Symbols.Minus).Append(Symbols.ExclamationMark).Append(c);
+                    StringBuffer.Append(Symbols.Minus).Append(Symbols.Minus).Append(Symbols.ExclamationMark).Append(c);
                     return null;
             }
 
@@ -1036,14 +1036,14 @@
             if (c.IsUppercaseAscii())
             {
                 var doctype = NewDoctype(false);
-                _stringBuffer.Append(Char.ToLower(c));
+                StringBuffer.Append(Char.ToLower(c));
                 return DoctypeName(doctype);
             }
             else if (c == Symbols.Null)
             {
                 var doctype = NewDoctype(false);
                 RaiseErrorOccurred(HtmlParseError.Null);
-                _stringBuffer.Append(Symbols.Replacement);
+                StringBuffer.Append(Symbols.Replacement);
                 return DoctypeName(doctype);
             }
             else if (c == Symbols.GreaterThan)
@@ -1063,7 +1063,7 @@
             else
             {
                 var doctype = NewDoctype(false);
-                _stringBuffer.Append(c);
+                StringBuffer.Append(c);
                 return DoctypeName(doctype);
             }
         }
@@ -1091,12 +1091,12 @@
                 }
                 else if (c.IsUppercaseAscii())
                 {
-                    _stringBuffer.Append(Char.ToLower(c));
+                    StringBuffer.Append(Char.ToLower(c));
                 }
                 else if (c == Symbols.Null)
                 {
                     RaiseErrorOccurred(HtmlParseError.Null);
-                    _stringBuffer.Append(Symbols.Replacement);
+                    StringBuffer.Append(Symbols.Replacement);
                 }
                 else if (c == Symbols.EndOfFile)
                 {
@@ -1108,7 +1108,7 @@
                 }
                 else
                 {
-                    _stringBuffer.Append(c);
+                    StringBuffer.Append(c);
                 }
             }
 
@@ -1257,7 +1257,7 @@
                 else if (c == Symbols.Null)
                 {
                     RaiseErrorOccurred(HtmlParseError.Null);
-                    _stringBuffer.Append(Symbols.Replacement);
+                    StringBuffer.Append(Symbols.Replacement);
                 }
                 else if (c == Symbols.GreaterThan)
                 {
@@ -1277,7 +1277,7 @@
                 }
                 else
                 {
-                    _stringBuffer.Append(c);
+                    StringBuffer.Append(c);
                 }
             }
 
@@ -1302,7 +1302,7 @@
                 else if (c == Symbols.Null)
                 {
                     RaiseErrorOccurred(HtmlParseError.Null);
-                    _stringBuffer.Append(Symbols.Replacement);
+                    StringBuffer.Append(Symbols.Replacement);
                 }
                 else if (c == Symbols.GreaterThan)
                 {
@@ -1322,7 +1322,7 @@
                 }
                 else
                 {
-                    _stringBuffer.Append(c);
+                    StringBuffer.Append(c);
                 }
             }
 
@@ -1518,7 +1518,7 @@
                 else if (c == Symbols.Null)
                 {
                     RaiseErrorOccurred(HtmlParseError.Null);
-                    _stringBuffer.Append(Symbols.Replacement);
+                    StringBuffer.Append(Symbols.Replacement);
                 }
                 else if (c == Symbols.GreaterThan)
                 {
@@ -1538,7 +1538,7 @@
                 }
                 else
                 {
-                    _stringBuffer.Append(c);
+                    StringBuffer.Append(c);
                 }
             }
 
@@ -1562,7 +1562,7 @@
                         return DoctypeSystemIdentifierAfter(doctype);
                     case Symbols.Null:
                         RaiseErrorOccurred(HtmlParseError.Null);
-                        _stringBuffer.Append(Symbols.Replacement);
+                        StringBuffer.Append(Symbols.Replacement);
                         continue;
                     case Symbols.GreaterThan:
                         _state = HtmlParseMode.PCData;
@@ -1577,7 +1577,7 @@
                         Back();
                         break;
                     default:
-                        _stringBuffer.Append(c);
+                        StringBuffer.Append(c);
                         continue;
                 }
 
@@ -1657,24 +1657,24 @@
             }
             else if (c.IsUppercaseAscii())
             {
-                _stringBuffer.Append(Char.ToLower(c));
+                StringBuffer.Append(Char.ToLower(c));
                 return AttributeName(tag);
             }
             else if (c == Symbols.Null)
             {
                 RaiseErrorOccurred(HtmlParseError.Null);
-                _stringBuffer.Append(Symbols.Replacement);
+                StringBuffer.Append(Symbols.Replacement);
                 return AttributeName(tag);
             }
             else if (c == Symbols.SingleQuote || c == Symbols.DoubleQuote || c == Symbols.Equality || c == Symbols.LessThan)
             {
                 RaiseErrorOccurred(HtmlParseError.AttributeNameInvalid);
-                _stringBuffer.Append(c);
+                StringBuffer.Append(c);
                 return AttributeName(tag);
             }
             else if (c != Symbols.EndOfFile)
             {
-                _stringBuffer.Append(c);
+                StringBuffer.Append(c);
                 return AttributeName(tag);
             }
             else
@@ -1715,21 +1715,21 @@
                 }
                 else if (c.IsUppercaseAscii())
                 {
-                    _stringBuffer.Append(Char.ToLower(c));
+                    StringBuffer.Append(Char.ToLower(c));
                 }
                 else if (c == Symbols.DoubleQuote || c == Symbols.SingleQuote || c == Symbols.LessThan)
                 {
                     RaiseErrorOccurred(HtmlParseError.AttributeNameInvalid);
-                    _stringBuffer.Append(c);
+                    StringBuffer.Append(c);
                 }
                 else if(c == Symbols.Null)
                 {
                     RaiseErrorOccurred(HtmlParseError.Null);
-                    _stringBuffer.Append(Symbols.Replacement);
+                    StringBuffer.Append(Symbols.Replacement);
                 }
                 else if (c != Symbols.EndOfFile)
                 {
-                    _stringBuffer.Append(c);
+                    StringBuffer.Append(c);
                 }
                 else
                 {
@@ -1760,24 +1760,24 @@
             }
             else if (c.IsUppercaseAscii())
             {
-                _stringBuffer.Append(Char.ToLower(c));
+                StringBuffer.Append(Char.ToLower(c));
                 return AttributeName(tag);
             }
             else if (c == Symbols.DoubleQuote || c == Symbols.SingleQuote || c == Symbols.LessThan)
             {
                 RaiseErrorOccurred(HtmlParseError.AttributeNameInvalid);
-                _stringBuffer.Append(c);
+                StringBuffer.Append(c);
                 return AttributeName(tag);
             }
             else if (c == Symbols.Null)
             {
                 RaiseErrorOccurred(HtmlParseError.Null);
-                _stringBuffer.Append(Symbols.Replacement);
+                StringBuffer.Append(Symbols.Replacement);
                 return AttributeName(tag);
             }
             else if (c != Symbols.EndOfFile)
             {
-                _stringBuffer.Append(c);
+                StringBuffer.Append(c);
                 return AttributeName(tag);
             }
             else
@@ -1814,18 +1814,18 @@
             else if (c == Symbols.LessThan || c == Symbols.Equality || c == Symbols.CurvedQuote)
             {
                 RaiseErrorOccurred(HtmlParseError.AttributeValueInvalid);
-                _stringBuffer.Append(c);
+                StringBuffer.Append(c);
                 return AttributeUnquotedValue(GetNext(), tag);
             }
             else if (c == Symbols.Null)
             {
                 RaiseErrorOccurred(HtmlParseError.Null);
-                _stringBuffer.Append(Symbols.Replacement);
+                StringBuffer.Append(Symbols.Replacement);
                 return AttributeUnquotedValue(GetNext(), tag);
             }
             else if (c != Symbols.EndOfFile)
             {
-                _stringBuffer.Append(c);
+                StringBuffer.Append(c);
                 return AttributeUnquotedValue(GetNext(), tag);
             }
             else
@@ -1856,11 +1856,11 @@
                 else if (c == Symbols.Null)
                 {
                     RaiseErrorOccurred(HtmlParseError.Null);
-                    _stringBuffer.Append(Symbols.Replacement);
+                    StringBuffer.Append(Symbols.Replacement);
                 }
                 else if (c != Symbols.EndOfFile)
                 {
-                    _stringBuffer.Append(c);
+                    StringBuffer.Append(c);
                 }
                 else
                 {
@@ -1891,11 +1891,11 @@
                 else if (c == Symbols.Null)
                 {
                     RaiseErrorOccurred(HtmlParseError.Null);
-                    _stringBuffer.Append(Symbols.Replacement);
+                    StringBuffer.Append(Symbols.Replacement);
                 }
                 else if (c != Symbols.EndOfFile)
                 {
-                    _stringBuffer.Append(c);
+                    StringBuffer.Append(c);
                 }
                 else
                 {
@@ -1930,16 +1930,16 @@
                 else if (c == Symbols.Null)
                 {
                     RaiseErrorOccurred(HtmlParseError.Null);
-                    _stringBuffer.Append(Symbols.Replacement);
+                    StringBuffer.Append(Symbols.Replacement);
                 }
                 else if (c == Symbols.DoubleQuote || c == Symbols.SingleQuote || c == Symbols.LessThan || c == Symbols.Equality || c == Symbols.CurvedQuote)
                 {
                     RaiseErrorOccurred(HtmlParseError.AttributeValueInvalid);
-                    _stringBuffer.Append(c);
+                    StringBuffer.Append(c);
                 }
                 else if (c != Symbols.EndOfFile)
                 {
-                    _stringBuffer.Append(c);
+                    StringBuffer.Append(c);
                 }
                 else
                 {
@@ -1990,45 +1990,45 @@
                 {
                     case Symbols.Null:
                         RaiseErrorOccurred(HtmlParseError.Null);
-                        _stringBuffer.Append(Symbols.Replacement);
+                        StringBuffer.Append(Symbols.Replacement);
                         break;
 
                     case Symbols.LessThan:
                         // See 8.2.4.17 Script data less-than sign state
-                        _stringBuffer.Append(Symbols.LessThan);
+                        StringBuffer.Append(Symbols.LessThan);
                         c = GetNext();
 
                         if (c == Symbols.Solidus)
                         {
                             // See 8.2.4.18 Script data end tag open state
                             c = GetNext();
-                            var offset = _stringBuffer.Append(Symbols.Solidus).Length;
+                            var offset = StringBuffer.Append(Symbols.Solidus).Length;
                             var tag = NewTagClose();
 
                             while (c.IsLetter())
                             {
                                 // See 8.2.4.19 Script data end tag name state
-                                _stringBuffer.Append(c);
+                                StringBuffer.Append(c);
                                 c = GetNext();
                                 var isspace = c.IsSpaceCharacter();
                                 var isclosed = c == Symbols.GreaterThan;
                                 var isslash = c == Symbols.Solidus;
-                                var hasLength = _stringBuffer.Length - offset == length;
+                                var hasLength = StringBuffer.Length - offset == length;
 
                                 if (hasLength && (isspace || isclosed || isslash))
                                 {
-                                    var name = _stringBuffer.ToString(offset, length);
+                                    var name = StringBuffer.ToString(offset, length);
 
                                     if (name.Isi(_lastStartTag))
                                     {
                                         if (offset > 2)
                                         {
                                             Back(3 + length);
-                                            _stringBuffer.Remove(offset - 2, length + 2);
+                                            StringBuffer.Remove(offset - 2, length + 2);
                                             return NewCharacter();
                                         }
 
-                                        _stringBuffer.Clear();
+                                        StringBuffer.Clear();
 
                                         if (isspace)
                                         {
@@ -2052,18 +2052,18 @@
                         else if (c == Symbols.ExclamationMark)
                         {
                             // See 8.2.4.20 Script data escape start state
-                            _stringBuffer.Append(Symbols.ExclamationMark);
+                            StringBuffer.Append(Symbols.ExclamationMark);
                             c = GetNext();
 
                             if (c == Symbols.Minus)
                             {
                                 // See 8.2.4.21 Script data escape start dash state
                                 c = GetNext();
-                                _stringBuffer.Append(Symbols.Minus);
+                                StringBuffer.Append(Symbols.Minus);
 
                                 if (c == Symbols.Minus)
                                 {
-                                    _stringBuffer.Append(Symbols.Minus);
+                                    StringBuffer.Append(Symbols.Minus);
                                     return ScriptDataEscapedDashDash();
                                 }
                             }
@@ -2076,7 +2076,7 @@
                         return NewCharacter();
 
                     default:
-                        _stringBuffer.Append(c);
+                        StringBuffer.Append(c);
                         break;
                 }
 
@@ -2095,13 +2095,13 @@
                 switch (c)
                 {
                     case Symbols.Minus:
-                        _stringBuffer.Append(Symbols.Minus);
+                        StringBuffer.Append(Symbols.Minus);
                         return ScriptDataEscapedDash(GetNext());
                     case Symbols.LessThan:
                         return ScriptDataEscapedLT(GetNext());
                     case Symbols.Null:
                         RaiseErrorOccurred(HtmlParseError.Null);
-                        _stringBuffer.Append(Symbols.Replacement);
+                        StringBuffer.Append(Symbols.Replacement);
                         break;
                     case Symbols.EndOfFile:
                         Back();
@@ -2123,19 +2123,19 @@
             switch (c)
             {
                 case Symbols.Minus:
-                    _stringBuffer.Append(Symbols.Minus);
+                    StringBuffer.Append(Symbols.Minus);
                     return ScriptDataEscapedDashDash();
                 case Symbols.LessThan:
                     return ScriptDataEscapedLT(GetNext());
                 case Symbols.Null:
                     RaiseErrorOccurred(HtmlParseError.Null);
-                    _stringBuffer.Append(Symbols.Replacement);
+                    StringBuffer.Append(Symbols.Replacement);
                     break;
                 case Symbols.EndOfFile:
                     Back();
                     return NewCharacter();
                 default:
-                    _stringBuffer.Append(c);
+                    StringBuffer.Append(c);
                     break;
             }
 
@@ -2154,21 +2154,21 @@
                 switch (c)
                 {
                     case Symbols.Minus:
-                        _stringBuffer.Append(Symbols.Minus);
+                        StringBuffer.Append(Symbols.Minus);
                         break;
                     case Symbols.LessThan:
                         return ScriptDataEscapedLT(GetNext());
                     case Symbols.GreaterThan:
-                        _stringBuffer.Append(Symbols.GreaterThan);
+                        StringBuffer.Append(Symbols.GreaterThan);
                         return ScriptData(GetNext());
                     case Symbols.Null:
                         RaiseErrorOccurred(HtmlParseError.Null);
-                        _stringBuffer.Append(Symbols.Replacement);
+                        StringBuffer.Append(Symbols.Replacement);
                         return ScriptDataEscaped(GetNext());
                     case Symbols.EndOfFile:
                         return NewCharacter();
                     default:
-                        _stringBuffer.Append(c);
+                        StringBuffer.Append(c);
                         return ScriptDataEscaped(GetNext());
                 }
             }
@@ -2187,13 +2187,13 @@
 
             if (c.IsLetter())
             {
-                var offset = _stringBuffer.Append(Symbols.LessThan).Length;
-                _stringBuffer.Append(c);
+                var offset = StringBuffer.Append(Symbols.LessThan).Length;
+                StringBuffer.Append(c);
                 return ScriptDataStartDoubleEscape(offset);
             }
             else
             {
-                _stringBuffer.Append(Symbols.LessThan);
+                StringBuffer.Append(Symbols.LessThan);
                 return ScriptDataEscaped(c);
             }
         }
@@ -2204,11 +2204,11 @@
         /// <param name="c">The next input character.</param>
         HtmlToken ScriptDataEscapedEndTag(Char c)
         {
-            var offset = _stringBuffer.Append(Symbols.LessThan).Append(Symbols.Solidus).Length;
+            var offset = StringBuffer.Append(Symbols.LessThan).Append(Symbols.Solidus).Length;
 
             if (c.IsLetter())
             {
-                _stringBuffer.Append(c);
+                StringBuffer.Append(c);
                 return ScriptDataEscapedNameEndTag(NewTagClose(), offset);
             }
             else
@@ -2229,13 +2229,13 @@
             while (true)
             {
                 var c = GetNext();
-                var hasLength = _stringBuffer.Length - offset == length;
+                var hasLength = StringBuffer.Length - offset == length;
 
                 if (hasLength && (c == Symbols.Solidus || c == Symbols.GreaterThan || c.IsSpaceCharacter()) && 
-                    _stringBuffer.ToString(offset, length).Isi(TagNames.Script))
+                    StringBuffer.ToString(offset, length).Isi(TagNames.Script))
                 {
                     Back(length + 3);
-                    _stringBuffer.Remove(offset - 2, length + 2);
+                    StringBuffer.Remove(offset - 2, length + 2);
                     return NewCharacter();
                 }
                 else if (!c.IsLetter())
@@ -2243,7 +2243,7 @@
                     return ScriptDataEscaped(c);
                 }
 
-                _stringBuffer.Append(c);
+                StringBuffer.Append(c);
             }
         }
 
@@ -2258,17 +2258,17 @@
             while (true)
             {
                 var c = GetNext();
-                var hasLength = _stringBuffer.Length - offset == length;
+                var hasLength = StringBuffer.Length - offset == length;
 
                 if (hasLength && (c == Symbols.Solidus || c == Symbols.GreaterThan || c.IsSpaceCharacter()))
                 {
-                    var isscript = _stringBuffer.ToString(offset, length).Isi(TagNames.Script);
-                    _stringBuffer.Append(c);
+                    var isscript = StringBuffer.ToString(offset, length).Isi(TagNames.Script);
+                    StringBuffer.Append(c);
                     return isscript ? ScriptDataEscapedDouble(GetNext()) : ScriptDataEscaped(GetNext());
                 }
                 else if (c.IsLetter())
                 {
-                    _stringBuffer.Append(c);
+                    StringBuffer.Append(c);
                 }
                 else
                 {
@@ -2288,14 +2288,14 @@
                 switch (c)
                 {
                     case Symbols.Minus:
-                        _stringBuffer.Append(Symbols.Minus);
+                        StringBuffer.Append(Symbols.Minus);
                         return ScriptDataEscapedDoubleDash(GetNext());
                     case Symbols.LessThan:
-                        _stringBuffer.Append(Symbols.LessThan);
+                        StringBuffer.Append(Symbols.LessThan);
                         return ScriptDataEscapedDoubleLT(GetNext());
                     case Symbols.Null:
                         RaiseErrorOccurred(HtmlParseError.Null);
-                        _stringBuffer.Append(Symbols.Replacement);
+                        StringBuffer.Append(Symbols.Replacement);
                         break;
                     case Symbols.EndOfFile:
                         RaiseErrorOccurred(HtmlParseError.EOF);
@@ -2303,7 +2303,7 @@
                         return NewCharacter();
                 }
 
-                _stringBuffer.Append(c);
+                StringBuffer.Append(c);
                 c = GetNext();
             }
         }
@@ -2317,10 +2317,10 @@
             switch (c)
             {
                 case Symbols.Minus:
-                    _stringBuffer.Append(Symbols.Minus);
+                    StringBuffer.Append(Symbols.Minus);
                     return ScriptDataEscapedDoubleDashDash();
                 case Symbols.LessThan:
-                    _stringBuffer.Append(Symbols.LessThan);
+                    StringBuffer.Append(Symbols.LessThan);
                     return ScriptDataEscapedDoubleLT(GetNext());
                 case Symbols.Null:
                     RaiseErrorOccurred(HtmlParseError.Null);
@@ -2347,24 +2347,24 @@
                 switch (c)
                 {
                     case Symbols.Minus:
-                        _stringBuffer.Append(Symbols.Minus);
+                        StringBuffer.Append(Symbols.Minus);
                         break;
                     case Symbols.LessThan:
-                        _stringBuffer.Append(Symbols.LessThan);
+                        StringBuffer.Append(Symbols.LessThan);
                         return ScriptDataEscapedDoubleLT(GetNext());
                     case Symbols.GreaterThan:
-                        _stringBuffer.Append(Symbols.GreaterThan);
+                        StringBuffer.Append(Symbols.GreaterThan);
                         return ScriptData(GetNext());
                     case Symbols.Null:
                         RaiseErrorOccurred(HtmlParseError.Null);
-                        _stringBuffer.Append(Symbols.Replacement);
+                        StringBuffer.Append(Symbols.Replacement);
                         return ScriptDataEscapedDouble(GetNext());
                     case Symbols.EndOfFile:
                         RaiseErrorOccurred(HtmlParseError.EOF);
                         Back();
                         return NewCharacter();
                     default:
-                        _stringBuffer.Append(c);
+                        StringBuffer.Append(c);
                         return ScriptDataEscapedDouble(GetNext());
                 }
             }
@@ -2378,7 +2378,7 @@
         {
             if (c == Symbols.Solidus)
             {
-                var offset = _stringBuffer.Append(Symbols.Solidus).Length;
+                var offset = StringBuffer.Append(Symbols.Solidus).Length;
                 return ScriptDataEndDoubleEscape(offset);
             }
 
@@ -2396,17 +2396,17 @@
             while (true)
             {
                 var c = GetNext();
-                var hasLength = _stringBuffer.Length - offset == length;
+                var hasLength = StringBuffer.Length - offset == length;
 
                 if (hasLength && (c.IsSpaceCharacter() || c == Symbols.Solidus || c == Symbols.GreaterThan))
                 {
-                    var isscript = _stringBuffer.ToString(offset, length).Isi(TagNames.Script);
-                    _stringBuffer.Append(c);
+                    var isscript = StringBuffer.ToString(offset, length).Isi(TagNames.Script);
+                    StringBuffer.Append(c);
                     return isscript ? ScriptDataEscaped(GetNext()) : ScriptDataEscapedDouble(GetNext());
                 }
                 else if (c.IsLetter())
                 {
-                    _stringBuffer.Append(c);
+                    StringBuffer.Append(c);
                 }
                 else
                 {
@@ -2460,12 +2460,12 @@
             var isspace = c.IsSpaceCharacter();
             var isclosed = c == Symbols.GreaterThan;
             var isslash = c == Symbols.Solidus;
-            var hasLength = _stringBuffer.Length == _lastStartTag.Length;
+            var hasLength = StringBuffer.Length == _lastStartTag.Length;
 
-            if (hasLength && (isspace || isclosed || isslash) && _stringBuffer.ToString().Is(_lastStartTag))
+            if (hasLength && (isspace || isclosed || isslash) && StringBuffer.ToString().Is(_lastStartTag))
             {
                 var tag = NewTagClose();
-                _stringBuffer.Clear();
+                StringBuffer.Clear();
 
                 if (isspace)
                 {

--- a/AngleSharp/Parser/Xml/XmlTokenizer.cs
+++ b/AngleSharp/Parser/Xml/XmlTokenizer.cs
@@ -91,17 +91,17 @@
                         return NewCharacters();
 
                     case Symbols.Ampersand:
-                        _stringBuffer.Append(CharacterReference(GetNext()));
+                        StringBuffer.Append(CharacterReference(GetNext()));
                         c = GetNext();
                         break;
 
                     case Symbols.SquareBracketClose:
-                        _stringBuffer.Append(c);
+                        StringBuffer.Append(c);
                         c = CheckCharacter(GetNext());
                         break;
 
                     default:
-                        _stringBuffer.Append(c);
+                        StringBuffer.Append(c);
                         c = GetNext();
                         break;
                 }
@@ -147,7 +147,7 @@
                     break;
                 }
 
-                _stringBuffer.Append(c);
+                StringBuffer.Append(c);
                 c = GetNext();
             }
 
@@ -161,7 +161,7 @@
         /// <returns>The entity token.</returns>
         String CharacterReference(Char c)
         {
-            var start = _stringBuffer.Length;
+            var start = StringBuffer.Length;
             var hex = false;
             var numeric = c == Symbols.Num;
 
@@ -176,7 +176,7 @@
 
                     while (c.IsHex())
                     {
-                        _stringBuffer.Append(c);
+                        StringBuffer.Append(c);
                         c = GetNext();
                     }
                 }
@@ -184,7 +184,7 @@
                 {
                     while (c.IsDigit())
                     {
-                        _stringBuffer.Append(c);
+                        StringBuffer.Append(c);
                         c = GetNext();
                     }
                 }
@@ -193,17 +193,17 @@
             {
                 do
                 {
-                    _stringBuffer.Append(c);
+                    StringBuffer.Append(c);
                     c = GetNext();
                 }
                 while (c.IsXmlName());
             }
 
-            if (c == Symbols.Semicolon && _stringBuffer.Length > start)
+            if (c == Symbols.Semicolon && StringBuffer.Length > start)
             {
-                var length = _stringBuffer.Length - start;
-                var content = _stringBuffer.ToString(start, length);
-                _stringBuffer.Remove(start, length);
+                var length = StringBuffer.Length - start;
+                var content = StringBuffer.ToString(start, length);
+                StringBuffer.Remove(start, length);
 
                 if (numeric)
                 {
@@ -259,7 +259,7 @@
             
             if (c.IsXmlNameStart())
             {
-                _stringBuffer.Append(c);
+                StringBuffer.Append(c);
                 return TagName(GetNext(), NewOpenTag());
             }
 
@@ -276,7 +276,7 @@
             {
                 do
                 {
-                    _stringBuffer.Append(c);
+                    StringBuffer.Append(c);
                     c = GetNext();
                 }
                 while (c.IsXmlName());
@@ -312,7 +312,7 @@
         {
             while (c.IsXmlName())
             {
-                _stringBuffer.Append(c);
+                StringBuffer.Append(c);
                 c = GetNext();
             }
 
@@ -386,7 +386,7 @@
         {
             if (!c.IsSpaceCharacter())
             {
-                _stringBuffer.Append(TagNames.Xml);
+                StringBuffer.Append(TagNames.Xml);
                 return ProcessingTarget(c, NewProcessing());
             }
 
@@ -447,7 +447,7 @@
                 if (c == Symbols.EndOfFile)
                     throw XmlParseError.EOF.At(GetCurrentPosition());
 
-                _stringBuffer.Append(c);
+                StringBuffer.Append(c);
                 c = GetNext();
             }
 
@@ -534,7 +534,7 @@
             {
                 if (c.IsAlphanumericAscii() || c == Symbols.Dot || c == Symbols.Underscore || c == Symbols.Minus)
                 {
-                    _stringBuffer.Append(c);
+                    StringBuffer.Append(c);
                     c = GetNext();
                 }
                 else
@@ -615,7 +615,7 @@
                 if (c == Symbols.EndOfFile)
                     throw XmlParseError.EOF.At(GetCurrentPosition());
 
-                _stringBuffer.Append(c);
+                StringBuffer.Append(c);
                 c = GetNext();
             }
 
@@ -674,7 +674,7 @@
 
             if (c.IsXmlNameStart())
             {
-                _stringBuffer.Append(c);
+                StringBuffer.Append(c);
                 return DoctypeName(GetNext(), NewDoctype());
             }
 
@@ -691,7 +691,7 @@
         {
             while (c.IsXmlName())
             {
-                _stringBuffer.Append(c);
+                StringBuffer.Append(c);
                 c = GetNext();
             }
 
@@ -775,7 +775,7 @@
                 if (!c.IsPubidChar())
                     throw XmlParseError.XmlInvalidPubId.At(GetCurrentPosition());
 
-                _stringBuffer.Append(c);
+                StringBuffer.Append(c);
                 c = GetNext();
             }
 
@@ -859,7 +859,7 @@
                 if (c == Symbols.EndOfFile)
                     throw XmlParseError.EOF.At(GetCurrentPosition());
 
-                _stringBuffer.Append(c);
+                StringBuffer.Append(c);
                 c = GetNext();
             }
 
@@ -927,7 +927,7 @@
 
             if (c.IsXmlNameStart())
             {
-                _stringBuffer.Append(c);
+                StringBuffer.Append(c);
                 return AttributeName(GetNext(), tag);
             }
 
@@ -943,7 +943,7 @@
         {
             while (c.IsXmlName())
             {
-                _stringBuffer.Append(c);
+                StringBuffer.Append(c);
                 c = GetNext();
             }
 
@@ -996,11 +996,11 @@
                     throw XmlParseError.EOF.At(GetCurrentPosition());
 
                 if (c == Symbols.Ampersand)
-                    _stringBuffer.Append(CharacterReference(GetNext()));
+                    StringBuffer.Append(CharacterReference(GetNext()));
                 else if (c == Symbols.LessThan)
                     throw XmlParseError.XmlLtInAttributeValue.At(GetCurrentPosition());
                 else 
-                    _stringBuffer.Append(c);
+                    StringBuffer.Append(c);
 
                 c = GetNext();
             }
@@ -1038,7 +1038,7 @@
         {
             if (c.IsXmlNameStart())
             {
-                _stringBuffer.Append(c);
+                StringBuffer.Append(c);
                 return ProcessingTarget(GetNext(), NewProcessing());
             }
 
@@ -1054,7 +1054,7 @@
         {
             while (c.IsXmlName())
             {
-                _stringBuffer.Append(c);
+                StringBuffer.Append(c);
                 c = GetNext();
             }
 
@@ -1095,11 +1095,11 @@
                         return pi;
                     }
 
-                    _stringBuffer.Append(Symbols.QuestionMark);
+                    StringBuffer.Append(Symbols.QuestionMark);
                 }
                 else
                 {
-                    _stringBuffer.Append(c);
+                    StringBuffer.Append(c);
                     c = GetNext();
                 }
             }
@@ -1131,7 +1131,7 @@
                 if (c == Symbols.Minus)
                     return CommentDash(GetNext());
 
-                _stringBuffer.Append(c);
+                StringBuffer.Append(c);
                 c = GetNext();
             }
 

--- a/AngleSharp/TextSource.cs
+++ b/AngleSharp/TextSource.cs
@@ -19,11 +19,11 @@
         const Int32 BufferSize = 4096;
 
         readonly Stream _baseStream;
-        readonly StringBuilder _content;
         readonly MemoryStream _raw;
         readonly Byte[] _buffer;
         readonly Char[] _chars;
 
+        StringBuilder _content;
         EncodingConfidence _confidence;
         Boolean _finished;
         Encoding _encoding;
@@ -177,8 +177,15 @@
 
         public void Dispose()
         {
+            var isDisposed = _content == null;
+            if (isDisposed)
+            {
+                return;
+            }
+
             _raw.Dispose();
             _content.Clear().ToPool();
+            _content = null;
         }
 
         #endregion


### PR DESCRIPTION
As per #300:
- [x] Change `BaseTokenizer` and `TextSource` to have a mutable `StringBuilder` and use it to check if the class is disposed.
- [x] Change `CssBuilder` to not use pooled resources after they've been released to the pool.

In order to facilitate making the `StringBuilder` mutable, I figured it'd make more sense to make it a private settable property since it was `protected`. This required renaming the variable to `StringBuffer`). Site note: I suggest changing the `_events` variable to a property.

Let me know what you'd like to do with the `...State` classes and I'll be glad to either add the changes to this PR or submit a new one.
