### PR TITLE
Issue #448

### DIFF
--- a/src/AngleSharp.Core.Tests/AngleSharp.Core.Tests.csproj
+++ b/src/AngleSharp.Core.Tests/AngleSharp.Core.Tests.csproj
@@ -104,7 +104,7 @@
     <Compile Include="Mocks\MarkdownDocument.cs" />
     <Compile Include="Mocks\MockIntegrityProvider.cs" />
     <Compile Include="Mocks\VirtualRequester.cs" />
-    <Compile Include="Url\MimeType.cs" />
+    <Compile Include="Urls\MimeType.cs" />
     <Compile Include="Library\MutationObserver.cs" />
     <Compile Include="Library\OptionWithLabel.cs" />
     <Compile Include="Library\PageImport.cs" />
@@ -133,7 +133,7 @@
     <Compile Include="Library\DOMExtensions.cs" />
     <Compile Include="Library\HttpRequester.cs" />
     <Compile Include="Library\AsyncParsing.cs" />
-    <Compile Include="Url\Location.cs" />
+    <Compile Include="Urls\Location.cs" />
     <Compile Include="Library\OptimizationPool.cs" />
     <Compile Include="Library\FormSubmit.cs" />
     <Compile Include="Css\Priority.cs" />
@@ -141,8 +141,8 @@
     <Compile Include="Library\TreeWalker.cs" />
     <Compile Include="Library\NodeIterator.cs" />
     <Compile Include="Library\DOMActions.cs" />
-    <Compile Include="Url\Url.cs" />
-    <Compile Include="Url\UrlValidation.cs" />
+    <Compile Include="Urls\Url.cs" />
+    <Compile Include="Urls\UrlValidation.cs" />
     <Compile Include="Mocks\CallbackScriptEngine.cs" />
     <Compile Include="Mocks\ContentScriptEngine.cs" />
     <Compile Include="Mocks\DelayedStream.cs" />
@@ -173,6 +173,7 @@
     <Compile Include="TestExtensions.cs" />
     <Compile Include="Xhtml\PreserveValidXhtml.cs" />
     <Compile Include="Xhtml\AutoSelectMarkupFormatter.cs" />
+    <Compile Include="Xml\XmlNamespace.cs" />
     <Compile Include="Xml\XmlParsing.cs" />
     <Compile Include="Xml\XmlSamples.cs" />
     <Compile Include="Xml\XmlTokenization.cs" />

