### PR TITLE
implement innerText

### DIFF
--- a/src/AngleSharp.Core.Tests/Html/InnerText.cs
+++ b/src/AngleSharp.Core.Tests/Html/InnerText.cs
@@ -14,6 +14,9 @@ namespace AngleSharp.Core.Tests.Html
         [TestCase("&nbsp;&nbsp;", "  ")] // these are non breaking spaces
         [TestCase(" &nbsp; test &nbsp; ", "  test  ")]
         [TestCase(" 1&nbsp;2 <span> 3&nbsp;4  5&nbsp;6 </span> 7&nbsp;8 ", "1 2 3 4 5 6 7 8")]
+        [TestCase("<span> test 1 </span><span> test 2 </span><span> test 3 </span>", "test 1 test 2 test 3")]
+        [TestCase("<span> test 1 <span></span></span>", "test 1")]
+        [TestCase("test1 <br> test2 <br> test3", "test1\ntest2\ntest3")]
         // paragraph
         [TestCase("<p>test</p>", "test")]
         [TestCase("<p>test1</p><p>test2</p>", "test1\n\ntest2")]

--- a/src/AngleSharp.Core.Tests/Html/InnerText.cs
+++ b/src/AngleSharp.Core.Tests/Html/InnerText.cs
@@ -20,6 +20,7 @@ namespace AngleSharp.Core.Tests.Html
         [TestCase("test1<br>test2<br>test3", "test1\ntest2\ntest3")]
         // table
         [TestCase("<table><tr><td>1</td><td>2</td></tr><tr><td>3</td><td>4</td></tr></table>", "1\t2\n3\t4")]
+        [TestCase("<table><tr><td>1</td><td>2</td></tr><tr><td><table><tr><td>3</td><td>4</td></tr></table></td><td>5</td></tr></table>", "1\t2\n\n3\t4\n\t5")]
         // style visibility
         [TestCase(@"<div hidden style=""display:block"">test1<br>test2<div>test3</div></div>", "test1\ntest2\ntest3")]
         [TestCase(@"<div hidden style=""visibility:visible"">test1<br>test2<div>test3</div></div>", "test1\ntest2\ntest3")]
@@ -32,8 +33,10 @@ namespace AngleSharp.Core.Tests.Html
         [TestCase(@"<span style=""text-transform:lowercase"">TEST</span>", "test")]
         [TestCase("<span style=\"text-transform:capitalize\">test1 test2\ntest3</span>", "Test1 Test2\nTest3")]
         [TestCase(@"<div style=""text-transform:lowercase"">TEST1<span>TEST2</span></div>", "test1test2")]
-        // input elements
+        // no css box
         [TestCase("<textarea>test</textarea>", "")]
