### PR TITLE
Processing instruction parsing support

### DIFF
--- a/src/AngleSharp.Core.Tests/Html/ProcessingInstructions.cs
+++ b/src/AngleSharp.Core.Tests/Html/ProcessingInstructions.cs
@@ -1,0 +1,33 @@
+namespace AngleSharp.Core.Tests.Html
+{
+    using AngleSharp.Html.Parser;
+    using NUnit.Framework;
+
+    [TestFixture]
+    public class ProcessingInstructions
+    {
+        [Test]
+        public void ParsingWithSupportForProcessingInstructionsShouldProduceNode()
+        {
+            var source = @"<?foo bar>";
+            var parser = new HtmlParser(new HtmlParserOptions
+            {
+                IsSupportingProcessingInstructions = true
+            });
+            var document = parser.ParseDocument(source);
+            Assert.AreEqual(Dom.NodeType.ProcessingInstruction, document.ChildNodes[0].NodeType);
+        }
+
+        [Test]
+        public void ParsingWithoutSupportForProcessingInstructionsShouldCommentThemOut()
+        {
+            var source = @"<?foo bar>";
+            var parser = new HtmlParser(new HtmlParserOptions
+            {
+                IsSupportingProcessingInstructions = false
+            });
+            var document = parser.ParseDocument(source);
+            Assert.AreEqual(Dom.NodeType.Comment, document.ChildNodes[0].NodeType);
+        }
+    }
+}

--- a/src/AngleSharp/Dom/Internal/ProcessingInstruction.cs
+++ b/src/AngleSharp/Dom/Internal/ProcessingInstruction.cs
@@ -40,6 +40,20 @@ namespace AngleSharp.Dom
             return node;
         }
 
+        /// <summary>
+        /// Creates a processing instruction by splitting data into the name/target and data.
+        /// </summary>
+        internal static ProcessingInstruction Create(Document owner, String data)
+        {
+            int nameLength = data.IndexOf(' ');
+            var pi = new ProcessingInstruction(owner, nameLength <= 0 ? data : data.Substring(0, nameLength));
+            if (nameLength > 0)
+            {
+                pi.Data = data.Substring(nameLength);
+            }
+            return pi;
+        }
+
         #endregion
     }
 }

--- a/src/AngleSharp/Html/Parser/HtmlDomBuilder.cs
+++ b/src/AngleSharp/Html/Parser/HtmlDomBuilder.cs
@@ -103,6 +103,7 @@ namespace AngleSharp.Html.Parser
             var source = _document.Source;
             var token = default(HtmlToken);
             _tokenizer.IsStrictMode = options.IsStrictMode;
+            _tokenizer.IsSupportingProcessingInstructions = options.IsSupportingProcessingInstructions;
             _options = options;
 
             do
@@ -134,6 +135,7 @@ namespace AngleSharp.Html.Parser
         {
             var token = default(HtmlToken);
             _tokenizer.IsStrictMode = options.IsStrictMode;
+            _tokenizer.IsSupportingProcessingInstructions = options.IsSupportingProcessingInstructions;
             _options = options;
 
             do
@@ -423,6 +425,11 @@ namespace AngleSharp.Html.Parser
                     _document.AddComment(token);
                     return;
                 }
+                case HtmlTokenType.ProcessingInstruction:
+                {
+                    _document.AddProcessingInstruction(token);
+                    return;
+                }
             }
 
             if (!_options.IsEmbedded)
@@ -457,6 +464,11 @@ namespace AngleSharp.Html.Parser
                 case HtmlTokenType.Comment:
                 {
                     _document.AddComment(token);
+                    return;
+                    }
+                case HtmlTokenType.ProcessingInstruction:
+                {
+                    _document.AddProcessingInstruction(token);
                     return;
                 }
                 case HtmlTokenType.StartTag:
@@ -543,6 +555,11 @@ namespace AngleSharp.Html.Parser
                     CurrentNode.AddComment(token);
                     return;
                 }
