### PR TITLE
Issue #519

### DIFF
--- a/src/AngleSharp.Core.Tests/Library/CookieHandling.cs
+++ b/src/AngleSharp.Core.Tests/Library/CookieHandling.cs
@@ -336,6 +336,20 @@
             Assert.AreEqual(cookieValue, imgCookie);
         }
 
+        [Test]
+        public async Task DefaultHttpRequesterWorksWithVersion1Cookies()
+        {
+            var config = Configuration.Default.WithDefaultLoader().WithCookies();
+            var context = BrowsingContext.New(config);
+            var cookieValue = "FGTServer=04E2E1A642B2BB49C6FE0115DE3976CB377263F3278BD6C8E2F8A24EE4DF7562F089BFAC5C0102; Version=1";
+
+            var document = await context.OpenAsync(res => res.Content("<div></div>")
+                                        .Address("http://localhost/")
+                                        .Header(HeaderNames.SetCookie, cookieValue));
+
+            await context.OpenAsync("http://localhost/");
+        }
+
         private static Task<IDocument> LoadDocumentWithFakeRequesterAndCookie(IResponse initialResponse, Func<Request, IResponse> onRequest)
         {
             var requester = new MockRequester();

--- a/src/AngleSharp/Io/DefaultHttpRequester.cs
+++ b/src/AngleSharp/Io/DefaultHttpRequester.cs
@@ -300,7 +300,7 @@
             private void SetCookies()
             {
                 var cookieHeader = _request.Headers.GetOrDefault(HeaderNames.Cookie, String.Empty);
-                _cookies.SetCookies(_http.RequestUri, cookieHeader.Replace(';', ','));
+                _cookies.SetCookies(_http.RequestUri, cookieHeader.Replace(';', ',').Replace("$", ""));
             }
 
             private void SetHeaders()


### PR DESCRIPTION
Workaround / intermediate fix. I think in the long run the .NET Cookie Container needs to be replaced. This one has far too many quirks and disadvantages.