+        [TestCase("<script>test</noscript>", "")]
+        [TestCase("<style>test</style>", "")]
         public void GetInnerText(String fixture, String expected)
         {
             var config = Configuration.Default.WithCss();
@@ -46,7 +49,7 @@ namespace AngleSharp.Core.Tests.Html
         [TestCase("", "")]
         [TestCase("test", "test")]
         [TestCase("test1\ntest2\ntest3", "test1<br>test2<br>test3")]
-        [TestCase("te\rst1\r\ntest2\ntest3", "test1<br>test2<br>test3")]
+        [TestCase("te\rst1\r\ntest2\ntest3\r", "te<br>st1<br>test2<br>test3<br>")]
         [TestCase("te st1\nte  st2\nte   st3", "te st1<br>te  st2<br>te   st3")]
         public void SetInnerText(String fixture, String expectedHtml)
         {
@@ -54,7 +57,7 @@ namespace AngleSharp.Core.Tests.Html
 
             doc.Body.InnerText = fixture;
 
-            Assert.AreEqual((fixture ?? "").Replace("\r", ""), doc.Body.InnerText);
+            Assert.AreEqual((fixture ?? "").Replace("\r\n", "\n").Replace("\r", "\n").Trim(), doc.Body.InnerText);
             Assert.AreEqual(expectedHtml, doc.Body.InnerHtml);
         }
 

--- a/src/AngleSharp.Core.Tests/Html/InnerText.cs
+++ b/src/AngleSharp.Core.Tests/Html/InnerText.cs
@@ -20,6 +20,8 @@ namespace AngleSharp.Core.Tests.Html
         // table
         [TestCase("<table><tr><td>1</td><td>2</td></tr><tr><td>3</td><td>4</td></tr></table>", "1\t2\n3\t4")]
         [TestCase("<table><tr><td>1</td><td>2</td></tr><tr><td><table><tr><td>3</td><td>4</td></tr></table></td><td>5</td></tr></table>", "1\t2\n\n3\t4\n\t5")]
+        // select
+        [TestCase("<select><option>test1</option><option>test2</option></select>", "test1\ntest2")]
         // style visibility
         [TestCase(@"<div hidden style=""display:block"">test1<br>test2<div>test3</div></div>", "test1\ntest2\ntest3")]
         [TestCase(@"<div hidden style=""visibility:visible"">test1<br>test2<div>test3</div></div>", "test1\ntest2\ntest3")]

--- a/src/AngleSharp.Core.Tests/Html/InnerText.cs
+++ b/src/AngleSharp.Core.Tests/Html/InnerText.cs
@@ -9,7 +9,6 @@ namespace AngleSharp.Core.Tests.Html
 
         // text
         [TestCase("test", "test")]
-        [TestCase("te  s\nt", "te  s\nt")]
         // paragraph
         [TestCase("<p>test</p>", "test")]
         [TestCase("<p>test1</p><p>test2</p>", "test1\n\ntest2")]
@@ -31,8 +30,16 @@ namespace AngleSharp.Core.Tests.Html
         // style text-transform
         [TestCase(@"<span style=""text-transform:uppercase"">test</span>", "TEST")]
         [TestCase(@"<span style=""text-transform:lowercase"">TEST</span>", "test")]
-        [TestCase("<span style=\"text-transform:capitalize\">test1 test2\ntest3</span>", "Test1 Test2\nTest3")]
+        [TestCase("<span style=\"text-transform:capitalize\">test1 test2\ntest3</span>", "Test1 Test2 Test3")]
         [TestCase(@"<div style=""text-transform:lowercase"">TEST1<span>TEST2</span></div>", "test1test2")]
+        [TestCase(@"<div style=""text-transform:lowercase"">TEST1<span style=""text-transform:uppercase"">test2</span></div>", "test1TEST2")]
+        // style white-space
+        [TestCase("t e  s\tt1\ntest2", "t e s t1 test2")]
+        [TestCase("<span style=\"white-space:normal\">t e  s\tt1\ntest2</span>", "t e s t1 test2")]
+        [TestCase("<span style=\"white-space:nowrap\">t e  s\tt1\ntest2</span>", "t e s t1 test2")]
+        [TestCase("<span style=\"white-space:pre-line\">t e  s\tt1\ntest2</span>", "t e s t1\ntest2")]
+        [TestCase("<span style=\"white-space:pre\">t e  s\tt1\ntest2</span>", "t e  s\tt1\ntest2")]
+        [TestCase("<span style=\"white-space:pre-wrap\">t e  s\tt1\ntest2</span>", "t e  s\tt1\ntest2")]
         // no css box
         [TestCase("<textarea>test</textarea>", "")]
         [TestCase("<script>test</noscript>", "")]
@@ -45,19 +52,19 @@ namespace AngleSharp.Core.Tests.Html
             Assert.AreEqual(expected, doc.Body.InnerText);
         }
 
