### PR TITLE
Don't process <img> elements when Source = null or empty

### DIFF
--- a/src/AngleSharp/Dom/Html/HtmlImageElement.cs
+++ b/src/AngleSharp/Dom/Html/HtmlImageElement.cs
@@ -133,7 +133,8 @@
         private void UpdateSource()
         {
             var url = this.GetImageCandidate();
-            this.Process(_request, url);
+            if (url != null)
+                this.Process(_request, url);
         }
 
         #endregion

--- a/src/AngleSharp/Extensions/ElementExtensions.cs
+++ b/src/AngleSharp/Extensions/ElementExtensions.cs
@@ -834,7 +834,7 @@
                 return new Url(img.BaseUrl, candidate);
             }
 
-            return Url.Create(img.Source);
+            return string.IsNullOrEmpty(img.Source) ? null : Url.Create(img.Source);
         }
 
         /// <summary>

--- a/src/AngleSharp/Html/LinkRels/BaseLinkRelation.cs
+++ b/src/AngleSharp/Html/LinkRels/BaseLinkRelation.cs
@@ -40,7 +40,12 @@
 
         public Url Url
         {
-            get { return new Url(_link.Href); }
+            get
+            {
+                if (string.IsNullOrEmpty(_link.Href))
+                    return null;
+                return new Url(_link.Href);
+            }
         }
 
         #endregion

--- a/src/AngleSharp/Html/LinkRels/ImportLinkRelation.cs
+++ b/src/AngleSharp/Html/LinkRels/ImportLinkRelation.cs
@@ -60,11 +60,11 @@
             var item = new ImportEntry 
             { 
                 Relation = this,
-                IsCycle = CheckCycle(document, location)
+                IsCycle = location != null && CheckCycle(document, location)
             };
             list.Add(item);
             
-            if (!item.IsCycle)
+            if (location != null && !item.IsCycle)
             {
                 var request = link.CreateRequestFor(location);
                 _isasync = link.HasAttribute(AttributeNames.Async);
@@ -113,7 +113,8 @@
             {
                 for (var i = 0; i < _list.Count; i++)
                 {
-                    if (_list[i].Relation.Url.Equals(location))
+                    Url relationUrl = _list[i].Relation.Url;
+                    if (relationUrl != null && relationUrl.Equals(location))
                     {
                         return true;
                     }

--- a/src/AngleSharp/Html/LinkRels/StyleSheetLinkRelation.cs
+++ b/src/AngleSharp/Html/LinkRels/StyleSheetLinkRelation.cs
@@ -34,6 +34,9 @@
 
         public override Task LoadAsync()
         {
+            if (Url == null)
+                return Task.FromResult(0);
+
             var request = Link.CreateRequestFor(Url);
             return Processor?.ProcessAsync(request);
         }


### PR DESCRIPTION
I was investigating a problem where `ICookieProvider.GetCookie` was called with `origin = null` which didn't seem right. 

Looking into why this happened I discovered that there was a bug where an `img` element with no `src` attribute was getting processed anyway. It only had some classes and a few custom attributes that would later lazy-load the image from the originating page. 

You can see it's a simple fix.

`build.ps1` failed for me but I ran the tests in VS. 5 tests failed but seems to be unrelated to this fix because they fail even if I revert.