--- a/src/AngleSharp.Core.Tests/Urls/Location.cs
+++ b/src/AngleSharp.Core.Tests/Urls/Location.cs
@@ -1,4 +1,4 @@
-﻿namespace AngleSharp.Core.Tests
+﻿namespace AngleSharp.Core.Tests.Urls
 {
     using AngleSharp.Dom;
     using NUnit.Framework;

--- a/src/AngleSharp.Core.Tests/Urls/MimeType.cs
+++ b/src/AngleSharp.Core.Tests/Urls/MimeType.cs
@@ -1,4 +1,4 @@
-﻿namespace AngleSharp.Core.Tests
+﻿namespace AngleSharp.Core.Tests.Urls
 {
     using AngleSharp.Network;
     using NUnit.Framework;

--- a/src/AngleSharp.Core.Tests/Urls/Url.cs
+++ b/src/AngleSharp.Core.Tests/Urls/Url.cs
@@ -1,4 +1,4 @@
-﻿namespace AngleSharp.Core.Tests
+﻿namespace AngleSharp.Core.Tests.Urls
 {
     using NUnit.Framework;
     using System;

--- a/src/AngleSharp.Core.Tests/Urls/UrlValidation.cs
+++ b/src/AngleSharp.Core.Tests/Urls/UrlValidation.cs
@@ -1,4 +1,4 @@
-namespace AngleSharp.Core.Tests
+namespace AngleSharp.Core.Tests.Urls
 {
     using AngleSharp.Dom;
     using AngleSharp.Dom.Html;

--- a/src/AngleSharp.Core.Tests/Xml/XmlNamespace.cs
+++ b/src/AngleSharp.Core.Tests/Xml/XmlNamespace.cs
@@ -1,0 +1,40 @@
+﻿namespace AngleSharp.Core.Tests.Xml
+{
+    using NUnit.Framework;
+    using System.Threading.Tasks;
+
+    [TestFixture]
+    public class XmlNamespaceTests
+    {
+        [Test]
+        public async Task XmlWithoutNamespaceUriShouldBeStandardNamespaceUri()
+        {
+            var document = await BrowsingContext.New().OpenAsync(req =>
+                req.Content(@"<a t='42'><b/><c>TEXT</c></a>")
+                   .Header("Content-Type", "text/xml"));
+            var root = document.DocumentElement;
+            Assert.AreEqual(null, root.NamespaceUri);
+        }
+
+        [Test]
+        public async Task XmlWithNewNamespaceShouldContainRightNamespaceUri()
+        {
+            var document = await BrowsingContext.New().OpenAsync(req =>
+              req.Content(@"<a xmlns=""http://www.w3.org/1999/xhtml"" t=""42""><b/><c>TEXT</c></a>")
+                 .Header("Content-Type", "text/xml"));
+            var root = document.DocumentElement;
+            Assert.AreEqual("http://www.w3.org/1999/xhtml", root.NamespaceUri);
+        }
+
+
+        [Test]
+        public async Task XmlWithCustomNamespaceShouldExposeThatNamespaceUri()
+        {
+            var document = await BrowsingContext.New().OpenAsync(req =>
+                req.Content(@"<x:a xmlns:x=""http://initd.org/ns/tesseract-1.0"" t=""42""><b/><c>TEXT</c></x:a>")
+                   .Header("Content-Type", "text/xml"));
+            var root = document.DocumentElement;
+            Assert.AreEqual("http://initd.org/ns/tesseract-1.0", root.NamespaceUri);
+        }
+    }
+}

--- a/src/AngleSharp.Core.Tests/Xml/XmlNamespace.cs
+++ b/src/AngleSharp.Core.Tests/Xml/XmlNamespace.cs
@@ -26,7 +26,6 @@
             Assert.AreEqual("http://www.w3.org/1999/xhtml", root.NamespaceUri);
         }
 
-
         [Test]
         public async Task XmlWithCustomNamespaceShouldExposeThatNamespaceUri()
         {
@@ -35,6 +34,47 @@
                    .Header("Content-Type", "text/xml"));
             var root = document.DocumentElement;
             Assert.AreEqual("http://initd.org/ns/tesseract-1.0", root.NamespaceUri);
+        }
+
+        [Test]
+        public async Task XmlSubElementsGetTheRightDefaultNamespace()
+        {
+            var document = await BrowsingContext.New().OpenAsync(req =>
+                req.Content(@"<xml xmlns=""http://test.com""><child attr=""1""/></xml>")
+                   .Header("Content-Type", "text/xml"));
+            var root = document.DocumentElement;
+            Assert.AreEqual("http://test.com", root.NamespaceUri);
+            Assert.AreEqual("http://test.com", root.LookupNamespaceUri(""));
+            Assert.AreEqual("http://test.com", root.FirstElementChild.NamespaceUri);
+            Assert.AreEqual("http://test.com", root.FirstElementChild.LookupNamespaceUri(""));
+            Assert.AreEqual(null, root.FirstElementChild.Attributes["attr"].NamespaceUri);
+        }
+
+        [Test]
+        public async Task XmlPrefixRefersToDefinedNamespace()
+        {
+            var document = await BrowsingContext.New().OpenAsync(req =>
+                req.Content(@"<xml xmlns:p1=""http://p1.com"" xmlns:p2=""http://p2.com""><p1:child a=""1"" p1:attr=""1"" b=""2""/><p2:child/></xml>")
+                   .Header("Content-Type", "text/xml"));
+            var root = document.DocumentElement;
+            Assert.AreEqual("http://p1.com", root.FirstElementChild.NamespaceUri);
+            Assert.AreEqual("http://p1.com", root.LookupNamespaceUri("p1"));
+            Assert.AreEqual(null, root.FirstElementChild.GetAttribute("attr"));
+            Assert.AreEqual("http://p1.com", root.FirstElementChild.Attributes["p1:attr"].NamespaceUri);
+            Assert.AreEqual("http://p2.com", root.FirstElementChild.NextElementSibling.NamespaceUri);
+            Assert.AreEqual("http://p2.com", root.FirstElementChild.NextElementSibling.LookupNamespaceUri("p2"));
+        }
+
+        [Test]
+        public async Task XmlRedefinitionOfPrefixedNamespace()
+        {
+            var document = await BrowsingContext.New().OpenAsync(req =>
+                req.Content(@"<xml xmlns:p=""http://test.com""><p:child xmlns:p=""http://p.com""/><p:child/></xml>")
+                   .Header("Content-Type", "text/xml"));
+            var root = document.DocumentElement;
+            Assert.AreEqual("http://p.com", root.FirstElementChild.NamespaceUri);
+            Assert.AreEqual("http://test.com", root.LastElementChild.NamespaceUri);
+            Assert.AreEqual("http://test.com", root.FirstElementChild.NextElementSibling.LookupNamespaceUri("p"));
         }
     }
 }

--- a/src/AngleSharp/Dom/Element.cs
+++ b/src/AngleSharp/Dom/Element.cs
@@ -118,7 +118,7 @@
 
         public String NamespaceUri
         {
-            get { return _namespace; }
+            get { return _namespace ?? this.GetNamespaceUri(); }
         }
 
         public override String TextContent

--- a/src/AngleSharp/Dom/Xml/XmlElement.cs
+++ b/src/AngleSharp/Dom/Xml/XmlElement.cs
@@ -1,6 +1,5 @@
 ﻿namespace AngleSharp.Dom.Xml
 {
-    using AngleSharp.Html;
     using System;
 
     /// <summary>
@@ -11,7 +10,7 @@
         #region ctor
 
         public XmlElement(Document owner, String name, String prefix = null)
-            : base(owner, name, prefix, NamespaceNames.XmlUri)
+            : base(owner, name, prefix, null)
         {
         }
 

--- a/src/AngleSharp/Extensions/ElementExtensions.cs
+++ b/src/AngleSharp/Extensions/ElementExtensions.cs
@@ -95,7 +95,7 @@
 
             if (!success)
             {
-                ns = element.ParentElement?.NamespaceUri;
+                ns = element.ParentElement?.LocateNamespaceFor(prefix);
             }
 
             return ns;


### PR DESCRIPTION
To fix #448 the following things have been improved:
- do consider flexible namespaces (i.e., not only initially fixed ones)
- separate local-names w. prefixes for elements in the XML parser
- separate local-names w. prefixes for attributes in the XML parser

This should enhance the situation. It fixes all problems from #448, but we should try to fix _any_ other XML-namespace related problems as well. Therefore I won't merge the PR before we agree that the commits in this PR are sufficient for handling namespace scenarios well.