-        [TestCase(null, "")]
-        [TestCase("", "")]
-        [TestCase("test", "test")]
-        [TestCase("test1\ntest2\ntest3", "test1<br>test2<br>test3")]
-        [TestCase("te\rst1\r\ntest2\ntest3\r", "te<br>st1<br>test2<br>test3<br>")]
-        [TestCase("te st1\nte  st2\nte   st3", "te st1<br>te  st2<br>te   st3")]
-        public void SetInnerText(String fixture, String expectedHtml)
+        [TestCase(null, "", "")]
+        [TestCase("", "", "")]
+        [TestCase("test", "test", "test")]
+        [TestCase("test1\ntest2\ntest3", "test1\ntest2\ntest3", "test1<br>test2<br>test3")]
+        [TestCase("te\rst1\r\ntest2\ntest3\r", "te\nst1\ntest2\ntest3", "te<br>st1<br>test2<br>test3<br>")]
+        [TestCase("te st1\nte  st2\nte   st3", "te st1\nte st2\nte st3", "te st1<br>te  st2<br>te   st3")]
+        public void SetInnerText(String fixture, String expectedInnerText, String expectedHtml)
         {
             var doc = ("<div>sample content</div>").ToHtmlDocument();
 
             doc.Body.InnerText = fixture;
 
-            Assert.AreEqual((fixture ?? "").Replace("\r\n", "\n").Replace("\r", "\n").Trim(), doc.Body.InnerText);
+            Assert.AreEqual(expectedInnerText, doc.Body.InnerText);
             Assert.AreEqual(expectedHtml, doc.Body.InnerHtml);
         }
 

