### PR TITLE
ToHtml(TextWriter) does not write to the TextWriter

### DIFF
--- a/src/AngleSharp.Core.Tests/AngleSharp.Core.Tests.csproj
+++ b/src/AngleSharp.Core.Tests/AngleSharp.Core.Tests.csproj
@@ -142,6 +142,7 @@
     <Compile Include="Library\DocumentEncoding.cs" />
     <Compile Include="Library\DOMTable.cs" />
     <Compile Include="Library\Error.cs" />
+    <Compile Include="Library\FormatExtensions.cs" />
     <Compile Include="Library\FormReset.cs" />
     <Compile Include="Library\FormSetFieldValues.cs" />
     <Compile Include="Library\ImageCandidates.cs" />

--- a/src/AngleSharp.Core.Tests/Library/FormatExtensions.cs
+++ b/src/AngleSharp.Core.Tests/Library/FormatExtensions.cs
@@ -1,0 +1,57 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Text;
+using System.Threading.Tasks;
+using AngleSharp.Extensions;
+using AngleSharp.Dom;
+using NUnit.Framework;
+using AngleSharp.Html;
+using System.IO;
+
+namespace AngleSharp.Core.Tests.Library
+{
+    [TestFixture]
+    public class FormatExtensions
+    {
+        static IDocument Html(String code)
+        {
+            var config = new Configuration().WithCss();
+            return code.ToHtmlDocument(config);
+        }
+
+        [Test]
+        public void ExtensionToHtml()
+        {
+            var document = Html("<!DOCTYPE html><html><head></head><body></body></html>");
+
+            var html = document.ToHtml();
+
+            Assert.AreEqual("<!DOCTYPE html><html><head></head><body></body></html>", html);
+        }
+
+        [Test]
+        public void ExtensionToHtmlWithFormatter()
+        {
+            var document = Html("<!DOCTYPE html><html><head></head><body></body></html>");
+
+            var html = document.ToHtml(HtmlMarkupFormatter.Instance);
+
+            Assert.AreEqual("<!DOCTYPE html><html><head></head><body></body></html>", html);
+        }
+
+        [Test]
+        public void ExtensionToHtmlWithTextWriter()
+        {
+            var builder = new StringBuilder();
+            using (var writer = new StringWriter(builder))
+            {
+                var document = Html("<!DOCTYPE html><html><head></head><body></body></html>");
+
+                document.ToHtml(writer);
+
+                Assert.AreEqual("<!DOCTYPE html><html><head></head><body></body></html>", builder.ToString());
+            }
+        }
+    }
+}

--- a/src/AngleSharp/Extensions/FormatExtensions.cs
+++ b/src/AngleSharp/Extensions/FormatExtensions.cs
@@ -83,7 +83,7 @@
         /// <param name="writer">The output target of the serialization.</param>
         public static void ToHtml(this IMarkupFormattable markup, TextWriter writer)
         {
-            markup.ToHtml(HtmlMarkupFormatter.Instance);
+            markup.ToHtml(writer, HtmlMarkupFormatter.Instance);
         }
     }
 }


### PR DESCRIPTION
The new `ToHtml(TextWriter)` extension method in `0.9.6` doesn't use the `TextWriter` resulting in no output being produced. I've added test cases for the `ToHtml()` extensions as well as fixing the bug.

The current workaround is to use the non-extension:

``` csharp
document.ToHtml(writer, HtmlMarkupFormatter.Instance);
```