+                case HtmlTokenType.ProcessingInstruction:
+                {
+                    CurrentNode.AddProcessingInstruction(token);
+                    return;
+                }
                 case HtmlTokenType.Doctype:
                 {
                     RaiseErrorOccurred(HtmlParseError.DoctypeTagInappropriate, token);
@@ -577,6 +594,11 @@ namespace AngleSharp.Html.Parser
                 case HtmlTokenType.Comment:
                 {
                     CurrentNode.AddComment(token);
+                    return;
+                }
+                case HtmlTokenType.ProcessingInstruction:
+                {
+                    CurrentNode.AddProcessingInstruction(token);
                     return;
                 }
                 case HtmlTokenType.Doctype:
@@ -749,6 +771,11 @@ namespace AngleSharp.Html.Parser
                     InHead(token);
                     return;
                 }
+                case HtmlTokenType.ProcessingInstruction:
+                {
+                    InHead(token);
+                    return;
+                }
                 case HtmlTokenType.StartTag:
                 {
                     var tagName = token.Name;
@@ -826,6 +853,11 @@ namespace AngleSharp.Html.Parser
                 case HtmlTokenType.Comment:
                 {
                     CurrentNode.AddComment(token);
+                    return;
+                }
+                case HtmlTokenType.ProcessingInstruction:
+                {
+                    CurrentNode.AddProcessingInstruction(token);
                     return;
                 }
                 case HtmlTokenType.Doctype:
@@ -1495,6 +1527,11 @@ namespace AngleSharp.Html.Parser
                     CurrentNode.AddComment(token);
                     return;
                 }
+                case HtmlTokenType.ProcessingInstruction:
+                {
+                    CurrentNode.AddProcessingInstruction(token);
+                    return;
+                }
                 case HtmlTokenType.Doctype:
                 {
                     RaiseErrorOccurred(HtmlParseError.DoctypeTagInappropriate, token);
@@ -1567,6 +1604,11 @@ namespace AngleSharp.Html.Parser
                 case HtmlTokenType.Comment:
                 {
                     CurrentNode.AddComment(token);
+                    return;
+                }
+                case HtmlTokenType.ProcessingInstruction:
+                {
+                    CurrentNode.AddProcessingInstruction(token);
                     return;
                 }
                 case HtmlTokenType.Doctype:
@@ -1799,6 +1841,11 @@ namespace AngleSharp.Html.Parser
                 case HtmlTokenType.Comment:
                 {
                     CurrentNode.AddComment(token);
+                    return;
+                }
+                case HtmlTokenType.ProcessingInstruction:
+                {
+                    CurrentNode.AddProcessingInstruction(token);
                     return;
                 }
                 case HtmlTokenType.Doctype:
@@ -2094,6 +2141,11 @@ namespace AngleSharp.Html.Parser
                     CurrentNode.AddComment(token);
                     return;
                 }
+                case HtmlTokenType.ProcessingInstruction:
+                {
+                    CurrentNode.AddProcessingInstruction(token);
+                    return;
+                }
                 case HtmlTokenType.Doctype:
                 {
                     RaiseErrorOccurred(HtmlParseError.DoctypeTagInappropriate, token);
@@ -2345,6 +2397,11 @@ namespace AngleSharp.Html.Parser
                     _openElements[0].AddComment(token);
                     return;
                 }
+                case HtmlTokenType.ProcessingInstruction:
+                {
+                    _openElements[0].AddProcessingInstruction(token);
+                    return;
+                }
                 case HtmlTokenType.Doctype:
                 {
                     RaiseErrorOccurred(HtmlParseError.DoctypeTagInappropriate, token);
@@ -2413,6 +2470,11 @@ namespace AngleSharp.Html.Parser
                 case HtmlTokenType.Comment:
                 {
                     CurrentNode.AddComment(token);
+                    return;
+                }
+                case HtmlTokenType.ProcessingInstruction:
+                {
+                    CurrentNode.AddProcessingInstruction(token);
                     return;
                 }
                 case HtmlTokenType.Doctype:
@@ -2519,6 +2581,11 @@ namespace AngleSharp.Html.Parser
                     CurrentNode.AddComment(token);
                     return;
                 }
