### PR TITLE
Optimized away INode.GetAllElements() allocations

### DIFF
--- a/src/AngleSharp/Dom/Internal/CollectionExtensions.cs
+++ b/src/AngleSharp/Dom/Internal/CollectionExtensions.cs
@@ -23,7 +23,7 @@
         /// </param>
         /// <param name="predicate">The filter function, if any.</param>
         /// <returns>The collection with the corresponding elements.</returns>
-        public static IEnumerable<T> GetElements<T>(this INode parent, Boolean deep = true, Predicate<T> predicate = null)
+        public static IEnumerable<T> GetElements<T>(this INode parent, Boolean deep = true, Func<T, bool> predicate = null)
             where T : class, INode
         {
             predicate = predicate ?? (m => true);
@@ -158,13 +158,13 @@
             return null;
         }
 
-        private static IEnumerable<T> GetAllElements<T>(this INode parent, Predicate<T> predicate)
+        private static IEnumerable<T> GetAllElements<T>(this INode parent, Func<T, bool> predicate)
             where T : class, INode
             => new NodeEnumerable(parent)
             .OfType<T>()
-            .Where(node => predicate(node));
+            .Where(predicate);
 
-        private static IEnumerable<T> GetDescendendElements<T>(this INode parent, Predicate<T> predicate)
+        private static IEnumerable<T> GetDescendendElements<T>(this INode parent, Func<T, bool> predicate)
             where T : class, INode
         {
             for (var i = 0; i < parent.ChildNodes.Length; i++)

--- a/src/AngleSharp/Dom/Internal/HtmlCollection.cs
+++ b/src/AngleSharp/Dom/Internal/HtmlCollection.cs
@@ -26,7 +26,7 @@
             _elements = elements;
         }
 
-        public HtmlCollection(INode parent, Boolean deep = true, Predicate<T> predicate = null)
+        public HtmlCollection(INode parent, Boolean deep = true, Func<T, bool> predicate = null)
         {
             _elements = parent.GetElements(deep, predicate);
         }


### PR DESCRIPTION
The PR greatly reduces the allocations made by `INode.GetAllElements()` extension that's called under the hoods every time the document tree is traversed to fill `HtmlCollection`. This method was surprisingly high on the list of top allocators when doing things like enumerating all links/scripts found in the HTML document. To illustrate the point, let's consider a simple benchmark:

```C#
HtmlParser parser = new HtmlParser();

for ( int i = 0; i < 1000; i++ )
{
	// I used some random real-world ~110KB HTML file here
	IHtmlDocument document = parser.ParseDocument( TestData.TorrentSite );
	foreach ( IElement link in document.Links )
	{
	}

	foreach ( IHtmlScriptElement script in document.Scripts )
	{
	}
}
```

Before this PR the allocation profile looked like this:

![Profile: before](http://i.imgur.com/5t2KfU7.png)

As you can see, the memory pressure caused by iterating through a parsed document was basically on par with creating all the strings for attribute values, tag names, etc. This was caused by all the `IEnumerable<T>` and `IEnumerator<T>` instances that were allocated recursively when traversing the tree. This PR addresses this by eliminating recursion and allocating fixed number of objects per `GetAllElements()` call ( 1 `Enumerable`, 1 `Enumerator` and 1 `Stack` for inner enumerable + 2 `Enumerable` / `Enumerator` pairs for `OfType()` and `Where()`. `Stack` can allocate multiple additional arrays under the hood, but they are not enough to be noticed in the profile). Here's the profile after this PR:

![Profile: after](http://i.imgur.com/CzHeNVQ.png)

`GetAllElements()` memory pressure was basically eliminated (it's somewhere around 0.3 MB now).