### PR TITLE
#285 stroke property

### DIFF
--- a/src/AngleSharp.Core.Tests/AngleSharp.Core.Tests.csproj
+++ b/src/AngleSharp.Core.Tests/AngleSharp.Core.Tests.csproj
@@ -76,6 +76,7 @@
     <Compile Include="Css\CssOutlineProperty.cs" />
     <Compile Include="Css\CssCoordinateProperty.cs" />
     <Compile Include="Css\CssListProperty.cs" />
+    <Compile Include="Css\CssStrokeProperty.cs" />
     <Compile Include="Css\CssSupports.cs" />
     <Compile Include="Css\CssTextProperty.cs" />
     <Compile Include="Css\CssTransformProperty.cs" />

--- a/src/AngleSharp.Core.Tests/Css/CssStrokeProperty.cs
+++ b/src/AngleSharp.Core.Tests/Css/CssStrokeProperty.cs
@@ -1,0 +1,112 @@
+﻿namespace AngleSharp.Core.Tests.Css
+{
+	using AngleSharp.Css.Values;
+	using Dom.Css;
+	using NUnit.Framework;
+	using System;
+	using System.Collections.Generic;
+	using System.Linq;
+	using System.Text;
+	using System.Threading.Tasks;
+
+	[TestFixture]
+	public class CssStrokePropertyTests : CssConstructionFunctions
+	{
+		[Test]
+		public void CssStrokeColorRedLegal()
+		{
+			var snippet = "stroke: red";
+			var property = ParseDeclaration(snippet);
+			Assert.AreEqual("stroke", property.Name);
+			Assert.IsFalse(property.IsImportant);
+			Assert.IsInstanceOf<CssStrokeProperty>(property);
+			var concrete = (CssStrokeProperty)property;
+			Assert.IsFalse(concrete.IsInherited);
+			Assert.IsTrue(concrete.HasValue);
+			Assert.AreEqual("rgb(255, 0, 0)", concrete.Value);
+		}
+
+		[Test]
+		public void CssStrokeColorHexLegal()
+		{
+			var snippet = "stroke: #0F0";
+			var property = ParseDeclaration(snippet);
+			Assert.AreEqual("stroke", property.Name);
+			Assert.IsFalse(property.IsImportant);
+			Assert.IsInstanceOf<CssStrokeProperty>(property);
+			var concrete = (CssStrokeProperty)property;
+			Assert.IsFalse(concrete.IsInherited);
+			Assert.IsTrue(concrete.HasValue);
+			Assert.AreEqual("rgb(0, 255, 0)", concrete.Value);
+		}
+
+		[Test]
+		public void CssStrokeColorRgbaLegal()
+		{
+			var snippet = "stroke: rgba(1, 1, 1, 0)";
+			var property = ParseDeclaration(snippet);
+			Assert.AreEqual("stroke", property.Name);
+			Assert.IsFalse(property.IsImportant);
+			Assert.IsInstanceOf<CssStrokeProperty>(property);
+			var concrete = (CssStrokeProperty)property;
+			Assert.IsFalse(concrete.IsInherited);
+			Assert.IsTrue(concrete.HasValue);
+			Assert.AreEqual("rgba(1, 1, 1, 0)", concrete.Value);
+		}
+
+		[Test]
+		public void CssStrokeColorRgbLegal()
+		{
+			var snippet = "stroke: rgb(1, 255, 100)";
+			var property = ParseDeclaration(snippet);
+			Assert.AreEqual("stroke", property.Name);
+			Assert.IsFalse(property.IsImportant);
+			Assert.IsInstanceOf<CssStrokeProperty>(property);
+			var concrete = (CssStrokeProperty)property;
+			Assert.IsFalse(concrete.IsInherited);
+			Assert.IsTrue(concrete.HasValue);
+			Assert.AreEqual("rgb(1, 255, 100)", concrete.Value);
+		}
+
+		[Test]
+		public void CssStrokeNoneLegal()
+		{
+			var snippet = "stroke: none";
+			var property = ParseDeclaration(snippet);
+			Assert.AreEqual("stroke", property.Name);
+			Assert.IsFalse(property.IsImportant);
+			Assert.IsInstanceOf<CssStrokeProperty>(property);
+			var concrete = (CssStrokeProperty)property;
+			Assert.IsFalse(concrete.IsInherited);
+			Assert.IsTrue(concrete.HasValue);
+			Assert.AreEqual("none", concrete.Value);
+		}
+
+		[Test]
+		public void CssStrokeColorRedRedIllegal()
+		{
+			var snippet = "stroke: red red";
+			var property = ParseDeclaration(snippet);
+			Assert.AreEqual("stroke", property.Name);
+			Assert.IsFalse(property.IsImportant);
+			Assert.IsInstanceOf<CssStrokeProperty>(property);
+			var concrete = (CssStrokeProperty)property;
+			Assert.IsFalse(concrete.IsInherited);
+			Assert.IsFalse(concrete.HasValue);
+		}
+
+		[Test]
+		public void CssStrokeLinearGradientIlegal()
+		{
+			var snippet = "stroke: url(#linear)";
+			var property = ParseDeclaration(snippet);
+			Assert.AreEqual("stroke", property.Name);
+			Assert.IsFalse(property.IsImportant);
+			Assert.IsInstanceOf<CssStrokeProperty>(property);
+			var concrete = (CssStrokeProperty)property;
+			Assert.IsFalse(concrete.IsInherited);
+			Assert.IsTrue(concrete.HasValue);
+			Assert.AreEqual("url(\"#linear\")", concrete.Value);
+		}
+	}
+}