+                case HtmlTokenType.ProcessingInstruction:
+                {
+                    CurrentNode.AddProcessingInstruction(token);
+                    return;
+                }
                 case HtmlTokenType.Doctype:
                 {
                     RaiseErrorOccurred(HtmlParseError.DoctypeTagInappropriate, token);
@@ -2592,6 +2659,11 @@ namespace AngleSharp.Html.Parser
                 case HtmlTokenType.Comment:
                 {
                     _document.AddComment(token);
+                    return;
+                }
+                case HtmlTokenType.ProcessingInstruction:
+                {
+                    _document.AddProcessingInstruction(token);
                     return;
                 }
                 case HtmlTokenType.Doctype:
@@ -3393,6 +3465,11 @@ namespace AngleSharp.Html.Parser
                 case HtmlTokenType.Comment:
                 {
                     CurrentNode.AddComment(token);
+                    return;
+                }
+                case HtmlTokenType.ProcessingInstruction:
+                {
+                    CurrentNode.AddProcessingInstruction(token);
                     return;
                 }
                 case HtmlTokenType.Doctype:

--- a/src/AngleSharp/Html/Parser/HtmlDomBuilder.cs
+++ b/src/AngleSharp/Html/Parser/HtmlDomBuilder.cs
@@ -425,11 +425,6 @@ namespace AngleSharp.Html.Parser
                     _document.AddComment(token);
                     return;
                 }
-                case HtmlTokenType.ProcessingInstruction:
-                {
-                    _document.AddProcessingInstruction(token);
-                    return;
-                }
             }
 
             if (!_options.IsEmbedded)
@@ -464,11 +459,6 @@ namespace AngleSharp.Html.Parser
                 case HtmlTokenType.Comment:
                 {
                     _document.AddComment(token);
-                    return;
-                    }
-                case HtmlTokenType.ProcessingInstruction:
-                {
-                    _document.AddProcessingInstruction(token);
                     return;
                 }
                 case HtmlTokenType.StartTag:
@@ -555,11 +545,6 @@ namespace AngleSharp.Html.Parser
                     CurrentNode.AddComment(token);
                     return;
                 }
-                case HtmlTokenType.ProcessingInstruction:
-                {
-                    CurrentNode.AddProcessingInstruction(token);
-                    return;
-                }
                 case HtmlTokenType.Doctype:
                 {
                     RaiseErrorOccurred(HtmlParseError.DoctypeTagInappropriate, token);
@@ -594,11 +579,6 @@ namespace AngleSharp.Html.Parser
                 case HtmlTokenType.Comment:
                 {
                     CurrentNode.AddComment(token);
-                    return;
-                }
-                case HtmlTokenType.ProcessingInstruction:
-                {
-                    CurrentNode.AddProcessingInstruction(token);
                     return;
                 }
                 case HtmlTokenType.Doctype:
@@ -771,11 +751,6 @@ namespace AngleSharp.Html.Parser
                     InHead(token);
                     return;
                 }
-                case HtmlTokenType.ProcessingInstruction:
-                {
-                    InHead(token);
-                    return;
-                }
                 case HtmlTokenType.StartTag:
                 {
                     var tagName = token.Name;
@@ -853,11 +828,6 @@ namespace AngleSharp.Html.Parser
                 case HtmlTokenType.Comment:
                 {
                     CurrentNode.AddComment(token);
-                    return;
-                }
-                case HtmlTokenType.ProcessingInstruction:
-                {
-                    CurrentNode.AddProcessingInstruction(token);
                     return;
                 }
                 case HtmlTokenType.Doctype:
@@ -1527,11 +1497,6 @@ namespace AngleSharp.Html.Parser
                     CurrentNode.AddComment(token);
                     return;
                 }
