### PR TITLE
Fix BaseLoader crash when Set-Cookie not present in headers

### DIFF
--- a/src/AngleSharp/Network/Default/BaseLoader.cs
+++ b/src/AngleSharp/Network/Default/BaseLoader.cs
@@ -152,7 +152,10 @@
                 if (response != null)
                 {
                     redirectCount++;
-                    SetCookie(request.Address, response.Headers[HeaderNames.SetCookie]);
+                    if (response.Headers.ContainsKey(HeaderNames.SetCookie))
+                    {
+                        SetCookie(request.Address, response.Headers[HeaderNames.SetCookie]);
+                    }
                     request = CreateNewRequest(request, response);
                     request.Headers[HeaderNames.Cookie] = GetCookie(request.Address);
                 }


### PR DESCRIPTION
The following crashes :

```
            var config = Configuration.Default.WithDefaultLoader();

            var address = "http://google.fr";
            var client = BrowsingContext.New(config);
            var document = await client.OpenAsync(address);
```

This pr aims to fix the crash when there is no Set-Cookie header.
