### PR TITLE
Added to HtmlEntityService.IsInvalidNumber method check for 0x0.

### DIFF
--- a/src/AngleSharp.Core.Tests/AngleSharp.Core.Tests.csproj
+++ b/src/AngleSharp.Core.Tests/AngleSharp.Core.Tests.csproj
@@ -107,6 +107,7 @@
     <Compile Include="Html\Doctype.cs" />
     <Compile Include="Html\DomManipulation.cs" />
     <Compile Include="Html\HtmlConstruction.cs" />
+    <Compile Include="Html\HtmlEntityServiceTests.cs" />
     <Compile Include="Html\MainElement.cs" />
     <Compile Include="Html\Namespace.cs" />
     <Compile Include="Html\NoScript.cs" />

--- a/src/AngleSharp.Core.Tests/Html/HtmlEntityServiceTests.cs
+++ b/src/AngleSharp.Core.Tests/Html/HtmlEntityServiceTests.cs
@@ -21,8 +21,6 @@ namespace AngleSharp.Core.Tests.Html
         [TestCase(0x110000, Description = "First value outside the range of unicode")]
         [TestCase(0x110001, Description = "Second value outside the range of unicode")]
         [TestCase(0x13579A, Description = "Some big positive value which outside the range of unicode")]
-        [TestCase(0x7FFF, Description = "Int16.MaxValue")]
-        [TestCase(0x8000, Description = "(Int16.MaxValue + 1) which overflow Int16, but doesn't overflow Int32")]
         [TestCase(0x7FFFFFFF, Description = "Int32.MaxValue")]
         public void IsInvalidNumber_WithPositiveInvalidCode_ShouldReturnTrue(Int32 code)
         {
@@ -31,7 +29,7 @@ namespace AngleSharp.Core.Tests.Html
 
         [TestCase(0xD800, Description = "First surrogate code")]
         [TestCase(0xD801, Description = "Second surrogate code")]
-        [TestCase(0xDCA86, Description = "Some internal surrogate code")]
+        [TestCase(0xDCA8, Description = "Some internal surrogate code")]
         [TestCase(0xDFFE, Description = "Penultimate surrogate code")]
         [TestCase(0xDFFF, Description = "Last surrogate code")]
         public void IsInvalidNumber_WithSurrogateCode_ShouldReturnTrue(Int32 code)
@@ -42,6 +40,8 @@ namespace AngleSharp.Core.Tests.Html
         [TestCase(0, Description = "Zero")]
         [TestCase(1, Description = "One")]
         [TestCase(0x6, Description = "Some small code before surrogate zone")]
+        [TestCase(0x7FFF, Description = "Int16.MaxValue")]
+        [TestCase(0x8000, Description = "(Int16.MaxValue + 1) which overflow Int16, but doesn't overflow Int32")]
         [TestCase(0xA987, Description = "Some big code before surrogate zone")]
         [TestCase(0xD799, Description = "Last code before surrogate zone")]
         [TestCase(0xE000, Description = "First code after surrogate zone")]

--- a/src/AngleSharp.Core.Tests/Html/HtmlEntityServiceTests.cs
+++ b/src/AngleSharp.Core.Tests/Html/HtmlEntityServiceTests.cs
@@ -1,0 +1,56 @@
+namespace AngleSharp.Core.Tests.Html
+{
+    using NUnit.Framework;
+    using System;
+    using AngleSharp.Html;
+
+    [TestFixture]
+    public class HtmlEntityServiceTests
+    {
+        [TestCase(-0x80000000, Description = "Int32.MinValue")]
+        [TestCase(-0x8001, Description = "(Int16.MinValue - 1) which overflow Int16, but doesn't overflow Int32")]
+        [TestCase(-0x8000, Description = "Int16.MinValue")]
+        [TestCase(-0x4321, Description = "Some big negative value")]
+        [TestCase(-0x5, Description = "Some small negative value")]
+        [TestCase(-0x1, Description = "Minus one")]
+        public void IsInvalidNumber_WithNegativeCode_ShouldReturnTrue(Int32 code)
+        {
+            Assert.IsTrue(HtmlEntityService.IsInvalidNumber(code));
+        }
+
+        [TestCase(0x110000, Description = "First value outside the range of unicode")]
+        [TestCase(0x110001, Description = "Second value outside the range of unicode")]
+        [TestCase(0x13579A, Description = "Some big positive value which outside the range of unicode")]
+        [TestCase(0x7FFF, Description = "Int16.MaxValue")]
+        [TestCase(0x8000, Description = "(Int16.MaxValue + 1) which overflow Int16, but doesn't overflow Int32")]
+        [TestCase(0x7FFFFFFF, Description = "Int32.MaxValue")]
+        public void IsInvalidNumber_WithPositiveInvalidCode_ShouldReturnTrue(Int32 code)
+        {
+            Assert.IsTrue(HtmlEntityService.IsInvalidNumber(code));
+        }
+
+        [TestCase(0xD800, Description = "First surrogate code")]
+        [TestCase(0xD801, Description = "Second surrogate code")]
+        [TestCase(0xDCA86, Description = "Some internal surrogate code")]
+        [TestCase(0xDFFE, Description = "Penultimate surrogate code")]
+        [TestCase(0xDFFF, Description = "Last surrogate code")]
+        public void IsInvalidNumber_WithSurrogateCode_ShouldReturnTrue(Int32 code)
+        {
+            Assert.IsTrue(HtmlEntityService.IsInvalidNumber(code));
+        }
+
+        [TestCase(0, Description = "Zero")]
+        [TestCase(1, Description = "One")]
+        [TestCase(0x6, Description = "Some small code before surrogate zone")]
+        [TestCase(0xA987, Description = "Some big code before surrogate zone")]
+        [TestCase(0xD799, Description = "Last code before surrogate zone")]
+        [TestCase(0xE000, Description = "First code after surrogate zone")]
+        [TestCase(0xEDCBA, Description = "Some code after surrogate zone which inside the range of unicode")]
+        [TestCase(0x10FFFE, Description = "Penultimate code inside the range of unicode")]
+        [TestCase(0x10FFFF, Description = "Last code inside the range of unicode")]
+        public void IsInvalidNumber_WithValidAndNotSurrogateCode_ShouldReturnFalse(Int32 code)
+        {
+            Assert.IsFalse(HtmlEntityService.IsInvalidNumber(code));
+        }
+    }
+}

--- a/src/AngleSharp/Html/HtmlEntityService.cs
+++ b/src/AngleSharp/Html/HtmlEntityService.cs
@@ -2605,9 +2605,11 @@
         public static Boolean IsInvalidNumber(Int32 code)
         {
             /*
-             * Otherwise, if the number is in the range 0xD800 to 0xDFFF or is
-             * greater than 0x10FFFF, then this is a parse error. Return a U+FFFD
-             * REPLACEMENT CHARACTER.
+             * Otherwise, if the number is
+             *     in the range 0xD800 to 0xDFFF (surrogate Unicode zone)
+             *     or less than 0x0 or is greater than 0x10FFFF,
+             * then this is a parse error.
+             * Return a U+FFFD REPLACEMENT CHARACTER.
              */
 
             return (code >= 0xD800 && code <= 0xDFFF) || (code < 0x0) || (code > 0x10FFFF);

--- a/src/AngleSharp/Html/HtmlEntityService.cs
+++ b/src/AngleSharp/Html/HtmlEntityService.cs
@@ -2610,7 +2610,7 @@
              * REPLACEMENT CHARACTER.
              */
 
-            return (code >= 0xD800 && code <= 0xDFFF) || (code > 0x10FFFF);
+            return (code >= 0xD800 && code <= 0xDFFF) || (code < 0x0) || (code > 0x10FFFF);
         }
 
         /// <summary>


### PR DESCRIPTION
This case will shoot when parsing hex code that is bigger than `Int32,MaxValue` from html page.
For examle `<p> This is shoot you down: &#80000000; </p>`.

Actually I would be so happy if you accept this as fast as you can. I need this code and I don't want to use my fork at project. Also I will start an issue describing base bug with overflow.

Also I did`t found any tests on this static class, so I just left as is.