### PR TITLE
Culture invariant parsing

### DIFF
--- a/build.cake
+++ b/build.cake
@@ -79,7 +79,7 @@ Task("Build")
 
         DotNetCoreBuild("./src/AngleSharp/project.json", new DotNetCoreBuildSettings
         {
-            Configuration = "Release"
+            Configuration = configuration
         });
     });
 

--- a/src/AngleSharp.Core.Tests/Html/ValidityRangeOverflow.cs
+++ b/src/AngleSharp.Core.Tests/Html/ValidityRangeOverflow.cs
@@ -1434,9 +1434,34 @@ namespace AngleSharp.Core.Tests.Html
 			element.Value = "6";
 			Assert.AreEqual("number", element.Type);
 			Assert.AreEqual(true, element.Validity.IsRangeOverflow);
-		}
-		
-		[Test]
+        }
+
+        [Test]
+        [SetCulture("ru")]
+        public void TestRangeoverflowInputNumber8InRussia()
+        {
+            var document = ("").ToHtmlDocument();
+            var element = document.CreateElement("input") as HtmlInputElement;
+            Assert.IsNotNull(element);
+            element.Type = "number";
+            element.RemoveAttribute("required");
+            element.RemoveAttribute("pattern");
+            element.RemoveAttribute("step");
+            element.RemoveAttribute("max");
+            element.RemoveAttribute("min");
+            element.RemoveAttribute("maxlength");
+            element.RemoveAttribute("value");
+            element.RemoveAttribute("multiple");
+            element.RemoveAttribute("checked");
+            element.RemoveAttribute("selected");
+            element.SetAttribute("max", "-5.5");
+            element.Value = "-5.4";
+            Assert.AreEqual("number", element.Type);
+            Assert.AreEqual(true, element.Validity.IsRangeOverflow);
+        }
+
+
+        [Test]
 		public void TestRangeoverflowInputNumber8()
 		{
 			var document = ("").ToHtmlDocument();

--- a/src/AngleSharp.Core.Tests/Html/ValidityRangeUnderflow.cs
+++ b/src/AngleSharp.Core.Tests/Html/ValidityRangeUnderflow.cs
@@ -176,9 +176,9 @@ namespace AngleSharp.Core.Tests.Html
 			element.Value = "2000-01-01T12:00:00Z";
 			Assert.AreEqual("datetime", element.Type);
 			Assert.AreEqual(true, element.Validity.IsRangeUnderflow);
-		}
-		
-		[Test]
+        }
+
+        [Test]
 		public void TestRangeunderflowInputDatetime8()
 		{
 			var document = CreateTestDocument();
@@ -1280,32 +1280,56 @@ namespace AngleSharp.Core.Tests.Html
 			element.Value = "5";
 			Assert.AreEqual("number", element.Type);
 			Assert.AreEqual(false, element.Validity.IsRangeUnderflow);
-		}
-		
-		[Test]
-		public void TestRangeunderflowInputNumber4()
-		{
-			var document = CreateTestDocument();
-			var element = document.CreateElement("input") as HtmlInputElement;
-			Assert.IsNotNull(element);
-			element.Type = "number";
-			element.RemoveAttribute("required");
-			element.RemoveAttribute("pattern");
-			element.RemoveAttribute("step");
-			element.RemoveAttribute("max");
-			element.RemoveAttribute("min");
-			element.RemoveAttribute("maxlength");
-			element.RemoveAttribute("value");
-			element.RemoveAttribute("multiple");
-			element.RemoveAttribute("checked");
-			element.RemoveAttribute("selected");
-			element.SetAttribute("min", "-5.6");
-			element.Value = "-5.5";
-			Assert.AreEqual("number", element.Type);
-			Assert.AreEqual(false, element.Validity.IsRangeUnderflow);
-		}
-		
-		[Test]
+        }
+
+        [Test]
+        public void TestRangeunderflowInputNumber4()
+        {
+            var document = CreateTestDocument();
+            var element = document.CreateElement("input") as HtmlInputElement;
+            Assert.IsNotNull(element);
+            element.Type = "number";
+            element.RemoveAttribute("required");
+            element.RemoveAttribute("pattern");
+            element.RemoveAttribute("step");
+            element.RemoveAttribute("max");
+            element.RemoveAttribute("min");
+            element.RemoveAttribute("maxlength");
+            element.RemoveAttribute("value");
+            element.RemoveAttribute("multiple");
+            element.RemoveAttribute("checked");
+            element.RemoveAttribute("selected");
+            element.SetAttribute("min", "-5.6");
+            element.Value = "-5.5";
+            Assert.AreEqual("number", element.Type);
+            Assert.AreEqual(false, element.Validity.IsRangeUnderflow);
+        }
+
+        [Test]
+        [SetCulture("ru")]
+        public void TestRangeunderflowInputNumber4InRussia()
+        {
+            var document = CreateTestDocument();
+            var element = document.CreateElement("input") as HtmlInputElement;
+            Assert.IsNotNull(element);
+            element.Type = "number";
+            element.RemoveAttribute("required");
+            element.RemoveAttribute("pattern");
+            element.RemoveAttribute("step");
+            element.RemoveAttribute("max");
+            element.RemoveAttribute("min");
+            element.RemoveAttribute("maxlength");
+            element.RemoveAttribute("value");
+            element.RemoveAttribute("multiple");
+            element.RemoveAttribute("checked");
+            element.RemoveAttribute("selected");
+            element.SetAttribute("min", "-5.6");
+            element.Value = "-5.5";
+            Assert.AreEqual("number", element.Type);
+            Assert.AreEqual(false, element.Validity.IsRangeUnderflow);
+        }
+
+        [Test]
 		public void TestRangeunderflowInputNumber5()
 		{
 			var document = CreateTestDocument();

--- a/src/AngleSharp.Core.Tests/Html/ValidityValueMissing.cs
+++ b/src/AngleSharp.Core.Tests/Html/ValidityValueMissing.cs
@@ -1711,9 +1711,33 @@ namespace AngleSharp.Core.Tests.Html
 			element.Value = "123.01e-10";
 			Assert.AreEqual("number", element.Type);
 			Assert.AreEqual(false, element.Validity.IsValueMissing);
-		}
-		
-		[Test]
+        }
+
+        [Test]
+        [SetCulture("ru")]
+        public void TestValuemissingInputNumber5InRussia()
+        {
+            var document = ("").ToHtmlDocument();
+            var element = document.CreateElement("input") as HtmlInputElement;
+            Assert.IsNotNull(element);
+            element.Type = "number";
+            element.RemoveAttribute("required");
+            element.RemoveAttribute("pattern");
+            element.RemoveAttribute("step");
+            element.RemoveAttribute("max");
+            element.RemoveAttribute("min");
+            element.RemoveAttribute("maxlength");
+            element.RemoveAttribute("value");
+            element.RemoveAttribute("multiple");
+            element.RemoveAttribute("checked");
+            element.RemoveAttribute("selected");
+            element.SetAttribute("required", "required");
+            element.Value = "123.01E+10";
+            Assert.AreEqual("number", element.Type);
+            Assert.AreEqual(false, element.Validity.IsValueMissing);
+        }
+
+        [Test]
 		public void TestValuemissingInputNumber5()
 		{
 			var document = ("").ToHtmlDocument();

--- a/src/AngleSharp/Css/Parser/CssSelectorConstructor.cs
+++ b/src/AngleSharp/Css/Parser/CssSelectorConstructor.cs
@@ -7,6 +7,7 @@
     using AngleSharp.Text;
     using System;
     using System.Collections.Generic;
+    using System.Globalization;
     using System.Linq;
 
     /// <summary>
@@ -975,7 +976,7 @@
                 if (token.Type == CssTokenType.Dimension)
                 {
                     var integral = token.Data.Remove(token.Data.Length - 1);
-                    _valid = _valid && token.Data.EndsWith("n", StringComparison.OrdinalIgnoreCase) && Int32.TryParse(integral, out _step);
+                    _valid = _valid && token.Data.EndsWith("n", StringComparison.OrdinalIgnoreCase) && Int32.TryParse(integral, NumberStyles.Integer, CultureInfo.InvariantCulture, out _step);
                     _step *= _sign;
                     _sign = 1;
                     _state = ParseState.Offset;
@@ -1042,7 +1043,7 @@
 
                 if (token.Type == CssTokenType.Number)
                 {
-                    _valid = _valid && Int32.TryParse(token.Data, out _offset);
+                    _valid = _valid && Int32.TryParse(token.Data, NumberStyles.Integer, CultureInfo.InvariantCulture, out _offset);
                     _offset *= _sign;
                     _state = ParseState.BeforeOf;
                     return false;

--- a/src/AngleSharp/Css/Parser/CssStringSourceExtensions.cs
+++ b/src/AngleSharp/Css/Parser/CssStringSourceExtensions.cs
@@ -64,7 +64,14 @@
                     source.Back();
                 }
 
-                var code = Int32.Parse(new String(escape, 0, length), NumberStyles.HexNumber);
+                var code = 0;
+                var pwr = 1;
+
+                for (var i = length - 1; i >= 0; i--)
+                {
+                    code += escape[i].FromHex() * pwr;
+                    pwr *= 16;
+                }
 
                 if (!code.IsInvalid())
                 {

--- a/src/AngleSharp/Html/Dom/Internal/HtmlListItemElement.cs
+++ b/src/AngleSharp/Html/Dom/Internal/HtmlListItemElement.cs
@@ -2,6 +2,7 @@
 {
     using AngleSharp.Dom;
     using System;
+    using System.Globalization;
 
     /// <summary>
     /// Represents an HTML li, dd or dt tag.
@@ -24,7 +25,7 @@
 
         public Int32? Value
         {
-            get { var i = 0; return Int32.TryParse(this.GetOwnAttribute(AttributeNames.Value), out i) ? i : new Int32?(); }
+            get { var i = 0; return Int32.TryParse(this.GetOwnAttribute(AttributeNames.Value), NumberStyles.Integer, CultureInfo.InvariantCulture, out i) ? i : new Int32?(); }
             set { this.SetOwnAttribute(AttributeNames.Value, value.HasValue ? value.Value.ToString() : null); }
         }
 

--- a/src/AngleSharp/Html/InputTypes/BaseInputType.cs
+++ b/src/AngleSharp/Html/InputTypes/BaseInputType.cs
@@ -314,7 +314,7 @@
             {
                 try
                 {
-                    var regex = new Regex(pattern, RegexOptions.ECMAScript);
+                    var regex = new Regex(pattern, RegexOptions.ECMAScript | RegexOptions.CultureInvariant);
                     return !regex.IsMatch(value);
                 }
                 catch { }
@@ -330,7 +330,7 @@
         {
             if (!String.IsNullOrEmpty(value) && Number.IsMatch(value))
             {
-                return Double.Parse(value);
+                return Double.Parse(value, CultureInfo.InvariantCulture);
             }
 
             return null;
@@ -350,14 +350,14 @@
                 value[position++].IsDigit() && 
                 value[position++] == Symbols.Colon)
             {
-                var hour = Int32.Parse(value.Substring(offset, 2));
+                var hour = Int32.Parse(value.Substring(offset, 2), CultureInfo.InvariantCulture);
 
                 if (!IsLegalHour(hour) || !value[position++].IsDigit() || !value[position++].IsDigit())
                 {
                     return null;
                 }
 
-                var minute = Int32.Parse(value.Substring(3 + offset, 2));
+                var minute = Int32.Parse(value.Substring(3 + offset, 2), CultureInfo.InvariantCulture);
 
                 if (!IsLegalMinute(minute))
                 {
@@ -373,7 +373,7 @@
                         return null;
                     }
 
-                    second = Int32.Parse(value.Substring(6 + offset, 2));
+                    second = Int32.Parse(value.Substring(6 + offset, 2), CultureInfo.InvariantCulture);
 
                     if (!IsLegalSecond(second))
                     {
@@ -391,7 +391,7 @@
                         }
 
                         var fraction = value.Substring(start, position - start);
-                        ms = Int32.Parse(fraction) * (Int32)Math.Pow(10, 3 - fraction.Length);
+                        ms = Int32.Parse(fraction, CultureInfo.InvariantCulture) * (Int32)Math.Pow(10, 3 - fraction.Length);
                     }
                 }
 

--- a/src/AngleSharp/Html/InputTypes/DateInputType.cs
+++ b/src/AngleSharp/Html/InputTypes/DateInputType.cs
@@ -103,9 +103,12 @@
 
                 if (IsLegalPosition(value, position))
                 {
-                    var year = Int32.Parse(value.Substring(0, position));
-                    var month = Int32.Parse(value.Substring(position + 1, 2));
-                    var day = Int32.Parse(value.Substring(position + 4, 2));
+                    var yearString = value.Substring(0, position);
+                    var year = Int32.Parse(yearString, CultureInfo.InvariantCulture);
+                    var monthString = value.Substring(position + 1, 2);
+                    var month = Int32.Parse(monthString, CultureInfo.InvariantCulture);
+                    var dayString = value.Substring(position + 4, 2);
+                    var day = Int32.Parse(dayString, CultureInfo.InvariantCulture);
 
                     if (IsLegalDay(day, month, year))
                     {

--- a/src/AngleSharp/Html/InputTypes/DateTimeInputType.cs
+++ b/src/AngleSharp/Html/InputTypes/DateTimeInputType.cs
@@ -105,9 +105,12 @@
 
                 if (PositionIsValidForDateTime(value, position))
                 {
-                    var year = Int32.Parse(value.Substring(0, position));
-                    var month = Int32.Parse(value.Substring(position + 1, 2));
-                    var day = Int32.Parse(value.Substring(position + 4, 2));
+                    var yearString = value.Substring(0, position);
+                    var year = Int32.Parse(yearString, CultureInfo.InvariantCulture);
+                    var monthString = value.Substring(position + 1, 2);
+                    var month = Int32.Parse(monthString, CultureInfo.InvariantCulture);
+                    var dayString = value.Substring(position + 4, 2);
+                    var day = Int32.Parse(dayString, CultureInfo.InvariantCulture);
                     position += 6;
 
                     if (IsLegalDay(day, month, year) && IsTimeSeparator(value[position]))
@@ -134,8 +137,10 @@
                             {
                                 if (IsLegalPosition(value, position))
                                 {
-                                    var hours = Int32.Parse(value.Substring(position + 1, 2));
-                                    var minutes = Int32.Parse(value.Substring(position + 4, 2));
+                                    var hoursString = value.Substring(position + 1, 2);
+                                    var hours = Int32.Parse(hoursString, CultureInfo.InvariantCulture);
+                                    var minutesString = value.Substring(position + 4, 2);
+                                    var minutes = Int32.Parse(minutesString, CultureInfo.InvariantCulture);
                                     var offset = new TimeSpan(hours, minutes, 0);
 
                                     if (value[position] == '+')

--- a/src/AngleSharp/Html/InputTypes/DatetimeLocalInputType.cs
+++ b/src/AngleSharp/Html/InputTypes/DatetimeLocalInputType.cs
@@ -105,9 +105,12 @@
 
                 if (PositionIsValidForDateTime(value, position))
                 {
-                    var year = Int32.Parse(value.Substring(0, position));
-                    var month = Int32.Parse(value.Substring(position + 1, 2));
-                    var day = Int32.Parse(value.Substring(position + 4, 2));
+                    var yearString = value.Substring(0, position);
+                    var year = Int32.Parse(yearString, CultureInfo.InvariantCulture);
+                    var monthString = value.Substring(position + 1, 2);
+                    var month = Int32.Parse(monthString, CultureInfo.InvariantCulture);
+                    var dayString = value.Substring(position + 4, 2);
+                    var day = Int32.Parse(dayString, CultureInfo.InvariantCulture);
                     position += 6;
 
                     if (IsLegalDay(day, month, year) && IsTimeSeparator(value[position]))

--- a/src/AngleSharp/Html/InputTypes/MonthInputType.cs
+++ b/src/AngleSharp/Html/InputTypes/MonthInputType.cs
@@ -103,8 +103,10 @@
 
                 if (IsLegalPosition(value, position))
                 {
-                    var year = Int32.Parse(value.Substring(0, position));
-                    var month = Int32.Parse(value.Substring(position + 1));
+                    var yearString = value.Substring(0, position);
+                    var year = Int32.Parse(yearString, CultureInfo.InvariantCulture);
+                    var monthString = value.Substring(position + 1);
+                    var month = Int32.Parse(monthString, CultureInfo.InvariantCulture);
 
                     if (IsLegalDay(1, month, year))
                     {

--- a/src/AngleSharp/Io/DefaultHttpRequester.cs
+++ b/src/AngleSharp/Io/DefaultHttpRequester.cs
@@ -4,6 +4,7 @@
     using AngleSharp.Text;
     using System;
     using System.Collections.Generic;
+    using System.Globalization;
     using System.IO;
     using System.Linq;
     using System.Net;
@@ -270,7 +271,7 @@
                 }
                 else if (key.Is(HeaderNames.Date))
                 {
-                    SetProperty(HeaderNames.Date, DateTime.Parse(value));
+                    SetProperty(HeaderNames.Date, DateTime.Parse(value, CultureInfo.InvariantCulture));
                 }
                 else if (key.Is(HeaderNames.Host))
                 {
@@ -278,7 +279,7 @@
                 }
                 else if (key.Is(HeaderNames.IfModifiedSince))
                 {
-                    SetProperty("IfModifiedSince", DateTime.Parse(value));
+                    SetProperty("IfModifiedSince", DateTime.Parse(value, CultureInfo.InvariantCulture));
                 }
                 else if (key.Is(HeaderNames.Referer))
                 {

--- a/src/AngleSharp/Text/StringExtensions.cs
+++ b/src/AngleSharp/Text/StringExtensions.cs
@@ -636,7 +636,7 @@
         [MethodImpl(MethodImplOptions.AggressiveInlining)]
         public static Int32 FromHex(this String s)
         {
-            return Int32.Parse(s, NumberStyles.HexNumber);
+            return Int32.Parse(s, NumberStyles.HexNumber, CultureInfo.InvariantCulture);
         }
 
         /// <summary>
@@ -647,7 +647,7 @@
         [MethodImpl(MethodImplOptions.AggressiveInlining)]
         public static Int32 FromDec(this String s)
         {
-            return Int32.Parse(s, NumberStyles.Integer);
+            return Int32.Parse(s, NumberStyles.Integer, CultureInfo.InvariantCulture);
         }
 
         /// <summary>


### PR DESCRIPTION
Some parsed wrongly used `Parse` without any explicit culture information. Thus, the parsing process may be different on different machines, which is not as desired.

This PR fixes the behavior. The issue was first described in #482.