### PR TITLE
memory fix

### DIFF
--- a/src/AngleSharp/Parser/Css/CssParser.cs
+++ b/src/AngleSharp/Parser/Css/CssParser.cs
@@ -155,6 +155,9 @@
                 creator.Apply(token);
                 token = tokenizer.Get();
             }
+            
+            // tokenizer should be disposed
+            tokenizer.Dispose();
 
             var valid = creator.IsValid;
             var result = creator.ToPool();


### PR DESCRIPTION
Hello,

Several weeks ago I do some benchmark testing on anglesharp and I found the memory usage was unusual. So I inspected that and found a little fix is improving the memory usage %25.
 
```
BenchmarkDotNet=v0.10.8, OS=Windows 10 Redstone 2 (10.0.15063)
Processor=AMD FX(tm)-6300 Six-Core Processor, ProcessorCount=6
Frequency=3429533 Hz, Resolution=291.5849 ns, Timer=TSC
dotnet cli version=1.0.1
  [Host]   : .NET Core 4.6.25009.03, 64bit RyuJITDEBUG
  ShortRun : .NET Core 4.6.25009.03, 64bit RyuJIT

Job=ShortRun  LaunchCount=1  TargetCount=3  
WarmupCount=3  

     Method |     Mean |    Error |   StdDev |       Gen 0 |   Gen 1 | Allocated |
----------- |---------:|---------:|---------:|------------:|--------:|----------:|
 AngleSharp | 738.7 ms | 69.29 ms | 3.915 ms | 996687.5000 | 62.5000 |   1.62 GB |

After fix

     Method |     Mean |    Error |   StdDev |       Gen 0 |   Gen 1 | Allocated |
----------- |---------:|---------:|---------:|------------:|--------:|----------:|
 AngleSharp | 715.0 ms | 42.50 ms | 2.401 ms | 757562.5000 | 62.5000 |   1.23 GB |
```
And the benchmark code
```
    [ShortRunJob, MemoryDiagnoser]
    public class AngleSharpTest
    {
        [Benchmark]
        public void AngleSharp()
        {
            var html = File.ReadAllText("empty.html");
            var parser = new HtmlParser();

            var document = parser.Parse(html);

            for (int i = 0; i < 100_000; i++)
            {
                var p = document.QuerySelector("p");
            }

            document.Dispose();
        }
    }

```

So it is not full fix but atleast improving the current situation, all textsource classes must be tracked and disposed for the full fix I think.


