### PR TITLE
improve InnerHtml performance

### DIFF
--- a/src/AngleSharp/Dom/DocumentFragment.cs
+++ b/src/AngleSharp/Dom/DocumentFragment.cs
@@ -1,4 +1,4 @@
-﻿namespace AngleSharp.Dom
+namespace AngleSharp.Dom
 {
     using AngleSharp.Dom.Collections;
     using AngleSharp.Dom.Html;
@@ -44,7 +44,11 @@
             {
                 var child = root.FirstChild;
                 root.RemoveChild(child);
-                this.PreInsert(child, null);
+                if (child is Node)
+                {
+                    Owner.AdoptNode(child);
+                    InsertBefore((Node)child, null, false);
+                }
             }
         }
 


### PR DESCRIPTION
In big HTML documents (> 1 MB) setting `InnerHtml` is very slow because of this:

https://github.com/AngleSharp/AngleSharp/blob/4e24a74548633017b9d49457a80d916c676012fa/src/AngleSharp/Extensions/NodeExtensions.cs#L362-L370

This checks all HTML nodes of the original document, [because the `Owner` of the `DocumentFragment` is the same as the original document](https://github.com/AngleSharp/AngleSharp/blob/4e24a74548633017b9d49457a80d916c676012fa/src/AngleSharp/Dom/DocumentFragment.cs#L30), if a template elements content is the same as the newly created `DocumentFragment` which is always `false` in this case.

To avoid this check we can just use `InserBefore` instead.
