### PR TITLE
Updating calls from Element.Text() to Element.TextContent

### DIFF
--- a/doc/Examples.md
+++ b/doc/Examples.md
@@ -96,7 +96,7 @@ static async Task UsingLinq()
 
     foreach (var item in blueListItemsLinq)
     {
-        Console.WriteLine(item.Text());
+        Console.WriteLine(item.TextContent);
     }
 
     Console.WriteLine();
@@ -104,7 +104,7 @@ static async Task UsingLinq()
 
     foreach (var item in blueListItemsCssSelector)
     {
-        Console.WriteLine(item.Text());
+        Console.WriteLine(item.TextContent);
     }
 }
 ```
@@ -142,7 +142,7 @@ static async Task SingleElements()
     Console.WriteLine("Only from C# / AngleSharp:");
     Console.WriteLine();
     Console.WriteLine(emphasize.ToHtml());   //<em> bold <u>and</u> italic </em>
-    Console.WriteLine(emphasize.Text());   // bold and italic
+    Console.WriteLine(emphasize.TextContent);   // bold and italic
 
     Console.WriteLine();
     Console.WriteLine("From the DOM:");


### PR DESCRIPTION
Calls to Text method were not building for me as the method could not be found so updating to use TextContent property used in SingleElements method example.

## Types of Changes
Very basic update to 2 examples in documentation

### Prerequisites

Please make sure you can check the following two boxes:

- [X] I have read the **CONTRIBUTING** document
- [ ] My code follows the code style of this project

### Contribution Type

What types of changes does your code introduce? Put an `x` in all the boxes that apply:

- [ ] Bug fix (non-breaking change which fixes an issue, please reference the issue id)
- [ ] New feature (non-breaking change which adds functionality, make sure to open an associated issue first)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] My change requires a change to the documentation
- [X] I have updated the documentation accordingly
- [ ] I have added tests to cover my changes
- [ ] All new and existing tests passed

### Description

Calls to Text method were not building for me as the method could not be found so updating to use TextContent property used in SingleElements method example.