### PR TITLE
Percentage decoding hostname

### DIFF
--- a/src/AngleSharp.Core.Tests/Urls/UrlValidation.cs
+++ b/src/AngleSharp.Core.Tests/Urls/UrlValidation.cs
@@ -4182,6 +4182,25 @@ org");
         }
 
         [Test]
+        public void DocumentUrlShouldDoUtf8PercentDecoding()
+        {
+            var document = Html("<base id=base>");
+            var element = document.GetElementById("base") as HtmlBaseElement;
+            Assert.IsNotNull(element);
+            element.Href = @"about:blank";
+            var anchor = document.CreateElement<IHtmlAnchorElement>();
+            anchor.SetAttribute("href", "https://%e2%98%83");
+            Assert.AreEqual("https:", anchor.Protocol);
+            Assert.AreEqual("xn--n3h", anchor.HostName);
+            Assert.AreEqual("", anchor.Port);
+            Assert.AreEqual("/", anchor.PathName);
+            Assert.AreEqual("", anchor.Search);
+            Assert.AreEqual("", anchor.Hash);
+            Assert.AreEqual("https://xn--n3h/", anchor.Href);
+            Assert.IsNotNull(document);
+        }
+
+        [Test]
         public void DocumentUrlShouldTransformBigDot()
 		{
 			var document = Html("<base id=base>");


### PR DESCRIPTION
## Types of Changes

### Contribution Type

What types of changes does your code introduce? Put an `x` in all the boxes that apply:

- [ ] Bug fix (non-breaking change which fixes an issue, please reference the issue id)
- [ ] New feature (non-breaking change which adds functionality, make sure to open an associated issue first)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] My change requires a change to the documentation
- [ ] I have updated the documentation accordingly
- [x] I have added tests to cover my changes
- [x] All new and existing tests passed

### Description
With the [help from WPT tests](https://github.com/web-platform-tests/wpt/issues/17420) we are able to fix [failing test](https://github.com/web-platform-tests/wpt/blob/master/url/resources/urltestdata.json#L4689) of input `https://%e2%98%83`.

Root cause is my previous PR https://github.com/AngleSharp/AngleSharp/pull/799 is wrong in *percent decoding*.

I removed the string to byte and byte to string operation in that PR, but actually it is required but in a different way (this test will fail even before https://github.com/AngleSharp/AngleSharp/pull/799).