### PR TITLE
Issue #550

### DIFF
--- a/src/AngleSharp.Core.Tests/Css/QueryExtensions.cs
+++ b/src/AngleSharp.Core.Tests/Css/QueryExtensions.cs
@@ -14,6 +14,36 @@
         }
 
         [Test]
+        public void QueryOnEmptyNodeListShouldYieldEmptyResult()
+        {
+            var document = GetTestDocument();
+            var result = document.Head.QuerySelectorAll("a");
+            Assert.AreEqual(0, result.Length);
+        }
+
+        [Test]
+        public void InvalidQueryOnEmptyNodeListShouldThrowException()
+        {
+            var document = GetTestDocument();
+            Assert.Catch<DomException>(() => document.Head.QuerySelectorAll("<invalid>"));
+        }
+
+        [Test]
+        public void QueryOnNonEmptyNodeListShouldYieldEmptyResult()
+        {
+            var document = GetTestDocument();
+            var result = document.Body.QuerySelectorAll("a");
+            Assert.AreEqual(0, result.Length);
+        }
+
+        [Test]
+        public void InvalidQueryOnNonEmptyNodeListShouldThrowException()
+        {
+            var document = GetTestDocument();
+            Assert.Catch<DomException>(() => document.Body.QuerySelectorAll("<invalid>"));
+        }
+
+        [Test]
         public void QueryEqValidIndexShouldYieldEntry()
         {
             var document = GetTestDocument();

--- a/src/AngleSharp.Core.Tests/Library/ContextLoading.cs
+++ b/src/AngleSharp.Core.Tests/Library/ContextLoading.cs
@@ -1,4 +1,4 @@
-﻿namespace AngleSharp.Core.Tests.Library
+namespace AngleSharp.Core.Tests.Library
 {
     using AngleSharp.Core.Tests.Mocks;
     using AngleSharp.Dom;
@@ -421,7 +421,7 @@
         {
             if (Helper.IsNetworkAvailable())
             {
-                var uri = "http://imama.shop.by/kolyaski/detskaya_kolyaska_tutis_zippy_2_v_1_cvet_12_shokoladnyy223222222/";
+                var uri = "http://florian-rappl.de";
                 var config = Configuration.Default.WithDefaultLoader(s => s.IsResourceLoadingEnabled = true);
 
                 var req = new HttpClient();

--- a/src/AngleSharp.Core.Tests/Library/CookieHandling.cs
+++ b/src/AngleSharp.Core.Tests/Library/CookieHandling.cs
@@ -1,4 +1,4 @@
-﻿namespace AngleSharp.Core.Tests.Library
+namespace AngleSharp.Core.Tests.Library
 {
     using AngleSharp.Common;
     using AngleSharp.Core.Tests.Mocks;
@@ -271,7 +271,9 @@
                 var document = await context.OpenAsync(redirectUrl);
 
                 Assert.AreEqual(@"{
-  ""cookies"": {}
+  ""cookies"": {
+    ""test"": ""baz""
+  }
 }
 ".Replace(Environment.NewLine, "\n"), document.Body.TextContent);
             }

--- a/src/AngleSharp/Dom/QueryExtensions.cs
+++ b/src/AngleSharp/Dom/QueryExtensions.cs
@@ -24,8 +24,8 @@
         /// <returns>An element object.</returns>
         public static IElement QuerySelector(this INodeList nodes, String selectorText, INode scopeNode = null)
         {
-            var sg = CreateSelector(nodes, selectorText);
             var scope = GetScope(scopeNode);
+            var sg = CreateSelector(nodes, scope, selectorText);
             return sg.MatchAny(nodes.OfType<IElement>(), scope);
         }
 
@@ -39,8 +39,8 @@
         /// <returns>A HTMLCollection with all elements that match the selection.</returns>
         public static IHtmlCollection<IElement> QuerySelectorAll(this INodeList nodes, String selectorText, INode scopeNode = null)
         {
-            var sg = CreateSelector(nodes, selectorText);
             var scope = GetScope(scopeNode);
+            var sg = CreateSelector(nodes, scope, selectorText);
             return sg.MatchAll(nodes.OfType<IElement>(), scope);
         }
 
@@ -208,16 +208,15 @@
                 (scopeNode as IShadowRoot)?.Host;
         }
 
-        private static ISelector CreateSelector(INodeList nodes, String selectorText)
+        private static ISelector CreateSelector(INodeList nodes, INode scope, String selectorText)
         {
-            var sg = default(ISelector);
+            var node = nodes.Length > 0 ? nodes[0] : scope;
 
-            if (nodes.Length > 0)
-            {
-                var node = nodes[0];
-                var parser = node.Owner.Context.GetService<ICssSelectorParser>();
-                sg = parser.ParseSelector(selectorText);
-            }
+            if (node == null)
+                throw new InvalidOperationException("A scope is required to parse the query");
+
+            var parser = node.Owner.Context.GetService<ICssSelectorParser>();
+            var sg = parser.ParseSelector(selectorText);
 
             if (sg == null)
                 throw new DomException(DomError.Syntax);

--- a/src/AngleSharp/Dom/QueryExtensions.cs
+++ b/src/AngleSharp/Dom/QueryExtensions.cs
@@ -17,6 +17,7 @@
         /// <summary>
         /// Returns the first element within the document (using depth-first pre-order traversal
         /// of the document's nodes) that matches the specified group of selectors.
+        /// Requires either a non-empty nodelist or a valid scope node.
         /// </summary>
         /// <param name="nodes">The nodes to take as source.</param>
         /// <param name="selectorText">A string containing one or more CSS selectors separated by commas.</param>
@@ -32,6 +33,7 @@
         /// <summary>
         /// Returns a list of the elements within the document (using depth-first pre-order traversal
         /// of the document's nodes) that match the specified group of selectors.
+        /// Requires either a non-empty nodelist or a valid scope node.
         /// </summary>
         /// <param name="nodes">The nodes to take as source.</param>
         /// <param name="selectorText">A string containing one or more CSS selectors separated by commas.</param>

--- a/src/AngleSharp/Dom/QueryExtensions.cs
+++ b/src/AngleSharp/Dom/QueryExtensions.cs
@@ -1,4 +1,4 @@
-﻿namespace AngleSharp.Dom
+namespace AngleSharp.Dom
 {
     using AngleSharp.Css.Dom;
     using AngleSharp.Css.Parser;
@@ -27,7 +27,13 @@
         {
             var scope = GetScope(scopeNode);
             var sg = CreateSelector(nodes, scope, selectorText);
-            return sg.MatchAny(nodes.OfType<IElement>(), scope);
+
+            if (sg != null)
+            {
+                return sg.MatchAny(nodes.OfType<IElement>(), scope);
+            }
+
+            return null;
         }
 
         /// <summary>
@@ -43,7 +49,13 @@
         {
             var scope = GetScope(scopeNode);
             var sg = CreateSelector(nodes, scope, selectorText);
-            return sg.MatchAll(nodes.OfType<IElement>(), scope);
+
+            if (sg != null)
+            {
+                return sg.MatchAll(nodes.OfType<IElement>(), scope);
+            }
+
+            return new HtmlCollection<IElement>(Enumerable.Empty<IElement>());
         }
 
         /// <summary>
@@ -213,15 +225,16 @@
         private static ISelector CreateSelector(INodeList nodes, INode scope, String selectorText)
         {
             var node = nodes.Length > 0 ? nodes[0] : scope;
+            var sg = default(ISelector);
 
-            if (node == null)
-                throw new InvalidOperationException("A scope is required to parse the query");
+            if (node != null)
+            {
+                var parser = node.Owner.Context.GetService<ICssSelectorParser>();
+                sg = parser.ParseSelector(selectorText);
 
-            var parser = node.Owner.Context.GetService<ICssSelectorParser>();
-            var sg = parser.ParseSelector(selectorText);
-
-            if (sg == null)
-                throw new DomException(DomError.Syntax);
+                if (sg == null)
+                    throw new DomException(DomError.Syntax);
+            }
 
             return sg;
         }


### PR DESCRIPTION
* Use `scopeNode` as fallback (solves issues with nodes that have no children)
* Throw invalid operation exception if the `NodeList` is empty when no scope has been provided (thus unable to evaluate the syntax)

The latter only applies outside of the "usual" DOM, i.e., in scenarios when we have, e.g., a bare list of nodes that needs to be filtered.

Potentially, it would be better (as this one is outside of the DOM) to just return the empty list (e.g., by returning the `*` selector). However, the issue is, that this way invites inconsistent behavior: We could write code that works until we have a non-empty list. Then a syntax error would be detected. This is quite fishy. 

On the other side we now force users (potentially without knowing) to provide only non-empty lists (or a scope - which is by default `null`, i..e, not demanded).

Maybe there is a third option that stays consistent, is convenient to write, and still allows to avoid passing in non-empty lists or a scope.