### PR TITLE
Align behavior of form- attributes with spec

### DIFF
--- a/src/AngleSharp.Core.Tests/Html/DOM.cs
+++ b/src/AngleSharp.Core.Tests/Html/DOM.cs
@@ -459,6 +459,39 @@ namespace AngleSharp.Core.Tests.Html
         }
 
         [Test]
+        public void HtmlFormAttributes()
+        {
+            var content = @"
+<form method=""get"" action=""action1"">
+    <button type=""submit"" formmethod=""dialog"" formaction=""action2"" formnovalidate>
+    <input type=""submit"" formmethod=""post"" formaction=""action3"" formenctype=""multipart/form-data"" formtarget=""_blank"">
+</form>";
+
+            var doc = content.ToHtmlDocument();
+
+            var form = doc.QuerySelector("form") as IHtmlFormElement;
+            Assert.AreEqual("get", form.Method);
+            Assert.AreEqual("action1", form.Action);
+            Assert.AreEqual("application/x-www-form-urlencoded", form.Enctype);
+            Assert.AreEqual(false, form.NoValidate);
+            Assert.AreEqual(String.Empty, form.Target);
+
+            var button = form.QuerySelector("button") as IHtmlButtonElement;
+            Assert.AreEqual("dialog", button.FormMethod);
+            Assert.AreEqual("action2", button.FormAction);
+            Assert.AreEqual(String.Empty, button.FormEncType);
+            Assert.AreEqual(true, button.FormNoValidate);
+            Assert.AreEqual(String.Empty, button.FormTarget);
+
+            var input = form.QuerySelector("input") as IHtmlInputElement;
+            Assert.AreEqual("post", input.FormMethod);
+            Assert.AreEqual("action3", input.FormAction);
+            Assert.AreEqual("multipart/form-data", input.FormEncType);
+            Assert.AreEqual(false, input.FormNoValidate);
+            Assert.AreEqual("_blank", input.FormTarget);
+        }
+
+        [Test]
         public void HtmlStandardHead()
         {
             var content = @"<!doctype html>

--- a/src/AngleSharp/Dom/AttributeNames.cs
+++ b/src/AngleSharp/Dom/AttributeNames.cs
@@ -143,6 +143,26 @@ namespace AngleSharp.Dom
         public static readonly String Shape = "shape";
 
         /// <summary>
+        /// The formaction attribute.
+        /// </summary>
+        public static readonly String FormAction = "formaction";
+
+        /// <summary>
+        /// The formmethod attribute.
+        /// </summary>
+        public static readonly String FormMethod = "formmethod";
+
+        /// <summary>
+        /// The formtarget attribute.
+        /// </summary>
+        public static readonly String FormTarget = "formtarget";
+
+        /// <summary>
+        /// The formenctype attribute.
+        /// </summary>
+        public static readonly String FormEncType = "formenctype";
+
+        /// <summary>
         /// The formnovalidate attribute.
         /// </summary>
         public static readonly String FormNoValidate = "formnovalidate";

--- a/src/AngleSharp/Html/Dom/Internal/HtmlButtonElement.cs
+++ b/src/AngleSharp/Html/Dom/Internal/HtmlButtonElement.cs
@@ -39,8 +39,8 @@ namespace AngleSharp.Html.Dom
         /// </summary>
         public String FormAction
         {
-            get { var form = Form; if (form == null) return String.Empty; return form.Action; }
-            set { var form = Form; if (form != null) form.Action = value; }
+            get { return this.GetOwnAttribute(AttributeNames.FormAction) ?? Owner?.DocumentUri; }
+            set { this.SetOwnAttribute(AttributeNames.FormAction, value); }
         }
 
         /// <summary>
@@ -49,8 +49,8 @@ namespace AngleSharp.Html.Dom
         /// </summary>
         public String FormEncType
         {
-            get { var form = Form; if (form == null) return String.Empty; return form.Enctype; }
-            set { var form = Form; if (form != null) form.Enctype = value; }
+            get { return this.GetOwnAttribute(AttributeNames.FormEncType).ToEncodingType() ?? String.Empty; }
+            set { this.SetOwnAttribute(AttributeNames.FormEncType, value); }
         }
 
         /// <summary>
@@ -59,8 +59,8 @@ namespace AngleSharp.Html.Dom
         /// </summary>
         public String FormMethod
         {
-            get { var form = Form; if (form == null) return String.Empty; return form.Method; }
-            set { var form = Form; if (form != null) form.Method = value; }
+            get { return this.GetOwnAttribute(AttributeNames.FormMethod).ToFormMethod() ?? String.Empty; }
+            set { this.SetOwnAttribute(AttributeNames.FormMethod, value); }
         }
 
         /// <summary>
@@ -69,8 +69,8 @@ namespace AngleSharp.Html.Dom
         /// </summary>
         public Boolean FormNoValidate
         {
-            get { var form = Form; if (form == null) return false; return form.NoValidate; }
-            set { var form = Form; if (form != null) form.NoValidate = value; }
+            get { return this.GetBoolAttribute(AttributeNames.FormNoValidate); }
+            set { this.SetBoolAttribute(AttributeNames.FormNoValidate, value); }
         }
 
         /// <summary>
@@ -79,8 +79,8 @@ namespace AngleSharp.Html.Dom
         /// </summary>
         public String FormTarget
         {
-            get { var form = Form; if (form == null) return String.Empty; return form.Target; }
-            set { var form = Form; if (form != null) form.Target = value; }
+            get { return this.GetOwnAttribute(AttributeNames.FormTarget) ?? String.Empty; }
+            set { this.SetOwnAttribute(AttributeNames.FormTarget, value); }
         }
 
         /// <summary>

--- a/src/AngleSharp/Html/Dom/Internal/HtmlFormElement.cs
+++ b/src/AngleSharp/Html/Dom/Internal/HtmlFormElement.cs
@@ -61,7 +61,7 @@ namespace AngleSharp.Html.Dom
 
         public String Action
         {
-            get => this.GetOwnAttribute(AttributeNames.Action);
+            get => this.GetOwnAttribute(AttributeNames.Action) ?? Owner.DocumentUri;
             set => this.SetOwnAttribute(AttributeNames.Action, value);
         }
 
@@ -73,8 +73,8 @@ namespace AngleSharp.Html.Dom
 
         public String Enctype
         {
-            get => this.GetOwnAttribute(AttributeNames.Enctype).ToEncodingType();
-            set => this.SetOwnAttribute(AttributeNames.Enctype, value.ToEncodingType());
+            get => this.GetOwnAttribute(AttributeNames.Enctype).ToEncodingType() ?? MimeTypeNames.UrlencodedForm;
+            set => this.SetOwnAttribute(AttributeNames.Enctype, value);
         }
 
         public String Encoding
@@ -85,7 +85,7 @@ namespace AngleSharp.Html.Dom
 
         public String Method
         {
-            get => this.GetOwnAttribute(AttributeNames.Method) ?? String.Empty;
+            get => this.GetOwnAttribute(AttributeNames.Method).ToFormMethod() ?? FormMethodNames.Get;
             set => this.SetOwnAttribute(AttributeNames.Method, value);
         }
 
@@ -97,7 +97,7 @@ namespace AngleSharp.Html.Dom
 
         public String Target
         {
-            get => this.GetOwnAttribute(AttributeNames.Target);
+            get => this.GetOwnAttribute(AttributeNames.Target) ?? String.Empty;
             set => this.SetOwnAttribute(AttributeNames.Target, value);
         }
 

--- a/src/AngleSharp/Html/Dom/Internal/HtmlInputElement.cs
+++ b/src/AngleSharp/Html/Dom/Internal/HtmlInputElement.cs
@@ -103,32 +103,32 @@ namespace AngleSharp.Html.Dom
 
         public String FormAction
         {
-            get { var form = Form; if (form == null) return String.Empty; return form.Action; }
-            set { var form = Form; if (form != null) form.Action = value; }
+            get { return this.GetOwnAttribute(AttributeNames.FormAction) ?? Owner?.DocumentUri; }
+            set { this.SetOwnAttribute(AttributeNames.FormAction, value); }
         }
 
         public String FormEncType
         {
-            get { var form = Form; if (form == null) return String.Empty; return form.Enctype; }
-            set { var form = Form; if (form != null) form.Enctype = value; }
+            get { return this.GetOwnAttribute(AttributeNames.FormEncType).ToEncodingType() ?? String.Empty; }
+            set { this.SetOwnAttribute(AttributeNames.FormEncType, value); }
         }
 
         public String FormMethod
         {
-            get { var form = Form; if (form == null) return String.Empty; return form.Method; }
-            set { var form = Form; if (form != null) form.Method = value; }
+            get { return this.GetOwnAttribute(AttributeNames.FormMethod).ToFormMethod() ?? String.Empty; }
+            set { this.SetOwnAttribute(AttributeNames.FormMethod, value); }
         }
 
         public Boolean FormNoValidate
         {
-            get { var form = Form; if (form == null) return false; return form.NoValidate; }
-            set { var form = Form; if (form != null) form.NoValidate = value; }
+            get { return this.GetBoolAttribute(AttributeNames.FormNoValidate); }
+            set { this.SetBoolAttribute(AttributeNames.FormNoValidate, value); }
         }
 
         public String FormTarget
         {
-            get { var form = Form; if (form == null) return String.Empty; return form.Target; }
-            set { var form = Form; if (form != null) form.Target = value; }
+            get { return this.GetOwnAttribute(AttributeNames.FormTarget) ?? String.Empty; }
+            set { this.SetOwnAttribute(AttributeNames.FormTarget, value); }
         }
 
         public String Accept

--- a/src/AngleSharp/Html/FormMethodNames.cs
+++ b/src/AngleSharp/Html/FormMethodNames.cs
@@ -1,0 +1,25 @@
+namespace AngleSharp.Html
+{
+    using System;
+
+    /// <summary>
+    /// The collection of (known / used) form method names.
+    /// </summary>
+    public static class FormMethodNames
+    {
+        /// <summary>
+        /// The get method.
+        /// </summary>
+        public static readonly String Get = "get";
+
+        /// <summary>
+        /// The post method.
+        /// </summary>
+        public static readonly String Post = "post";
+
+        /// <summary>
+        /// The dialog method.
+        /// </summary>
+        public static readonly String Dialog = "dialog";
+    }
+}

--- a/src/AngleSharp/Text/StringExtensions.cs
+++ b/src/AngleSharp/Text/StringExtensions.cs
@@ -3,6 +3,7 @@ namespace AngleSharp.Text
     using AngleSharp.Attributes;
     using AngleSharp.Browser;
     using AngleSharp.Dom;
+    using AngleSharp.Html;
     using AngleSharp.Io;
     using System;
     using System.Collections.Generic;
@@ -802,12 +803,25 @@ namespace AngleSharp.Text
         /// </summary>
         /// <param name="encType">The string to convert.</param>
         /// <returns>
-        /// The encoding type with fallback application/x-www-form-urlencoded.
+        /// The valid encoding type string or null.
         /// </returns>
         public static String ToEncodingType(this String encType) =>
             encType.Isi(MimeTypeNames.Plain) ||
             encType.Isi(MimeTypeNames.MultipartForm) ||
             encType.Isi(MimeTypeNames.ApplicationJson) ?
-                encType : MimeTypeNames.UrlencodedForm;
+                encType.ToLowerInvariant() : null;
+
+        /// <summary>
+        /// Converts the current string to one of the form methods.
+        /// </summary>
+        /// <param name="method">The string to convert.</param>
+        /// <returns>
+        /// The valid form method string or null.
+        /// </returns>
+        public static String ToFormMethod(this String method) =>
+            method.Isi(FormMethodNames.Get) ||
+            method.Isi(FormMethodNames.Post) ||
+            method.Isi(FormMethodNames.Dialog) ?
+                method.ToLowerInvariant() : null;
     }
 }


### PR DESCRIPTION
## Types of Changes

### Prerequisites

Please make sure you can check the following two boxes:

- [x] I have read the **CONTRIBUTING** document
- [x] My code follows the code style of this project

### Contribution Type

What types of changes does your code introduce? Put an `x` in all the boxes that apply:

- [ ] Bug fix (non-breaking change which fixes an issue, please reference the issue id)
- [ ] New feature (non-breaking change which adds functionality, make sure to open an associated issue first)
- [x] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] My change requires a change to the documentation
- [ ] I have updated the documentation accordingly
- [x] I have added tests to cover my changes
- [x] All new and existing tests passed

### Description

Basically, one of the first tests I wrote for my own project involved reading the `formmethod` attribute on a `<button>`, and I noticed it was just giving me the method on the form, which is... not right. 

This commit makes the `FormAction`, `FormMethod`, etc. properties of `HtmlButtonElement` and `HtmlInputElement` behave in better alignment with the living standard. It also brings some similar tweaks to `HtmlFormElement`. 

