### PR TITLE
Issue #382

### DIFF
--- a/build.cake
+++ b/build.cake
@@ -189,7 +189,8 @@ Task("Publish-Release")
             Credentials = new Credentials(githubToken)
         };
 
-        github.Release.Create("AngleSharp", "AngleSharp", new NewRelease("v" + version)
+        var newRelease = github.Repository.Release;
+        newRelease.Create("AngleSharp", "AngleSharp", new NewRelease("v" + version)
         {
             Name = version,
             Body = String.Join(Environment.NewLine, releaseNotes.Notes),

--- a/src/AngleSharp.Core.Tests/Css/CssFontProperty.cs
+++ b/src/AngleSharp.Core.Tests/Css/CssFontProperty.cs
@@ -737,7 +737,20 @@
         }
 
         [Test]
-        public void CssFontFaceShouldSerializeCorrectly()
+        public void CssFontFaceWithThreeRulesShouldSerializeCorrectly()
+        {
+            var snippet = @"@font-face {
+        font-family: FrutigerLTStd;
+            src: url(""https://example.com/FrutigerLTStd-Light.otf"") format(""opentype"");
+           font-weight: bold;
+    }";
+            var rule = ParseRule(snippet);
+            Assert.AreEqual(CssRuleType.FontFace, rule.Type);
+            Assert.AreEqual("@font-face { font-family: FrutigerLTStd; src: url(\"https://example.com/FrutigerLTStd-Light.otf\") format(\"opentype\"); font-weight: bold }", rule.ToCss());
+        }
+
+        [Test]
+        public void CssFontFaceWithTwoRulesShouldSerializeCorrectly()
         {
             var snippet = @"@font-face {
         font-family: FrutigerLTStd;
@@ -746,6 +759,17 @@
             var rule = ParseRule(snippet);
             Assert.AreEqual(CssRuleType.FontFace, rule.Type);
             Assert.AreEqual("@font-face { font-family: FrutigerLTStd; src: url(\"https://example.com/FrutigerLTStd-Light.otf\") format(\"opentype\") }", rule.ToCss());
+        }
+
+        [Test]
+        public void CssFontFaceWithOneRuleShouldSerializeCorrectly()
+        {
+            var snippet = @"@font-face {
+        font-family: FrutigerLTStd;
+    }";
+            var rule = ParseRule(snippet);
+            Assert.AreEqual(CssRuleType.FontFace, rule.Type);
+            Assert.AreEqual("@font-face { font-family: FrutigerLTStd }", rule.ToCss());
         }
 
         [Test]

--- a/src/AngleSharp.Core.Tests/Css/CssFontProperty.cs
+++ b/src/AngleSharp.Core.Tests/Css/CssFontProperty.cs
@@ -1,6 +1,7 @@
 ﻿namespace AngleSharp.Core.Tests.Css
 {
     using AngleSharp.Dom.Css;
+    using AngleSharp.Extensions;
     using NUnit.Framework;
 
     [TestFixture]
@@ -733,6 +734,18 @@
             Assert.IsFalse(concrete.IsInherited);
             Assert.IsTrue(concrete.HasValue);
             Assert.AreEqual("status-bar", concrete.Value);
+        }
+
+        [Test]
+        public void CssFontFaceShouldSerializeCorrectly()
+        {
+            var snippet = @"@font-face {
+        font-family: FrutigerLTStd;
+            src: url(""https://example.com/FrutigerLTStd-Light.otf"") format(""opentype"");
+    }";
+            var rule = ParseRule(snippet);
+            Assert.AreEqual(CssRuleType.FontFace, rule.Type);
+            Assert.AreEqual("@font-face { font-family: FrutigerLTStd; src: url(\"https://example.com/FrutigerLTStd-Light.otf\") format(\"opentype\") }", rule.ToCss());
         }
 
         [Test]

--- a/src/AngleSharp/Dom/Css/Rules/CssDeclarationRule.cs
+++ b/src/AngleSharp/Dom/Css/Rules/CssDeclarationRule.cs
@@ -114,13 +114,31 @@
 
         public override void ToCss(TextWriter writer, IStyleFormatter formatter)
         {
-            var rules = formatter.Block(Declarations.Where(m => m.HasValue));
-            writer.Write(formatter.Rule("@" + _name, null, rules));
+            var rules = new FormatTransporter(Declarations);
+            var content = formatter.Style("@" + _name, rules);
+            writer.Write(content);
         }
 
         #endregion
 
         #region Helpers
+
+        struct FormatTransporter : IStyleFormattable
+        {
+            private readonly IEnumerable<CssProperty> _properties;
+
+            public FormatTransporter(IEnumerable<CssProperty> properties)
+            {
+                _properties = properties.Where(m => m.HasValue);
+            }
+
+            public void ToCss(TextWriter writer, IStyleFormatter formatter)
+            {
+                var properties = _properties.Select(m => m.ToCss(formatter));
+                var content = formatter.Declarations(properties);
+                writer.Write(content);
+            }
+        }
 
         protected abstract CssProperty CreateNewProperty(String name);
 


### PR DESCRIPTION
It turns out that the `CssDeclarationRule` based rules (`@font-face` and `@viewport`) have a problem once multiple declarations are contained. This PR fixes the problem.
