### PR TITLE
Made resource directory lookup relative to the source file

### DIFF
--- a/src/AngleSharp.Core.Tests/External/PageRequester.cs
+++ b/src/AngleSharp.Core.Tests/External/PageRequester.cs
@@ -17,7 +17,13 @@
 
         private static String GetResourceDirectory( [CallerFilePath] String fileName = null )
         {
-            return Path.Combine(Path.GetDirectoryName(fileName), "..", "Resources");
+            var directoryPath = Path.Combine(Path.GetDirectoryName(fileName), "..", "Resources");
+            if (!Directory.Exists(directoryPath))
+            {
+                Directory.CreateDirectory(directoryPath);
+            }
+
+            return directoryPath;
         }
 
         public override Boolean SupportsProtocol(String protocol)

--- a/src/AngleSharp.Core.Tests/External/PageRequester.cs
+++ b/src/AngleSharp.Core.Tests/External/PageRequester.cs
@@ -7,12 +7,18 @@
     using System.Reflection;
     using System.Threading;
     using System.Threading.Tasks;
+    using System.Runtime.CompilerServices;
 
     sealed class PageRequester : BaseRequester
     {
         private readonly static DefaultHttpRequester _default = new DefaultHttpRequester();
-        private readonly static String _directory = Path.Combine(Path.GetDirectoryName(Assembly.GetExecutingAssembly().Location), "..", "..", "Resources");
+        private readonly static String _directory = GetResourceDirectory();
         private readonly static SiteMapping _mapping = new SiteMapping(Path.Combine(_directory, "content.xml"));
+
+        private static String GetResourceDirectory( [CallerFilePath] String fileName = null )
+        {
+            return Path.Combine(Path.GetDirectoryName(fileName), "..", "Resources");
+        }
 
         public override Boolean SupportsProtocol(String protocol)
         {


### PR DESCRIPTION
Here's what I can suggest to deal with #483. Instead of assuming the dll location, this assumes the source file location, which in my opinion makes more sense: both resource folder and the source file locations are explicitly controlled by the repository, unlike the dll location, which is controlled by the test runner.