### PR TITLE
Fix XHTML issue with nbsp by using #160 in stead.

### DIFF
--- a/AngleSharp/Xhtml/XhtmlMarkupFormatter.cs
+++ b/AngleSharp/Xhtml/XhtmlMarkupFormatter.cs
@@ -113,7 +113,7 @@
                 switch (text[i])
                 {
                     case Symbols.Ampersand: temp.Append("&amp;"); break;
-                    case Symbols.NoBreakSpace: temp.Append("&nbsp;"); break;
+                    case Symbols.NoBreakSpace: temp.Append("&#160;"); break;
                     case Symbols.GreaterThan: temp.Append("&gt;"); break;
                     case Symbols.LessThan: temp.Append("&lt;"); break;
                     default: temp.Append(text[i]); break;


### PR DESCRIPTION
Small fix for XHTML issue with `&nbsp;` by replacing it by `&#160;`.

As See http://stackoverflow.com/questions/17095154/xhtml-and-nbsp-doesnt-work 
Thanks to @thorn0 for pointing this out!

Kind regards,
Henry
