### PR TITLE
Issue #546

### DIFF
--- a/src/AngleSharp.Core.Tests/Library/CookieHandling.cs
+++ b/src/AngleSharp.Core.Tests/Library/CookieHandling.cs
@@ -213,7 +213,7 @@
                 var context = BrowsingContext.New(config);
                 var document = await context.OpenAsync(url);
 
-                Assert.AreEqual("k2=v2; k1=v1", document.Cookie);
+                Assert.AreEqual("k1=v1; k2=v2", document.Cookie);
             }
         }
 
@@ -227,7 +227,7 @@
                 var context = BrowsingContext.New(config);
                 var document = await context.OpenAsync(url);
 
-                Assert.AreEqual("test=baz; k2=v2; k1=v1; foo=bar", document.Cookie);
+                Assert.AreEqual("k1=v1; k2=v2; test=baz; foo=bar", document.Cookie);
             }
         }
 

--- a/src/AngleSharp.Core.Tests/Library/CookieHandling.cs
+++ b/src/AngleSharp.Core.Tests/Library/CookieHandling.cs
@@ -7,6 +7,7 @@
     using AngleSharp.Io;
     using NUnit.Framework;
     using System;
+    using System.Linq;
     using System.Threading.Tasks;
 
     [TestFixture]
@@ -212,8 +213,9 @@
                 var config = Configuration.Default.WithCookies().WithDefaultLoader();
                 var context = BrowsingContext.New(config);
                 var document = await context.OpenAsync(url);
+                var cookies = document.Cookie.Split(';').Select(m => m.Trim());
 
-                Assert.AreEqual("k1=v1; k2=v2", document.Cookie);
+                CollectionAssert.AreEquivalent(new[] { "k1=v1", "k2=v2" }, cookies);
             }
         }
 
@@ -226,8 +228,9 @@
                 var config = Configuration.Default.WithCookies().WithDefaultLoader();
                 var context = BrowsingContext.New(config);
                 var document = await context.OpenAsync(url);
+                var cookies = document.Cookie.Split(';').Select(m => m.Trim());
 
-                Assert.AreEqual("k1=v1; k2=v2; test=baz; foo=bar", document.Cookie);
+                CollectionAssert.AreEquivalent(new[] { "k1=v1", "k2=v2", "foo=bar", "test=baz" }, cookies);
             }
         }
 
@@ -268,9 +271,7 @@
                 var document = await context.OpenAsync(redirectUrl);
 
                 Assert.AreEqual(@"{
-  ""cookies"": {
-    ""test"": ""baz""
-  }
+  ""cookies"": {}
 }
 ".Replace(Environment.NewLine, "\n"), document.Body.TextContent);
             }

--- a/src/AngleSharp.Core.Tests/Library/OptimizationPool.cs
+++ b/src/AngleSharp.Core.Tests/Library/OptimizationPool.cs
@@ -3,10 +3,34 @@
     using AngleSharp.Text;
     using NUnit.Framework;
     using System;
