### PR TITLE
Issue #358

### DIFF
--- a/src/AngleSharp.Core.Tests/Html/HtmlFragment.cs
+++ b/src/AngleSharp.Core.Tests/Html/HtmlFragment.cs
@@ -614,5 +614,34 @@
 
             Assert.AreEqual(fragment, element.InnerHtml);
         }
+
+        [Test]
+        public void FragmentTailShouldBeConsidered()
+        {
+            var fragment = "<script>alert('foo');</script><p>Test</p>";
+            var document = "<!DOCTYPE html><div id=outputPanel></div>".ToHtmlDocument();
+            var nodes = fragment.ToHtmlFragment(document.Body);
+
+            Assert.AreEqual(2, nodes.Length);
+            Assert.AreEqual("script", nodes[0].GetTagName());
+            Assert.AreEqual("p", nodes[1].GetTagName());
+        }
+
+        [Test]
+        public void InnerHtmlShouldConsiderAllElementsOfFragmentsContainingScriptElements()
+        {
+            var fragment = "<p>Foo</p><script>alert('foo');</script><p>Test</p>";
+            var document = "<!DOCTYPE html><div id=outputPanel></div>".ToHtmlDocument();
+            document.Body.InnerHtml = fragment;
+            var nodes = document.Body.ChildNodes;
+
+            Assert.IsNull(document.QuerySelector("#outputPanel"));
+            Assert.AreEqual(3, nodes.Length);
+            Assert.AreEqual("p", nodes[0].GetTagName());
+            Assert.AreEqual("Foo", nodes[0].TextContent);
+            Assert.AreEqual("script", nodes[1].GetTagName());
+            Assert.AreEqual("p", nodes[2].GetTagName());
+            Assert.AreEqual("Test", nodes[2].TextContent);
+        }
     }
 }

--- a/src/AngleSharp/Parser/Html/HtmlDomBuilder.cs
+++ b/src/AngleSharp/Parser/Html/HtmlDomBuilder.cs
@@ -3651,17 +3651,25 @@
         /// </summary>
         void HandleScript(HtmlScriptElement script)
         {
-            //Disable scripting for HTML fragments (security reasons)
-            if (script != null && !IsFragmentCase)
+            if (script != null)
             {
-                _document.PerformMicrotaskCheckpoint();
-                _document.ProvideStableState();
-                CloseCurrentNode();
-                _currentMode = _previousMode;
-
-                if (script.Prepare(_document))
+                //Disable scripting for HTML fragments (security reasons)
+                if (IsFragmentCase)
                 {
-                    _waiting = RunScript(script);
+                    CloseCurrentNode();
+                    _currentMode = _previousMode;
+                }
+                else
+                {
+                    _document.PerformMicrotaskCheckpoint();
+                    _document.ProvideStableState();
+                    CloseCurrentNode();
+                    _currentMode = _previousMode;
+
+                    if (script.Prepare(_document))
+                    {
+                        _waiting = RunScript(script);
+                    }
                 }
             }
         }


### PR DESCRIPTION
This one essentially fixes #358. I think this bug has been introduced with some refactoring a long time ago. Unfortunately, there was no unit test to cover this (it only appears with fragment parsing when a script tag is seen / script tags are skipped in fragment parsing anyway, which is why mostly no one uses script tags in such scenarios).
