### PR TITLE
Issue #509

### DIFF
--- a/src/AngleSharp.Core.Tests/Library/FormSetFieldValues.cs
+++ b/src/AngleSharp.Core.Tests/Library/FormSetFieldValues.cs
@@ -118,7 +118,7 @@
             }, createMissing: true);
 
             var newField = document.Forms[0]
-                .GetElements<IHtmlInputElement>()
+                .GetNodes<IHtmlInputElement>()
                 .SingleOrDefault(x => x.Name == newFieldName);
 
             Assert.NotNull(newFieldName);

--- a/src/AngleSharp/Dom/Internal/CollectionExtensions.cs
+++ b/src/AngleSharp/Dom/Internal/CollectionExtensions.cs
@@ -22,11 +22,11 @@
         /// </param>
         /// <param name="predicate">The filter function, if any.</param>
         /// <returns>The collection with the corresponding elements.</returns>
-        public static IEnumerable<T> GetElements<T>(this INode parent, Boolean deep = true, Func<T, Boolean> predicate = null)
+        public static IEnumerable<T> GetNodes<T>(this INode parent, Boolean deep = true, Func<T, Boolean> predicate = null)
             where T : class, INode
         {
             predicate = predicate ?? (m => true);
-            return deep ? parent.GetAllElements(predicate) : parent.GetDescendendElements(predicate);
+            return deep ? parent.GetAllNodes(predicate) : parent.GetDescendendElements(predicate);
         }
 
         /// <summary>
@@ -113,19 +113,6 @@
         }
 
         /// <summary>
-        /// Gets the elements that satisfy the provided filter settings.
-        /// </summary>
-        /// <typeparam name="T">The type of nodes to obtain.</typeparam>
-        /// <param name="parent">The parent of the nodes to find.</param>
-        /// <param name="filter">The filter settings to apply.</param>
-        /// <returns>
-        /// The filtered list of all descendents from the provided node.
-        /// </returns>
-        public static IEnumerable<T> GetElements<T>(this INode parent, FilterSettings filter)
-            where T : class, INode
-            => parent.GetElements<T>(predicate: (node => filter.Accepts(node)));
-
-        /// <summary>
         /// Gets the element with the provided id, if any. Otherwise the
         /// element with the same name is searched.
         /// </summary>
@@ -155,7 +142,7 @@
             return null;
         }
 
-        private static IEnumerable<T> GetAllElements<T>(this INode parent, Func<T, Boolean> predicate)
+        private static IEnumerable<T> GetAllNodes<T>(this INode parent, Func<T, Boolean> predicate)
             where T : class, INode
             => new NodeEnumerable(parent).OfType<T>().Where(predicate);
 

--- a/src/AngleSharp/Dom/Internal/HtmlAllCollection.cs
+++ b/src/AngleSharp/Dom/Internal/HtmlAllCollection.cs
@@ -21,7 +21,7 @@
 
         public HtmlAllCollection(IDocument document)
         {
-            _elements = document.GetElements<IElement>();
+            _elements = document.GetNodes<IElement>();
         }
 
         #endregion

--- a/src/AngleSharp/Dom/Internal/HtmlCollection.cs
+++ b/src/AngleSharp/Dom/Internal/HtmlCollection.cs
@@ -28,7 +28,7 @@
 
         public HtmlCollection(INode parent, Boolean deep = true, Func<T, bool> predicate = null)
         {
-            _elements = parent.GetElements(deep, predicate);
+            _elements = parent.GetNodes(deep, predicate);
         }
 
         #endregion

--- a/src/AngleSharp/Dom/Internal/HtmlFormControlsCollection.cs
+++ b/src/AngleSharp/Dom/Internal/HtmlFormControlsCollection.cs
@@ -29,7 +29,7 @@
                 root = form.Owner.DocumentElement;
             }
 
-            _elements = root.GetElements<HtmlFormControlElement>().Where(m =>
+            _elements = root.GetNodes<HtmlFormControlElement>().Where(m =>
             {
                 if (Object.ReferenceEquals(m.Form, form))
                 {

--- a/src/AngleSharp/Dom/Internal/Range.cs
+++ b/src/AngleSharp/Dom/Internal/Range.cs
@@ -42,7 +42,7 @@
 
         public IEnumerable<INode> Nodes
         {
-            get { return CommonAncestor.GetElements<INode>(predicate: Intersects); }
+            get { return CommonAncestor.GetNodes<INode>(predicate: Intersects); }
         }
 
         public INode Head
@@ -311,10 +311,10 @@
                     }
 
                     var firstPartiallyContainedChild = !originalStart.Node.IsInclusiveAncestorOf(originalEnd.Node) ?
-                        commonAncestor.GetElements<INode>(predicate: IsPartiallyContained).FirstOrDefault() : null;
+                        commonAncestor.GetNodes<INode>(predicate: IsPartiallyContained).FirstOrDefault() : null;
                     var lastPartiallyContainedchild = !originalEnd.Node.IsInclusiveAncestorOf(originalStart.Node) ?
-                        commonAncestor.GetElements<INode>(predicate: IsPartiallyContained).LastOrDefault() : null;
-                    var containedChildren = commonAncestor.GetElements<INode>(predicate: Intersects).ToList();
+                        commonAncestor.GetNodes<INode>(predicate: IsPartiallyContained).LastOrDefault() : null;
+                    var containedChildren = commonAncestor.GetNodes<INode>(predicate: Intersects).ToList();
 
                     if (containedChildren.OfType<IDocumentType>().Any())
                         throw new DomException(DomError.HierarchyRequest);
@@ -409,10 +409,10 @@
                     }
 
                     var firstPartiallyContainedChild = !originalStart.Node.IsInclusiveAncestorOf(originalEnd.Node) ?
-                        commonAncestor.GetElements<INode>(predicate: IsPartiallyContained).FirstOrDefault() : null;
+                        commonAncestor.GetNodes<INode>(predicate: IsPartiallyContained).FirstOrDefault() : null;
                     var lastPartiallyContainedchild = !originalEnd.Node.IsInclusiveAncestorOf(originalStart.Node) ?
-                        commonAncestor.GetElements<INode>(predicate: IsPartiallyContained).LastOrDefault() : null;
-                    var containedChildren = commonAncestor.GetElements<INode>(predicate: Intersects).ToList();
+                        commonAncestor.GetNodes<INode>(predicate: IsPartiallyContained).LastOrDefault() : null;
+                    var containedChildren = commonAncestor.GetNodes<INode>(predicate: Intersects).ToList();
 
                     if (containedChildren.OfType<IDocumentType>().Any())
                         throw new DomException(DomError.HierarchyRequest);

--- a/src/AngleSharp/Html/Dom/Internal/HtmlFormElement.cs
+++ b/src/AngleSharp/Html/Dom/Internal/HtmlFormElement.cs
@@ -415,7 +415,7 @@
         private FormDataSet ConstructDataSet(IHtmlElement submitter)
         {
             var formDataSet = new FormDataSet();
-            var fields = this.GetElements<HtmlFormControlElement>();
+            var fields = this.GetNodes<HtmlFormControlElement>();
 
             foreach (var field in fields)
             {


### PR DESCRIPTION
Improved the implementation of the `NodeIterator`. Besides the problem(s) mentioned in #509 we also had an issue that the root node was not present (if not filtered) in the first `Next()` call.

The root node is now part of the enumerable, even though it may be excluded due to filtering.