+    using System.Collections.Generic;
+    using System.Reflection;
+    using System.Text;
 
     [TestFixture]
     public class OptimizationPoolTests
     {
+        private Int32 _defaultCount;
+        private Int32 _defaultLimit;
+
+        [SetUp]
+        public void InitStringBuilders()
+        {
+            _defaultCount = StringBuilderPool.MaxCount;
+            _defaultLimit = StringBuilderPool.SizeLimit;
+        }
+
+        [TearDown]
+        public void ClearStringBuilders()
+        {
+            var builderField = typeof(StringBuilderPool).GetField("_builder", BindingFlags.Static | BindingFlags.NonPublic);
+            var builder = builderField.GetValue(null) as Stack<StringBuilder>;
+            builder.Clear();
+
+            StringBuilderPool.MaxCount = _defaultCount;
+            StringBuilderPool.SizeLimit = _defaultLimit;
+        }
+
         [Test]
         public void RecycleStringBuilderReused()
         {
@@ -48,6 +72,133 @@
             Assert.AreNotEqual(sb1, sb3);
             Assert.AreEqual(String.Empty, sb3.ToPool());
             sb2.ToPool();
+        }
+
+        [Test]
+        public void DiscardLargeStringBuilderInstances()
+        {
+            var newLimit = _defaultLimit / 2;
+            var sbO = StringBuilderPool.Obtain();
+            var defaultCapacity = sbO.Capacity;
+            sbO.Capacity = newLimit;
+            sbO.ToPool();
+            var sbR = StringBuilderPool.Obtain();
+            Assert.AreEqual(newLimit, sbR.Capacity);
+            sbR.Capacity = _defaultLimit * 2;
+            sbR.ToPool();
+            var sbF = StringBuilderPool.Obtain();
+            Assert.AreEqual(defaultCapacity, sbF.Capacity);
+        }
+
+        [Test]
+        public void StringBuilderPoolMaxInstancesIsRespected()
+        {
+            StringBuilderPool.MaxCount = 2;
+            var sb1 = StringBuilderPool.Obtain();
+            var sb2 = StringBuilderPool.Obtain();
+            var sb3 = StringBuilderPool.Obtain();
+            sb1.ToPool();
+            sb2.ToPool();
+            sb3.ToPool();
+            Assert.AreEqual(sb2, StringBuilderPool.Obtain());
+            Assert.AreEqual(sb1, StringBuilderPool.Obtain());
+            Assert.AreNotEqual(sb3, StringBuilderPool.Obtain());
+        }
+
+        [Test]
+        public void StringBuilderDropsOneWithLeastCapacity()
+        {
+            StringBuilderPool.MaxCount = 4;
+            var sb1 = StringBuilderPool.Obtain();
+            var sb2 = StringBuilderPool.Obtain();
+            var sb3 = StringBuilderPool.Obtain();
+            var sb4 = StringBuilderPool.Obtain();
+            var sb5 = StringBuilderPool.Obtain();
+            sb1.Capacity = 1024;
+            sb1.ToPool();
+            sb2.Capacity = 512;
+            sb2.ToPool();
+            sb3.Capacity = 2048;
+            sb3.ToPool();
+            sb4.Capacity = 8192;
+            sb4.ToPool();
+            sb5.Capacity = 16384;
+            sb5.ToPool();
+            Assert.AreEqual(16384, StringBuilderPool.Obtain().Capacity);
+            Assert.AreEqual(8192, StringBuilderPool.Obtain().Capacity);
+            Assert.AreEqual(2048, StringBuilderPool.Obtain().Capacity);
+            Assert.AreEqual(1024, StringBuilderPool.Obtain().Capacity);
+        }
+
+        [Test]
+        public void StringBuilderDoesNotAddSmallerInstances()
+        {
+            StringBuilderPool.MaxCount = 4;
+            var sb1 = StringBuilderPool.Obtain();
+            var sb2 = StringBuilderPool.Obtain();
+            var sb3 = StringBuilderPool.Obtain();
+            var sb4 = StringBuilderPool.Obtain();
+            sb1.Capacity = 1024;
+            sb1.ToPool();
+            sb2.Capacity = 2048;
+            sb2.ToPool();
+            sb3.Capacity = 8192;
+            sb3.ToPool();
+            sb4.Capacity = 4096;
+            sb4.ToPool();
+            Assert.AreEqual(8192, StringBuilderPool.Obtain().Capacity);
+            Assert.AreEqual(2048, StringBuilderPool.Obtain().Capacity);
+            Assert.AreEqual(1024, StringBuilderPool.Obtain().Capacity);
+        }
+
+        [Test]
+        public void StringBuilderPreservesOrderWhenRebuilding()
+        {
+            StringBuilderPool.MaxCount = 4;
+            var sb0 = StringBuilderPool.Obtain();
+            var sb1 = StringBuilderPool.Obtain();
+            var sb2 = StringBuilderPool.Obtain();
+            var sb3 = StringBuilderPool.Obtain();
+            var sb4 = StringBuilderPool.Obtain();
+            sb0.Capacity = 512;
+            sb0.ToPool();
+            sb1.Capacity = 1024;
+            sb1.ToPool();
+            sb2.Capacity = 2048;
+            sb2.ToPool();
+            sb3.Capacity = 4096;
+            sb3.ToPool();
+            sb4.Capacity = 8192;
+            sb4.ToPool();
+            Assert.AreEqual(8192, StringBuilderPool.Obtain().Capacity);
+            Assert.AreEqual(4096, StringBuilderPool.Obtain().Capacity);
+            Assert.AreEqual(2048, StringBuilderPool.Obtain().Capacity);
+            Assert.AreEqual(1024, StringBuilderPool.Obtain().Capacity);
+        }
+
+        [Test]
+        public void StringBuilderDoesNotRebuildIfLeastOneIsAdded()
+        {
+            StringBuilderPool.MaxCount = 4;
+            var sb1 = StringBuilderPool.Obtain();
+            var sb2 = StringBuilderPool.Obtain();
+            var sb3 = StringBuilderPool.Obtain();
+            var sb4 = StringBuilderPool.Obtain();
+            var sb5 = StringBuilderPool.Obtain();
+            sb1.Capacity = 1024;
+            sb1.ToPool();
+            sb2.Capacity = 2048;
+            sb2.ToPool();
+            sb3.Capacity = 4096;
+            sb3.ToPool();
+            sb4.Capacity = 8192;
+            sb4.ToPool();
+            sb5.Capacity = 512;
+            sb5.ToPool();
+            Assert.AreEqual(8192, StringBuilderPool.Obtain().Capacity);
+            Assert.AreEqual(4096, StringBuilderPool.Obtain().Capacity);
+            Assert.AreEqual(2048, StringBuilderPool.Obtain().Capacity);
+            Assert.AreEqual(1024, StringBuilderPool.Obtain().Capacity);
         }
     }
 }

--- a/src/AngleSharp/Html/HtmlMarkupFormatter.cs
+++ b/src/AngleSharp/Html/HtmlMarkupFormatter.cs
@@ -122,7 +122,7 @@
 
         /// <summary>
         /// Escapes the given text by replacing special characters with their