--- a/src/AngleSharp.Core.Tests/Html/InnerText.cs
+++ b/src/AngleSharp.Core.Tests/Html/InnerText.cs
@@ -7,8 +7,13 @@ namespace AngleSharp.Core.Tests.Html
     public class InnerText
     {
 
-        // text
+        // text & spaces
         [TestCase("test", "test")]
+        [TestCase("  test  ", "test")]
+        [TestCase("  ", "")]
+        [TestCase("&nbsp;&nbsp;", "  ")] // these are non breaking spaces
+        [TestCase(" &nbsp; test &nbsp; ", "  test  ")]
+        [TestCase(" 1&nbsp;2 <span> 3&nbsp;4  5&nbsp;6 </span> 7&nbsp;8 ", "1 2 3 4 5 6 7 8")]
         // paragraph
         [TestCase("<p>test</p>", "test")]
         [TestCase("<p>test1</p><p>test2</p>", "test1\n\ntest2")]
@@ -58,7 +63,7 @@ namespace AngleSharp.Core.Tests.Html
         [TestCase("", "", "")]
         [TestCase("test", "test", "test")]
         [TestCase("test1\ntest2\ntest3", "test1\ntest2\ntest3", "test1<br>test2<br>test3")]
-        [TestCase("te\rst1\r\ntest2\ntest3\r", "te\nst1\ntest2\ntest3", "te<br>st1<br>test2<br>test3<br>")]
+        [TestCase("te\rst1\r\ntest2\ntest3\r", "te\nst1\ntest2\ntest3\n", "te<br>st1<br>test2<br>test3<br>")]
         [TestCase("te st1\nte  st2\nte   st3", "te st1\nte st2\nte st3", "te st1<br>te  st2<br>te   st3")]
         public void SetInnerText(String fixture, String expectedInnerText, String expectedHtml)
         {

--- a/src/AngleSharp.Core.Tests/Html/InnerText.cs
+++ b/src/AngleSharp.Core.Tests/Html/InnerText.cs
@@ -1,0 +1,62 @@
+namespace AngleSharp.Core.Tests.Html
+{
+    using NUnit.Framework;
+    using System;
+
+    [TestFixture]
+    public class InnerText
+    {
+
+        // text
+        [TestCase("test", "test")]
+        [TestCase("te  s\nt", "te  s\nt")]
+        // paragraph
+        [TestCase("<p>test</p>", "test")]
+        [TestCase("<p>test1</p><p>test2</p>", "test1\n\ntest2")]
+        // block-level
+        [TestCase("<div>test1</div><div>test2</div><div>test3</div>", "test1\ntest2\ntest3")]
+        [TestCase(@"test1<span style=""display:block"">test2</span>test3", "test1\ntest2\ntest3")]
+        // line break
+        [TestCase("test1<br>test2<br>test3", "test1\ntest2\ntest3")]
+        // table
+        [TestCase("<table><tr><td>1</td><td>2</td></tr><tr><td>3</td><td>4</td></tr></table>", "1\t2\n3\t4")]
+        // style visibility
+        [TestCase(@"<div hidden style=""display:block"">test1<br>test2<div>test3</div></div>", "test1\ntest2\ntest3")]
+        [TestCase(@"<div hidden style=""visibility:visible"">test1<br>test2<div>test3</div></div>", "test1\ntest2\ntest3")]
+        [TestCase("<div hidden>test1<br>test2<div>test3</div></div>", "")]
+        [TestCase(@"<div style=""display:none"">test1<br>test2<div>test3</div></div>", "")]
+        [TestCase(@"<div hidden style=""display:block;visibility:hidden;"">test1<br>test2<div>test3</div></div>", "")]
+        [TestCase(@"<div hidden style=""display:none;visibility:visible;"">test1<br>test2<div>test3</div></div>", "")]
+        // style text-transform
+        [TestCase(@"<span style=""text-transform:uppercase"">test</span>", "TEST")]
+        [TestCase(@"<span style=""text-transform:lowercase"">TEST</span>", "test")]
+        [TestCase("<span style=\"text-transform:capitalize\">test1 test2\ntest3</span>", "Test1 Test2\nTest3")]
+        [TestCase(@"<div style=""text-transform:lowercase"">TEST1<span>TEST2</span></div>", "test1test2")]
+        // input elements
+        [TestCase("<textarea>test</textarea>", "")]
+        public void GetInnerText(String fixture, String expected)
+        {
+            var config = Configuration.Default.WithCss();
+            var doc = (fixture).ToHtmlDocument(config);
+
+            Assert.AreEqual(expected, doc.Body.InnerText);
+        }
+
+        [TestCase(null, "")]
+        [TestCase("", "")]
+        [TestCase("test", "test")]
+        [TestCase("test1\ntest2\ntest3", "test1<br>test2<br>test3")]
+        [TestCase("te\rst1\r\ntest2\ntest3", "test1<br>test2<br>test3")]
+        [TestCase("te st1\nte  st2\nte   st3", "te st1<br>te  st2<br>te   st3")]
+        public void SetInnerText(String fixture, String expectedHtml)
+        {
+            var doc = ("<div>sample content</div>").ToHtmlDocument();
+
+            doc.Body.InnerText = fixture;
+
+            Assert.AreEqual((fixture ?? "").Replace("\r", ""), doc.Body.InnerText);
+            Assert.AreEqual(expectedHtml, doc.Body.InnerHtml);
+        }
+
+    }
+}

--- a/src/AngleSharp/Dom/Html/HtmlElement.cs
+++ b/src/AngleSharp/Dom/Html/HtmlElement.cs
@@ -721,9 +721,7 @@ namespace AngleSharp.Dom.Html
                 case "IMG":
                 case "INPUT":
                 case "METER":
-                case "OPTGROUP":
                 case "PROGRESS":
-                case "SELECT":
                 case "TEMPLATE":
                 case "TEXTAREA":
                 case "VIDEO":

--- a/src/AngleSharp/Dom/Html/HtmlElement.cs
+++ b/src/AngleSharp/Dom/Html/HtmlElement.cs
@@ -536,7 +536,7 @@ namespace AngleSharp.Dom.Html
                 }
 
                 var sb = Pool.NewStringBuilder();
-                var requiredLineBreakCounts = new SortedDictionary<Int32, Int32>();
+                var requiredLineBreakCounts = new Dictionary<Int32, Int32>();
 
                 InnerTextCollection(this, sb, requiredLineBreakCounts, ParentElement?.ComputeCurrentStyle());
 
@@ -594,7 +594,7 @@ namespace AngleSharp.Dom.Html
             }
         }
 
