### PR TITLE
Issue #507

### DIFF
--- a/src/AngleSharp.Core.Tests/Html/HtmlFragment.cs
+++ b/src/AngleSharp.Core.Tests/Html/HtmlFragment.cs
@@ -589,7 +589,7 @@
             Assert.IsNotNull(body);
 
             var output = body.InnerHtml.Replace("" + (char)160, "&nbsp;");
-            Assert.AreEqual(@"<span class="""">Test </span><div class=""""><br></div>", output);
+            Assert.AreEqual(@"<span class="""" style="""">Test </span><div class="""" style=""""><br></div>", output);
         }
 
         [Test]

--- a/src/AngleSharp.Core.Tests/Html/UserJsUnsafe.cs
+++ b/src/AngleSharp.Core.Tests/Html/UserJsUnsafe.cs
@@ -227,8 +227,8 @@ bar]]>").ToHtmlDocument();
 <polyline fill-rule=""evenodd"" fill=""#747474"" points=""8.5,0.6 7.9,0 4.3,3.6 0.6,0 0,0.6 4.3,4.9 "" style=""""/>
 </svg></body></html>").ToHtmlDocument();
             var polyline = doc.QuerySelector("polyline");
-            Assert.IsNull(polyline.GetAttribute("style"));
-            Assert.AreEqual(3, polyline.Attributes.Length);
+            Assert.IsEmpty(polyline.GetAttribute("style"));
+            Assert.AreEqual(4, polyline.Attributes.Length);
         }
 
         [Test]

--- a/src/AngleSharp/Dom/Internal/Element.cs
+++ b/src/AngleSharp/Dom/Internal/Element.cs
@@ -612,14 +612,6 @@
 
         #region Helpers
 
-        protected void UpdateStyle(String value)
-        {
-            if (String.IsNullOrEmpty(value))
-            {
-                _attributes.RemoveNamedItemOrDefault(AttributeNames.Style, suppressMutationObservers: true);
-            }
-        }
-
         protected void UpdateAttribute(String name, String value)
         {
             this.SetOwnAttribute(name, value, suppressCallbacks: true);

--- a/src/AngleSharp/Html/Dom/Internal/HtmlElement.cs
+++ b/src/AngleSharp/Html/Dom/Internal/HtmlElement.cs
@@ -553,18 +553,6 @@
 
         #region Internal Methods
 
-        internal override void SetupElement()
-        {
-            base.SetupElement();
-
-            var style = this.GetOwnAttribute(AttributeNames.Style);
-
-            if (style != null)
-            {
-                UpdateStyle(style);
-            }
-        }
-
         internal void UpdateDropZone(String value)
         {
             _dropZone?.Update(value);

--- a/src/AngleSharp/Svg/Dom/Internal/SvgElement.cs
+++ b/src/AngleSharp/Svg/Dom/Internal/SvgElement.cs
@@ -28,21 +28,5 @@
         }
 
         #endregion
-
-        #region Internal Methods
-
-        internal override void SetupElement()
-        {
-            base.SetupElement();
-
-            var style = this.GetOwnAttribute(AttributeNames.Style);
-
-            if (style != null)
-            {
-                UpdateStyle(style);
-            }
-        }
-
-        #endregion
     }
 }


### PR DESCRIPTION
Special handling of the `style` attribute (remove if empty) was deactivated. This now behaves exactly as current browsers (e.g., Chrome, Firefox, IE, ...) are handling it.