-                case HtmlTokenType.ProcessingInstruction:
-                {
-                    CurrentNode.AddProcessingInstruction(token);
-                    return;
-                }
                 case HtmlTokenType.Doctype:
                 {
                     RaiseErrorOccurred(HtmlParseError.DoctypeTagInappropriate, token);
@@ -1604,11 +1569,6 @@ namespace AngleSharp.Html.Parser
                 case HtmlTokenType.Comment:
                 {
                     CurrentNode.AddComment(token);
-                    return;
-                }
-                case HtmlTokenType.ProcessingInstruction:
-                {
-                    CurrentNode.AddProcessingInstruction(token);
                     return;
                 }
                 case HtmlTokenType.Doctype:
@@ -1841,11 +1801,6 @@ namespace AngleSharp.Html.Parser
                 case HtmlTokenType.Comment:
                 {
                     CurrentNode.AddComment(token);
-                    return;
-                }
-                case HtmlTokenType.ProcessingInstruction:
-                {
-                    CurrentNode.AddProcessingInstruction(token);
                     return;
                 }
                 case HtmlTokenType.Doctype:
@@ -2141,11 +2096,6 @@ namespace AngleSharp.Html.Parser
                     CurrentNode.AddComment(token);
                     return;
                 }
-                case HtmlTokenType.ProcessingInstruction:
-                {
-                    CurrentNode.AddProcessingInstruction(token);
-                    return;
-                }
                 case HtmlTokenType.Doctype:
                 {
                     RaiseErrorOccurred(HtmlParseError.DoctypeTagInappropriate, token);
@@ -2397,11 +2347,6 @@ namespace AngleSharp.Html.Parser
                     _openElements[0].AddComment(token);
                     return;
                 }
-                case HtmlTokenType.ProcessingInstruction:
-                {
-                    _openElements[0].AddProcessingInstruction(token);
-                    return;
-                }
                 case HtmlTokenType.Doctype:
                 {
                     RaiseErrorOccurred(HtmlParseError.DoctypeTagInappropriate, token);
@@ -2470,11 +2415,6 @@ namespace AngleSharp.Html.Parser
                 case HtmlTokenType.Comment:
                 {
                     CurrentNode.AddComment(token);
-                    return;
-                }
-                case HtmlTokenType.ProcessingInstruction:
-                {
-                    CurrentNode.AddProcessingInstruction(token);
                     return;
                 }
                 case HtmlTokenType.Doctype:
@@ -2581,11 +2521,6 @@ namespace AngleSharp.Html.Parser
                     CurrentNode.AddComment(token);
                     return;
                 }
-                case HtmlTokenType.ProcessingInstruction:
-                {
-                    CurrentNode.AddProcessingInstruction(token);
-                    return;
-                }
                 case HtmlTokenType.Doctype:
                 {
                     RaiseErrorOccurred(HtmlParseError.DoctypeTagInappropriate, token);
@@ -2659,11 +2594,6 @@ namespace AngleSharp.Html.Parser
                 case HtmlTokenType.Comment:
                 {
                     _document.AddComment(token);
-                    return;
-                }
-                case HtmlTokenType.ProcessingInstruction:
-                {
-                    _document.AddProcessingInstruction(token);
                     return;
                 }
                 case HtmlTokenType.Doctype:
@@ -3465,11 +3395,6 @@ namespace AngleSharp.Html.Parser
                 case HtmlTokenType.Comment:
                 {
                     CurrentNode.AddComment(token);
-                    return;
-                }
-                case HtmlTokenType.ProcessingInstruction:
-                {
-                    CurrentNode.AddProcessingInstruction(token);
                     return;
                 }
                 case HtmlTokenType.Doctype:

--- a/src/AngleSharp/Html/Parser/HtmlDomBuilderExtensions.cs
+++ b/src/AngleSharp/Html/Parser/HtmlDomBuilderExtensions.cs
@@ -166,6 +166,18 @@ namespace AngleSharp.Html.Parser
             parent.AddNode(new Comment(parent, token.Data));
         }
 