--- a/src/AngleSharp/AngleSharp.Core.csproj
+++ b/src/AngleSharp/AngleSharp.Core.csproj
@@ -145,6 +145,7 @@
     <Compile Include="Dom\Css\Properties\Font\CssSrcProperty.cs" />
     <Compile Include="Dom\Css\Properties\Sizing\CssObjectFitProperty.cs" />
     <Compile Include="Dom\Css\Properties\Sizing\CssObjectPositionProperty.cs" />
+    <Compile Include="Dom\Css\Properties\Stroke\CssStrokeProperty.cs" />
     <Compile Include="Dom\Css\Rules\CssDeclarationRule.cs" />
     <Compile Include="Dom\Css\Rules\CssUnknownRule.cs" />
     <Compile Include="Dom\Css\Rules\CssViewportRule.cs" />

--- a/src/AngleSharp/Css/Converters.cs
+++ b/src/AngleSharp/Css/Converters.cs
@@ -689,11 +689,16 @@
         /// </summary>
         public static readonly IValueConverter InvertedColorConverter = CurrentColorConverter.Or(Keywords.Invert);
 
-        /// <summary>
-        /// Represents a ratio object.
-        /// https://developer.mozilla.org/en-US/docs/Web/CSS/ratio
-        /// </summary>
-        public static readonly IValueConverter RatioConverter = WithOrder(
+		/// <summary>
+		/// Represents a paint object.
+		/// </summary>
+		public static readonly IValueConverter PaintConverter = UrlConverter.Or(CurrentColorConverter.OrNone());
+
+		/// <summary>
+		/// Represents a ratio object.
+		/// https://developer.mozilla.org/en-US/docs/Web/CSS/ratio
+		/// </summary>
+		public static readonly IValueConverter RatioConverter = WithOrder(
             IntegerConverter.Required(), 
             IntegerConverter.StartsWithDelimiter().Required());
 

--- a/src/AngleSharp/Dom/Css/Properties/Stroke/CssStrokeProperty.cs
+++ b/src/AngleSharp/Dom/Css/Properties/Stroke/CssStrokeProperty.cs
@@ -1,0 +1,32 @@
+﻿namespace AngleSharp.Dom.Css
+{
+	using AngleSharp.Css;
+
+	sealed class CssStrokeProperty : CssProperty
+	{
+		#region Fields
+
+		static readonly IValueConverter StyleConverter = Converters.PaintConverter;
+
+		#endregion
+
+
+		#region ctor
+
+		internal CssStrokeProperty()
+			: base(PropertyNames.Stroke, PropertyFlags.Animatable)
+		{
+		}
+
+		#endregion
+
+		#region Properties
+
+		internal override IValueConverter Converter
+		{
+			get { return StyleConverter; }
+		}
+
+		#endregion
+	}
+}

--- a/src/AngleSharp/Services/Default/CssPropertyFactory.cs
+++ b/src/AngleSharp/Services/Default/CssPropertyFactory.cs
@@ -264,6 +264,7 @@
             AddLonghand(PropertyNames.Position, () => new CssPositionProperty(), animatable: false);
             AddLonghand(PropertyNames.Quotes, () => new CssQuotesProperty(), animatable: false);
             AddLonghand(PropertyNames.Right, () => new CssRightProperty(), animatable: true);
+			AddLonghand(PropertyNames.Stroke, () => new CssStrokeProperty(), animatable: true);
             AddLonghand(PropertyNames.TableLayout, () => new CssTableLayoutProperty(), animatable: false);
             AddLonghand(PropertyNames.TextAlign, () => new CssTextAlignProperty(), animatable: false);
 


### PR DESCRIPTION
This PR adds `Stroke` css property along with the tests.

Please review and feel free to comment on this PR

If this PR seems ok, I can work on the rest of the stroke-\* properties.
