### PR TITLE
Add Element DOM method "Closest"

### DIFF
--- a/src/AngleSharp.Core.Tests/Library/DOMActions.cs
+++ b/src/AngleSharp.Core.Tests/Library/DOMActions.cs
@@ -1310,5 +1310,17 @@
             Assert.AreEqual("http://example.com/foo.htm", a.Href);
             Assert.AreEqual("/foo.htm", a.GetAttribute("href"));
         }
+
+        [Test]
+        public void GetClosestAncestor()
+        {
+            var document = Create(@"<div id=""div1""><div id=""div2""><table><tr><td id=""exampletd""><div id=""div3""></div></td></tr><tr></tr></table></div></div>");
+            var cell = document.QuerySelector("#exampletd") as IHtmlTableCellElement;
+
+            Assert.IsNotNull(cell);
+            Assert.AreEqual(cell.Closest("td"), cell);
+            Assert.AreEqual(cell.Closest("a"), null);
+            Assert.AreEqual(cell.Closest("div"), document.QuerySelector("#div2"));
+        }
     }
 }

--- a/src/AngleSharp/Dom/IElement.cs
+++ b/src/AngleSharp/Dom/IElement.cs
@@ -211,6 +211,16 @@
         Boolean Matches(String selectors);
 
         /// <summary>
+        /// Returns the closest ancestor of the current element (or the current element itself) which matches the selectors given in the parameter.
+        /// </summary>
+        /// <param name="selectors">Represents the selector to test.</param>
+        /// <returns>
+        /// The closest ancestor of the current element (or the current element itself) which matches the selectors given. If there isn't such an ancestor, it returns null.
+        /// </returns>
+        [DomName("closest")]
+        IElement Closest(String selectors);
+
+        /// <summary>
         /// Gets or sets the inner HTML (excluding the current element) of the
         /// element.
         /// </summary>

--- a/src/AngleSharp/Dom/Internal/Element.cs
+++ b/src/AngleSharp/Dom/Internal/Element.cs
@@ -1,4 +1,4 @@
-﻿namespace AngleSharp.Dom
+namespace AngleSharp.Dom
 {
     using AngleSharp.Css.Parser;
     using AngleSharp.Dom.Events;
@@ -368,6 +368,29 @@
                 throw new DomException(DomError.Syntax);
 
             return sg.Match(this, this);
+        }
+
+        public IElement Closest(String selectorText)
+        {
+            var parser = Context.GetService<ICssSelectorParser>();
+            var sg = parser.ParseSelector(selectorText);
+
+            if (sg == null)
+                throw new DomException(DomError.Syntax);
+
+            IElement node = this;
+            while (node != null)
+            {
+                if (sg.Match(node, node))
+                {
+                    return node;
+                }
+                else
+                {
+                    node = node.ParentElement;
+                }
+            }
+            return null;
         }
 
         public Boolean HasAttribute(String name)


### PR DESCRIPTION
Hi,

I saw from the project readme that the vision for the project is to have all main JavaScript DOM methods available from C#, and in my uses I found that the standardized [`Element.closest` method](https://developer.mozilla.org/en-US/docs/Web/API/Element/closest) was currently unimplemented in AngleSharp.

I implemented this method for my own use, and would like to share it upstream, in the hope that it will get this useful project a little closer to your vision. :)