### PR TITLE
Optimized CharacterData.Append() a bit

### DIFF
--- a/src/AngleSharp/Dom/Internal/CharacterData.cs
+++ b/src/AngleSharp/Dom/Internal/CharacterData.cs
@@ -180,7 +180,12 @@
             owner.QueueMutation(MutationRecord.CharacterData(target: this, previousValue: _content));
 
             var deleteOffset = offset + data.Length;
-            _content = _content.Insert(offset, data).Remove(deleteOffset, count);
+            _content = _content.Insert(offset, data);
+
+            if (count > 0)
+            {
+                _content = _content.Remove(deleteOffset, count);
+            }
 
             owner.ForEachRange(m => m.Head == this && m.Start > offset && m.Start <= offset + count, m => m.StartWith(this, offset));
             owner.ForEachRange(m => m.Tail == this && m.End > offset && m.End <= offset + count, m => m.EndWith(this, offset));


### PR DESCRIPTION
Just a small thing I've noticed while looking around. This method is called *a lot* when appending tokens to `CharacterData`, and every time `String.Remove()` was called with `count = 0`. For the reasons unknown, this is not a noop, but actually copies the string. The difference on my current benchmark:

Before:
![Before](http://i.imgur.com/oSwrrI1.png)

After:
![After](http://i.imgur.com/mV7Fdh1.png)

I'm not a huge fan of those `Insert()`s either: we create a token, allocate a string for it, then pass it around a bit... just to append it to another string. And then do it again a few more dozen times =) This scenario can be optimised further, but some preparation is needed to handle it properly, so this will do for now.