+        [MethodImpl(MethodImplOptions.AggressiveInlining)]
+        public static void AddProcessingInstruction(this Element parent, HtmlToken token)
+        {
+            parent.AddNode(ProcessingInstruction.Create(parent.Owner, token.Data));
+        }
+
+        [MethodImpl(MethodImplOptions.AggressiveInlining)]
+        public static void AddProcessingInstruction(this Document parent, HtmlToken token)
+        {
+            parent.AddNode(ProcessingInstruction.Create(parent, token.Data));
+        }
+
         public static QuirksMode GetQuirksMode(this HtmlDoctypeToken doctype)
         {
             if (doctype.IsFullQuirks)

--- a/src/AngleSharp/Html/Parser/HtmlDomBuilderExtensions.cs
+++ b/src/AngleSharp/Html/Parser/HtmlDomBuilderExtensions.cs
@@ -157,25 +157,17 @@ namespace AngleSharp.Html.Parser
         [MethodImpl(MethodImplOptions.AggressiveInlining)]
         public static void AddComment(this Element parent, HtmlToken token)
         {
-            parent.AddNode(new Comment(parent.Owner, token.Data));
+            parent.AddNode(token.IsProcessingInstruction
+                ? (Node)ProcessingInstruction.Create(parent.Owner, token.Data)
+                : new Comment(parent.Owner, token.Data));
         }
 
         [MethodImpl(MethodImplOptions.AggressiveInlining)]
         public static void AddComment(this Document parent, HtmlToken token)
         {
-            parent.AddNode(new Comment(parent, token.Data));
-        }
-
-        [MethodImpl(MethodImplOptions.AggressiveInlining)]
-        public static void AddProcessingInstruction(this Element parent, HtmlToken token)
-        {
-            parent.AddNode(ProcessingInstruction.Create(parent.Owner, token.Data));
-        }
-
-        [MethodImpl(MethodImplOptions.AggressiveInlining)]
-        public static void AddProcessingInstruction(this Document parent, HtmlToken token)
-        {
-            parent.AddNode(ProcessingInstruction.Create(parent, token.Data));
+            parent.AddNode(token.IsProcessingInstruction
+                ? (Node)ProcessingInstruction.Create(parent, token.Data)
+                : new Comment(parent, token.Data));
         }
 
         public static QuirksMode GetQuirksMode(this HtmlDoctypeToken doctype)

--- a/src/AngleSharp/Html/Parser/HtmlParserOptions.cs
+++ b/src/AngleSharp/Html/Parser/HtmlParserOptions.cs
@@ -48,6 +48,16 @@ namespace AngleSharp.Html.Parser
         }
 
         /// <summary>
+        /// Gets or sets if XML processing instructions should
+        /// be parsed into DOM nodes.
+        /// </summary>
+        public Boolean IsSupportingProcessingInstructions
+        {
+            get;
+            set;
+        }
+
+        /// <summary>
         /// Gets or sets the callback once a new element was created.
         /// </summary>
         public Action<IElement, TextPosition> OnCreated

--- a/src/AngleSharp/Html/Parser/HtmlTokenType.cs
+++ b/src/AngleSharp/Html/Parser/HtmlTokenType.cs
@@ -28,10 +28,6 @@ namespace AngleSharp.Html.Parser
         /// <summary>
         /// The End-Of-File token to mark the end.
         /// </summary>
-        EndOfFile,
-        /// <summary>
-        /// A processing instruction.
-        /// </summary>
-        ProcessingInstruction
+        EndOfFile
     }
 }

--- a/src/AngleSharp/Html/Parser/HtmlTokenType.cs
+++ b/src/AngleSharp/Html/Parser/HtmlTokenType.cs
@@ -28,6 +28,10 @@ namespace AngleSharp.Html.Parser
         /// <summary>
         /// The End-Of-File token to mark the end.
         /// </summary>
-        EndOfFile
+        EndOfFile,
+        /// <summary>
+        /// A processing instruction.
+        /// </summary>
+        ProcessingInstruction
     }
 }

--- a/src/AngleSharp/Html/Parser/HtmlTokenizer.cs
+++ b/src/AngleSharp/Html/Parser/HtmlTokenizer.cs
@@ -2544,7 +2544,10 @@ namespace AngleSharp.Html.Parser
         private HtmlToken NewProcessingInstruction()
         {
             var content = FlushBuffer();
-            return new HtmlToken(HtmlTokenType.ProcessingInstruction, _position, content);
+            return new HtmlToken(HtmlTokenType.Comment, _position, content)
+            {
+                IsProcessingInstruction = true
+            };
         }
 
         private HtmlToken NewComment()

