### PR TITLE
Fix a few possible null references

### DIFF
--- a/src/AngleSharp/Browser/TaskEventLoop.cs
+++ b/src/AngleSharp/Browser/TaskEventLoop.cs
@@ -125,13 +125,13 @@
 
             public Boolean IsRunning
             {
-                get 
-                { 
+                get
+                {
                     return _task != null &&
-                           _task.Status == TaskStatus.Running || 
-                           _task.Status == TaskStatus.WaitingForActivation || 
+                           (_task.Status == TaskStatus.Running ||
+                           _task.Status == TaskStatus.WaitingForActivation ||
                            _task.Status == TaskStatus.WaitingToRun ||
-                           _task.Status == TaskStatus.WaitingForChildrenToComplete; 
+                           _task.Status == TaskStatus.WaitingForChildrenToComplete);
                 }
             }
 

--- a/src/AngleSharp/BrowsingContextExtensions.cs
+++ b/src/AngleSharp/BrowsingContextExtensions.cs
@@ -347,10 +347,11 @@
             foreach (var service in services)
             {
                 var otherCulture = service.Culture;
-                var otherTwoLetters = otherCulture.TwoLetterISOLanguageName;
 
                 if (otherCulture != null)
                 {
+                    var otherTwoLetters = otherCulture.TwoLetterISOLanguageName;
+
                     if (otherCulture.Equals(culture))
                     {
                         return service;

--- a/src/AngleSharp/Html/Dom/Internal/HtmlElement.cs
+++ b/src/AngleSharp/Html/Dom/Internal/HtmlElement.cs
@@ -583,13 +583,13 @@
             {
                 parent = parent.ParentElement;
             }
-            
+
             if (parent == null)
             {
                 var formid = this.GetOwnAttribute(AttributeNames.Form);
                 var owner = Owner;
 
-                if (owner == null || parent != null || String.IsNullOrEmpty(formid))
+                if (owner == null || String.IsNullOrEmpty(formid))
                 {
                     return null;
                 }

--- a/src/AngleSharp/Html/Dom/Internal/HtmlLinkElement.cs
+++ b/src/AngleSharp/Html/Dom/Internal/HtmlLinkElement.cs
@@ -84,7 +84,7 @@
                     _relList.Changed += value => UpdateAttribute(AttributeNames.Rel, value);
                 }
 
-                return _relList; 
+                return _relList;
             }
         }
 
@@ -98,7 +98,7 @@
                     _sizes.Changed += value => UpdateAttribute(AttributeNames.Sizes, value);
                 }
 
-                return _sizes; 
+                return _sizes;
             }
         }
 
@@ -140,8 +140,8 @@
 
         public IStyleSheet Sheet
         {
-            get 
-            { 
+            get
+            {
                 var sheetRelation = _relation as StyleSheetLinkRelation;
                 return sheetRelation?.Sheet;
             }
@@ -227,7 +227,7 @@
 
             foreach (var relation in relations)
             {
-                var rel = factory.Create(this, relation);
+                var rel = factory?.Create(this, relation);
 
                 if (rel != null)
                 {


### PR DESCRIPTION
I've found these while playing with the static analysis tool [PVS-Studio](http://www.viva64.com/en/b/0457/). It reports a large number of additional issues. Most of them are benevolent or false alarms but some could be fixed, plus there are some where I'm not sure. Here are a few examples:

- `V3072 The 'CreateDocumentOptions' class containing IDisposable members does not itself implement IDisposable. Inspect: _source. CreateDocumentOptions.cs 14` (quite a few of those)
- `V3114 IDisposable object 'ms' is not disposed before method returns. StringExtensions.cs 764` (MemoryStream)
- `V3090 Unsafe locking on 'this' instance in class 'BaseLoader'. BaseLoader.cs 19`
- `V3013 It is odd that the body of 'NegatedAttributeExistenceSelectorWithDeclaredNamespaceA' function is fully equivalent to the body of 'NegatedAttributeExistenceSelectorWithDeclaredNamespaceB' function. CssW3CSelector.cs 2500` (large number of these, at first glance there seems to be some css which was not copied from the test cases at w3.org)

If you want to check it yourself, here's a shell one-liner to add the comment which is required by the free version of PVS-Studio to all *.cs files:

```shell
 find . -not -path "*/obj/*" -name "*.cs" -exec sed -i -e '1s/^\xef\xbb\xbf//' -e '1i// This is an open source non-commercial project. Dear PVS-Studio, please check it.\r\n// PVS-Studio Static Code Analyzer for C, C++ and C#: http://www.viva64.com\r\n' {} \;
```