### PR TITLE
Fix Cookie Expiry TimeZone

### DIFF
--- a/src/AngleSharp.Core.Tests/Library/CookieHandling.cs
+++ b/src/AngleSharp.Core.Tests/Library/CookieHandling.cs
@@ -456,6 +456,17 @@ namespace AngleSharp.Core.Tests.Library
             Assert.AreEqual(String.Empty, receivedCookieHeader);
         }
 
+        [Test]
+        public void MissingCookie_Issue768()
+        {
+            var mcp = new MemoryCookieProvider();
+            var url = Url.Create("http://www.example.com");
+            var cookie = "A=A";
+            mcp.SetCookie(url,
+                $"{cookie}; expires={DateTime.UtcNow.AddHours(1).ToString("ddd, dd MMM yyyy HH:mm:ss")} GMT");
+            Assert.AreEqual(mcp.GetCookie(url), cookie);
+        }
+
         private static Task<IDocument> LoadDocumentWithFakeRequesterAndCookie(IResponse initialResponse,
             Func<Request, IResponse> onRequest)
         {

--- a/src/AngleSharp/Io/MemoryCookieProvider.cs
+++ b/src/AngleSharp/Io/MemoryCookieProvider.cs
@@ -80,7 +80,7 @@ namespace AngleSharp.Io
 
                     if (DateTime.TryParse(middle.Replace("UTC", "GMT"), out var utc))
                     {
-                        var time = utc.ToString("ddd, dd MMM yyyy HH:mm:ss", CultureInfo.InvariantCulture);
+                        var time = utc.ToUniversalTime().ToString("ddd, dd MMM yyyy HH:mm:ss", CultureInfo.InvariantCulture);
                         cookie = $"{front}{time}{back}";
                     }
 


### PR DESCRIPTION
## Types of Changes

Fixes #768 

### Prerequisites

Please make sure you can check the following two boxes:

- [X] I have read the **CONTRIBUTING** document
- [X] My code follows the code style of this project

### Contribution Type

What types of changes does your code introduce? Put an `x` in all the boxes that apply:

- [X] Bug fix (non-breaking change which fixes an issue, please reference the issue id)
- [ ] New feature (non-breaking change which adds functionality, make sure to open an associated issue first)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] My change requires a change to the documentation
- [ ] I have updated the documentation accordingly
- [X] I have added tests to cover my changes
- [X] All new and existing tests passed

### Description

The TimeZone of the Cookie expiry datetime was in Local instead of UTC.