-        private static void InnerTextCollection(INode node, StringBuilder sb, SortedDictionary<Int32, Int32> requiredLineBreakCounts, ICssStyleDeclaration parentStyle)
+        private static void InnerTextCollection(INode node, StringBuilder sb, Dictionary<Int32, Int32> requiredLineBreakCounts, ICssStyleDeclaration parentStyle)
         {
             if (node is IHtmlTextAreaElement || node is IHtmlInputElement || node is IHtmlVideoElement)
             {
@@ -633,8 +633,9 @@ namespace AngleSharp.Dom.Html
 
             var endIndex = sb.Length;
 
-            if (node is IText textElement)
+            if (node is IText)
             {
+                var textElement = (IText)node;
                 switch (parentStyle?.TextTransform)
                 {
                     case "uppercase":
@@ -689,13 +690,14 @@ namespace AngleSharp.Dom.Html
             }
             else if (node is IHtmlParagraphElement)
             {
-                requiredLineBreakCounts.TryGetValue(startIndex, out var startIndexCount);
+                var startIndexCount = 0;
+                requiredLineBreakCounts.TryGetValue(startIndex, out startIndexCount);
                 if (startIndexCount < 2)
                 {
                     requiredLineBreakCounts[startIndex] = 2;
                 }
-
-                requiredLineBreakCounts.TryGetValue(endIndex, out var endIndexCount);
+                var endIndexCount = 0;
+                requiredLineBreakCounts.TryGetValue(endIndex, out endIndexCount);
                 if (endIndexCount < 2)
                 {
                     requiredLineBreakCounts[endIndex] = 2;
@@ -703,6 +705,7 @@ namespace AngleSharp.Dom.Html
             }
 
             bool? isBlockLevel = null;
+            // https://www.w3.org/TR/css-display-3/#display-value-summary
             switch (elementCss?.Display)
             {
                 case "block":
@@ -763,13 +766,14 @@ namespace AngleSharp.Dom.Html
             }
             if (isBlockLevel.Value)
             {
-                requiredLineBreakCounts.TryGetValue(startIndex, out var startIndexCount);
+                var startIndexCount = 0;
+                requiredLineBreakCounts.TryGetValue(startIndex, out startIndexCount);
                 if (startIndexCount < 1)
                 {
                     requiredLineBreakCounts[startIndex] = 1;
                 }
-
-                requiredLineBreakCounts.TryGetValue(endIndex, out var endIndexCount);
+                var endIndexCount = 0;
+                requiredLineBreakCounts.TryGetValue(endIndex, out endIndexCount);
                 if (endIndexCount < 1)
                 {
                     requiredLineBreakCounts[endIndex] = 1;

--- a/src/AngleSharp/Dom/Html/HtmlElement.cs
+++ b/src/AngleSharp/Dom/Html/HtmlElement.cs
@@ -786,6 +786,7 @@ namespace AngleSharp.Dom.Html
                 case "NAV":
                 case "NOSCRIPT":
                 case "OL":
+                case "OPTION": 
                 case "OUTPUT":
                 case "P":
                 case "PRE":
@@ -802,14 +803,8 @@ namespace AngleSharp.Dom.Html
 
         private static void ProcessText(String text, StringBuilder sb, ICssStyleDeclaration style)
         {
-            if (style == null)
-            {
-                sb.Append(text);
-                return;
-            }
-
-            var whiteSpace = style.WhiteSpace;
-            var textTransform = style.TextTransform;
+            var whiteSpace = style?.WhiteSpace;
+            var textTransform = style?.TextTransform;
 
             var isWhiteSpace = true;
             for (var i = 0; i < text.Length; i++)

--- a/src/AngleSharp/Extensions/StyleExtensions.cs
+++ b/src/AngleSharp/Extensions/StyleExtensions.cs
@@ -1,9 +1,8 @@
-﻿namespace AngleSharp.Extensions
+namespace AngleSharp.Extensions
 {
     using AngleSharp.Dom;
     using AngleSharp.Dom.Collections;
     using AngleSharp.Dom.Css;
-    using AngleSharp.Dom.Html;
     using System;
     using System.Collections.Generic;
     using System.Linq;
@@ -32,13 +31,6 @@
             }
 
             computedStyle.SetDeclarations(rules.ComputeCascadedStyle(element).Declarations);
-            var htmlElement = element as IHtmlElement;
-
-            if (htmlElement != null)
-            {
-                var declarations = htmlElement.Style.OfType<CssProperty>();
-                computedStyle.SetDeclarations(declarations);
-            }
 
             var nodes = element.GetAncestors().OfType<IElement>();
 

--- a/src/AngleSharp/Extensions/WindowExtensions.cs
+++ b/src/AngleSharp/Extensions/WindowExtensions.cs
@@ -1,9 +1,10 @@
-﻿namespace AngleSharp.Extensions
+namespace AngleSharp.Extensions
 {
     using AngleSharp.Css;
     using AngleSharp.Dom;
     using AngleSharp.Dom.Collections;
     using AngleSharp.Dom.Css;
+    using AngleSharp.Dom.Html;
     using System;
     using System.Collections.Generic;
     using System.Linq;
@@ -58,6 +59,12 @@
             {
                 var inlineStyle = rule.Style;
                 computedStyle.SetDeclarations(inlineStyle.Declarations);
+            }
+
+            if (element is IHtmlElement htmlElement && htmlElement.Style != null)
+            {
+                var declarations = htmlElement.Style.OfType<CssProperty>();
+                computedStyle.SetDeclarations(declarations);
             }
 
             return computedStyle;

--- a/src/AngleSharp/Extensions/WindowExtensions.cs
+++ b/src/AngleSharp/Extensions/WindowExtensions.cs
@@ -61,10 +61,14 @@ namespace AngleSharp.Extensions
                 computedStyle.SetDeclarations(inlineStyle.Declarations);
             }
 
-            if (element is IHtmlElement htmlElement && htmlElement.Style != null)
+            if (element is IHtmlElement)
             {
-                var declarations = htmlElement.Style.OfType<CssProperty>();
-                computedStyle.SetDeclarations(declarations);
+                var htmlElement = (IHtmlElement)element;
+                if (htmlElement.Style != null)
+                {
+                    var declarations = htmlElement.Style.OfType<CssProperty>();
+                    computedStyle.SetDeclarations(declarations);
+                }
             }
 
             return computedStyle;

--- a/src/AngleSharp/Interfaces/Html/IHtmlElement.cs
+++ b/src/AngleSharp/Interfaces/Html/IHtmlElement.cs
@@ -1,4 +1,4 @@
-﻿namespace AngleSharp.Dom.Html
+namespace AngleSharp.Dom.Html
 {
     using AngleSharp.Attributes;
     using AngleSharp.Dom.Events;
@@ -103,6 +103,12 @@
         [DomName("dropzone")]
         [DomPutForwards("value")]
         ISettableTokenList DropZone { get; }
+
+        /// <summary>
+        /// Gets or sets the innerText of the element.
+        /// </summary>
+        [DomName("innerText")]
+        String InnerText { get; set; }
 
         /// <summary>
         /// Simulates a mouse click on an element.


### PR DESCRIPTION
[`innerText`](https://html.spec.whatwg.org/multipage/dom.html#the-innertext-idl-attribute) is part of the [HTML5.2 spec](https://www.w3.org/TR/html52/changes.html#changes) (See https://github.com/AngleSharp/AngleSharp/issues/618)
See [here](https://html.spec.whatwg.org/multipage/dom.html#the-innertext-idl-attribute) for the documentation of the implementation.

~~There are still tests missing for some CSS cases.~~