-        /// html entity.
+        /// HTML entity (amp, nobsp, lt, and gt).
         /// </summary>
         /// <param name="content">The string to alter.</param>
         /// <returns>The altered string.</returns>

--- a/src/AngleSharp/Html/HtmlMarkupFormatter.cs
+++ b/src/AngleSharp/Html/HtmlMarkupFormatter.cs
@@ -120,6 +120,12 @@
 
         #region Helpers
 
+        /// <summary>
+        /// Escapes the given text by replacing special characters with their
+        /// html entity.
+        /// </summary>
+        /// <param name="content">The string to alter.</param>
+        /// <returns>The altered string.</returns>
         public static String EscapeText(String content)
         {
             var temp = StringBuilderPool.Obtain();

--- a/src/AngleSharp/Text/StringBuilderPool.cs
+++ b/src/AngleSharp/Text/StringBuilderPool.cs
@@ -11,6 +11,26 @@
     {
         private static readonly Stack<StringBuilder> _builder = new Stack<StringBuilder>();
         private static readonly Object _lock = new Object();
+        private static Int32 _count = 4;
+        private static Int32 _limit = 85000;
+
+        /// <summary>
+        /// Gets or sets the maximum number of instances - at least 1.
+        /// </summary>
+        public static Int32 MaxCount
+        {
+            get { return _count; }
+            set { _count = Math.Max(1, value); }
+        }
+
+        /// <summary>
+        /// Gets or sets the max. capacity per instance - at least 85000.
+        /// </summary>
+        public static Int32 SizeLimit
+        {
+            get { return _limit; }
+            set { _limit = Math.Max(1024, value); }
+        }
 
         /// <summary>
         /// Either creates a fresh stringbuilder or gets a (cleaned) used one.
@@ -41,10 +61,71 @@
 
             lock (_lock)
             {
-                _builder.Push(sb);
+                var current = _builder.Count;
+
+                if (sb.Capacity > _limit)
+                {
+                    // Drop large instances
+                }
+                else if (current == _count)
+                {
+                    DropMinimum(sb);
+                }
+                else if (current < Math.Min(2, _count) || _builder.Peek().Capacity < sb.Capacity)
+                {
+                    _builder.Push(sb);
+                }
             }
 
             return result;
+        }
+
+        private static void DropMinimum(StringBuilder sb)
+        {
+            var minimum = sb.Capacity;
+            var instances = _builder.ToArray();
+            var index = FindIndex(instances, minimum);
+
+            if (index > -1)
+            {
+                RebuildPool(sb, instances, index);
+            }
+        }
+
+        private static void RebuildPool(StringBuilder sb, StringBuilder[] instances, Int32 index)
+        {
+            _builder.Clear();
+            var i = instances.Length - 1;
+
+            while (i > index)
+            {
+                _builder.Push(instances[i--]);
+            }
+
+            while (i > 0)
+            {
+                _builder.Push(instances[--i]);
+            }
+
+            _builder.Push(sb);
+        }
+
+        private static Int32 FindIndex(StringBuilder[] instances, Int32 minimum)
+        {
+            var index = -1;
+
+            for (var i = 0; i < instances.Length; i++)
+            {
+                var capacity = instances[i].Capacity;
+
+                if (capacity < minimum)
+                {
+                    minimum = capacity;
+                    index = i;
+                }
+            }
+
+            return index;
         }
     }
 }

--- a/src/AngleSharp/Xhtml/XhtmlMarkupFormatter.cs
+++ b/src/AngleSharp/Xhtml/XhtmlMarkupFormatter.cs
@@ -132,6 +132,12 @@
 
         #region Helpers
 
+        /// <summary>
+        /// Escapes the given text by replacing special characters with their
+        /// XHTML entity (amp, nbsp as numeric value, lt, and gt).
+        /// </summary>
+        /// <param name="content">The string to alter.</param>
+        /// <returns>The altered string.</returns>
         public static String EscapeText(String content)
         {
             var temp = StringBuilderPool.Obtain();

--- a/src/AngleSharp/Xml/XmlMarkupFormatter.cs
+++ b/src/AngleSharp/Xml/XmlMarkupFormatter.cs
@@ -108,6 +108,12 @@
 
         #region Helpers
 
+        /// <summary>
+        /// Escapes the given text by replacing special characters with their
+        /// XML entity (only applies to ampersands and opening angle brackets).
+        /// </summary>
+        /// <param name="content">The string to alter.</param>
+        /// <returns>The altered string.</returns>
         public static String EscapeText(String content)
         {
             var temp = StringBuilderPool.Obtain();


### PR DESCRIPTION
Added more tests to check the novel requirements for the `StringBuilderPool`.

In contrast to #546 the limit has been set to 85k as this is also the LOH limit. That way, such massive string builders are discarded, which should keep the memory clean (LOH fragmentation is still an issue - even though we can now include the LOH for compactification).