--- a/src/AngleSharp/Html/Parser/HtmlTokenizer.cs
+++ b/src/AngleSharp/Html/Parser/HtmlTokenizer.cs
@@ -80,6 +80,16 @@ namespace AngleSharp.Html.Parser
             set;
         }
 
+        /// <summary>
+        /// Gets or sets if XML processing instructions should
+        /// be parsed into DOM nodes.
+        /// </summary>
+        public Boolean IsSupportingProcessingInstructions
+        {
+            get;
+            set;
+        }
+
         #endregion
 
         #region Methods
@@ -636,6 +646,10 @@ namespace AngleSharp.Html.Parser
             {
                 return MarkupDeclaration(GetNext());
             }
+            else if (c == Symbols.QuestionMark && IsSupportingProcessingInstructions)
+            {
+                return ProcessingInstruction(c);
+            }
             else if (c != Symbols.QuestionMark)
             {
                 State = HtmlParseMode.PCData;
@@ -786,6 +800,37 @@ namespace AngleSharp.Html.Parser
             {
                 RaiseErrorOccurred(HtmlParseError.UndefinedMarkupDeclaration);
                 return BogusComment(c);
+            }
+        }
+
+        #endregion
+
+        #region ProcessingInstructions
+
+        private HtmlToken ProcessingInstruction(Char c)
+        {
+            StringBuffer.Clear();
+
+            while (true)
+            {
+                switch (c)
+                {
+                    case Symbols.GreaterThan:
+                        break;
+                    case Symbols.EndOfFile:
+                        Back();
+                        break;
+                    case Symbols.Null:
+                        c = Symbols.Replacement;
+                        goto default;
+                    default:
+                        StringBuffer.Append(c);
+                        c = GetNext();
+                        continue;
+                }
+
+                State = HtmlParseMode.PCData;
+                return NewProcessingInstruction();
             }
         }
 
@@ -2494,6 +2539,12 @@ namespace AngleSharp.Html.Parser
         {
             var content = FlushBuffer();
             return new HtmlToken(HtmlTokenType.Character, _position, content);
+        }
+
+        private HtmlToken NewProcessingInstruction()
+        {
+            var content = FlushBuffer();
+            return new HtmlToken(HtmlTokenType.ProcessingInstruction, _position, content);
         }
 
         private HtmlToken NewComment()

--- a/src/AngleSharp/Html/Parser/Tokens/HtmlToken.cs
+++ b/src/AngleSharp/Html/Parser/Tokens/HtmlToken.cs
@@ -101,6 +101,11 @@ namespace AngleSharp.Html.Parser.Tokens
         /// </summary>
         public HtmlTokenType Type => _type;
 
+        /// <summary>
+        /// Indicates that this comment token is a processing instruction.
+        /// </summary>
+        public bool IsProcessingInstruction { get; internal set; }
+
         #endregion
 
         #region Methods


### PR DESCRIPTION
## Types of Changes

This change implements support for parsing XML processing instructions (#761)

### Prerequisites

Please make sure you can check the following two boxes:

- [x] I have read the **CONTRIBUTING** document
- [x] My code follows the code style of this project

### Contribution Type

What types of changes does your code introduce? Put an `x` in all the boxes that apply:

- [ ] Bug fix (non-breaking change which fixes an issue, please reference the issue id)
- [x] New feature (non-breaking change which adds functionality, make sure to open an associated issue first)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] My change requires a change to the documentation
- [ ] I have updated the documentation accordingly
- [x] I have added tests to cover my changes
- [x] All new and existing tests passed

### Description

This introduces a new option `HtmlParserOptions.IsSupportingProcessingInstructions` which causes the parser to emit `ProcessingInstruction` nodes when `<? ... >` tokens are encountered instead of treat them as "bogus comment" content.

Happy to address any feedback you have. Particularly interested in a look at how I implemented tokenizing the processing instruction and splitting it's target/data after tokenization in a `ProcessingInstruction.Create()` factory method - there might be a more "correct" way to do this. Also happy to add any additional tests you think might be warranted.
