### PR TITLE
This fixes #539

### DIFF
--- a/src/AngleSharp.Core.Tests/Library/CookieHandling.cs
+++ b/src/AngleSharp.Core.Tests/Library/CookieHandling.cs
@@ -117,7 +117,7 @@
 
             document = await document.QuerySelector<IHtmlAnchorElement>("a").NavigateAsync();
 
-            Assert.AreEqual("UserID=Foo; Auth=Bar", document.Cookie);
+            Assert.AreEqual("Auth=Bar; UserID=Foo", document.Cookie);
         }
 
         [Test]

--- a/src/AngleSharp/Dom/Document.cs
+++ b/src/AngleSharp/Dom/Document.cs
@@ -757,8 +757,8 @@
 
         public String Cookie
         {
-            get { return Options.GetCookie(_location.Origin); }
-            set { Options.SetCookie(_location.Origin, value); }
+            get { return Options.GetCookie(_location.Href); }
+            set { Options.SetCookie(_location.Href, value); }
         }
 
         public String Domain

--- a/src/AngleSharp/Network/Default/BaseLoader.cs
+++ b/src/AngleSharp/Network/Default/BaseLoader.cs
@@ -86,7 +86,7 @@
         /// <returns>The associated cookie string, if any.</returns>
         protected virtual String GetCookie(Url url)
         {
-            return _context.Configuration.GetCookie(url.Origin);
+            return _context.Configuration.GetCookie(url.Href);
         }
 
         /// <summary>
@@ -96,7 +96,7 @@
         /// <param name="value">The value of the cookie.</param>
         protected virtual void SetCookie(Url url, String value)
         {
-            _context.Configuration.SetCookie(url.Origin, value);
+            _context.Configuration.SetCookie(url.Href, value);
         }
 
         /// <summary>
@@ -153,7 +153,6 @@
                 if (response != null)
                 {
                     redirectCount++;
-                    ExtractCookieFrom(response);
                     request = CreateNewRequest(request, response);
                     AppendCookieTo(request);
                 }
@@ -168,6 +167,7 @@
                         break;
                     }
                 }
+                ExtractCookieFrom(response);
             }
             while (response != null && response.StatusCode.IsRedirected() && redirectCount < MaxRedirects);
 


### PR DESCRIPTION
1. We should provide full path to `ICookieProvider `  to handle cookie's properly.
2. We should check for cookie after every response.
3. `HttpWebRequest`  Cookie header should be set manually. We can't use `CookieContainer `  for cookie header extracted from `ICookieProvider`. Because passing cookie like 'sessionid=abc1; sessionid=abc2' again to   `CookieContainer `  makes invalid cookie.
