### PR TITLE
Improved cookie container handling

### DIFF
--- a/src/AngleSharp.Core.Tests/Library/CookieHandling.cs
+++ b/src/AngleSharp.Core.Tests/Library/CookieHandling.cs
@@ -20,6 +20,17 @@
         }
 
         [Test]
+        public async Task AccessLloydsBankWithMixedPathAndDomainCookiesShouldWork()
+        {
+            if (Helper.IsNetworkAvailable())
+            {
+                var configuration = Configuration.Default.WithDefaultLoader().WithCookies();
+                var context = BrowsingContext.New(configuration);
+                await context.OpenAsync("https://online.lloydsbank.co.uk/personal/logon/login.jsp");
+            }
+        }
+
+        [Test]
         public async Task PlainVersion1CookieIsCorrectlyTransformed()
         {
             var cookie = await LoadDocumentWithCookie("FGTServer=04E2E1A642B2BB49C6FE0115DE3976CB377263F3278BD6C8E2F8A24EE4DF7562F089BFAC5C0102; Version=1");
@@ -147,12 +158,12 @@
                 WithVirtualRequester(req => VirtualResponse.Create(
                     res => res.Address("http://localhost/mockpage.html").
                                Content("<div></div>").
-                               Header(HeaderNames.SetCookie, "Auth=Bar")));
+                               Cookie("Auth=Bar; Path=/")));
             var context = BrowsingContext.New(config);
             var document = await context.OpenAsync(res =>
                 res.Content("<a href=mockpage.html></a>").
                     Address("http://localhost/").
-                    Header(HeaderNames.SetCookie, "UserID=Foo"));
+                    Cookie("UserID=Foo; Path=/"));
 
             document = await document.QuerySelector<IHtmlAnchorElement>("a").NavigateAsync();
 
@@ -171,7 +182,7 @@
             var document = await context.OpenAsync(res =>
                 res.Content("<a href=mockpage.html></a>").
                     Address("http://localhost/").
-                    Header(HeaderNames.SetCookie, "UserID=Foo"));
+                    Cookie("UserID=Foo"));
 
             document = await document.QuerySelector<IHtmlAnchorElement>("a").NavigateAsync();
 
@@ -272,7 +283,7 @@
             var cookieValue = "test=true";
             var requestCount = 0;
             var imgCookie = String.Empty;
-            var initial = VirtualResponse.Create(m => m.Content(content).Address("http://www.local.com").Header(HeaderNames.SetCookie, cookieValue));
+            var initial = VirtualResponse.Create(m => m.Content(content).Address("http://www.local.com").Cookie(cookieValue));
             await LoadDocumentWithFakeRequesterAndCookie(initial, req =>
             {
                 var res = VirtualResponse.Create(m => m.Content(String.Empty).Address(req.Address));
@@ -292,7 +303,7 @@
             var cookieValue = "test=true";
             var requestCount = 0;
             var imgCookie = String.Empty;
-            var initial = VirtualResponse.Create(m => m.Content(content).Address("http://www.local.com").Header(HeaderNames.SetCookie, cookieValue));
+            var initial = VirtualResponse.Create(m => m.Content(content).Address("http://www.local.com").Cookie(cookieValue));
             await LoadDocumentWithFakeRequesterAndCookie(initial, req =>
             {
                 var res = VirtualResponse.Create(m => m.Content(String.Empty).Address(req.Address));
@@ -312,7 +323,7 @@
             var cookieValue = "test=true";
             var requestCount = 0;
             var imgCookie = String.Empty;
-            var initial = VirtualResponse.Create(m => m.Content(content).Address("http://www.local.com").Header(HeaderNames.SetCookie, cookieValue));
+            var initial = VirtualResponse.Create(m => m.Content(content).Address("http://www.local.com").Cookie(cookieValue));
             await LoadDocumentWithFakeRequesterAndCookie(initial, req =>
             {
                 var res = VirtualResponse.Create(m => m.Content(String.Empty).Address(req.Address));

--- a/src/AngleSharp/Io/DefaultHttpRequester.cs
+++ b/src/AngleSharp/Io/DefaultHttpRequester.cs
@@ -207,7 +207,9 @@
             {
                 if (response != null)
                 {
-                    var cookies = _cookies.GetCookies(response.ResponseUri);
+                    var originalCookies = _cookies.GetCookies(_request.Address);
+                    var newCookies = _cookies.GetCookies(response.ResponseUri);
+                    var cookies = newCookies.OfType<Cookie>().Except(originalCookies.OfType<Cookie>()).ToArray();
                     var headers = response.Headers.AllKeys.Select(m => new { Key = m, Value = response.Headers[m] });
                     var result = new DefaultResponse
                     {
@@ -221,9 +223,9 @@
                         result.Headers.Add(header.Key, header.Value);
                     }
 
-                    if (cookies.Count > 0)
+                    if (cookies.Length > 0)
                     {
-                        var strings = cookies.OfType<Cookie>().Select(m => Stringify(m));
+                        var strings = cookies.Select(Stringify);
                         result.Headers[HeaderNames.SetCookie] = String.Join(", ", strings);
                     }
 

--- a/src/AngleSharp/Io/MemoryCookieProvider.cs
+++ b/src/AngleSharp/Io/MemoryCookieProvider.cs
@@ -33,8 +33,7 @@
         /// <returns>The value of the cookie.</returns>
         public String GetCookie(Url url)
         {
-            var uri = new Uri(url.Origin);
-            return _container.GetCookieHeader(uri);
+            return _container.GetCookieHeader(url);
         }
 
         /// <summary>
@@ -44,8 +43,9 @@
         /// <param name="value">The value of the cookie.</param>
         public void SetCookie(Url url, String value)
         {
-            var uri = new Uri(url.Origin);
-            _container.SetCookies(uri, value);
+            var domain = String.Concat("Domain=", url.HostName, ";");
+            var newValue = value.Replace(domain, "");
+            _container.SetCookies(url, newValue);
         }
     }
 }

--- a/src/AngleSharp/Io/VirtualResponse.cs
+++ b/src/AngleSharp/Io/VirtualResponse.cs
@@ -41,7 +41,7 @@
         public static IResponse Create(Action<VirtualResponse> request)
         {
             var vr = new VirtualResponse();
-            request(vr);
+            request.Invoke(vr);
             return vr;
         }
 
@@ -102,6 +102,16 @@
         public VirtualResponse Address(Uri url)
         {
             return Address(Url.Convert(url));
+        }
+
+        /// <summary>
+        /// Sets the value of the cookie associated with the response.
+        /// </summary>
+        /// <param name="value">The cookie's value.</param>
+        /// <returns>The current instance.</returns>
+        public VirtualResponse Cookie(String value)
+        {
+            return Header(HeaderNames.SetCookie, value);
         }
 
         /// <summary>


### PR DESCRIPTION
The improvements here two-fold:

* Use the full url to retrieve / set cookies - such that paths may be considered (the container already handles the access correctly)
* Remove cookies transported in the request from the response (set-cookie is only used on "new" / changed cookies)

Furthermore, another quirk in the cookie container was seen and had to be circumvented. The container throws if the `Domain=x` has been specified, where `x` is the same as the hostname of the given URL.

For more details about the original issue see #477.