### PR TITLE
Fix NullReferenceException when parsing a link tag with incomplete href

### DIFF
--- a/src/AngleSharp/Io/Processors/StyleSheetRequestProcessor.cs
+++ b/src/AngleSharp/Io/Processors/StyleSheetRequestProcessor.cs
@@ -60,7 +60,7 @@ namespace AngleSharp.Io.Processors
                 return FinishDownloadAsync();
             }
 
-            return null;
+            return Task.CompletedTask;
         }
 
         protected override async Task ProcessResponseAsync(IResponse response)


### PR DESCRIPTION
## Types of Changes

### Prerequisites

Please make sure you can check the following two boxes:

- [x] I have read the **CONTRIBUTING** document
- [x] My code follows the code style of this project

### Contribution Type

What types of changes does your code introduce? Put an `x` in all the boxes that apply:

- [x] Bug fix (non-breaking change which fixes an issue, please reference the issue id) #753 
- [ ] New feature (non-breaking change which adds functionality, make sure to open an associated issue first)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] My change requires a change to the documentation
- [ ] I have updated the documentation accordingly
- [ ] I have added tests to cover my changes
- [ ] All new and existing tests passed

### Description

The following tests fail and all the others pass.

- `AngleSharp.Core.Tests.Library.FormSubmitTests.PostStandardTypeWithNamesButMissingValueShouldOmitRedundantAmpersand`
- `AngleSharp.Core.Tests.Library.FormSubmitTests.PostUrlencodeFile`
- `AngleSharp.Core.Tests.Library.FormSubmitTests.PostUrlencodeNormal`

May be due to network issues.