### PR TITLE
GetHashCode now corresponds with Equals

### DIFF
--- a/src/AngleSharp.Core.Tests/Urls/Url.cs
+++ b/src/AngleSharp.Core.Tests/Urls/Url.cs
@@ -224,5 +224,15 @@ namespace AngleSharp.Core.Tests.Urls
             Assert.IsFalse(url.IsInvalid);
             Assert.AreEqual("https:///", url.ToString());
         }
+
+        [TestCase("http://localhost:12345/signin")]
+        [TestCase("https://loony_picture.dirty.ru/")]
+        [TestCase("http://www.google.de/some-path?a=b#header")]
+        public void SameUrlsHaveSameHashCode(string url)
+        {
+            var url1 = new Url(url);
+            var url2 = new Url(url);
+            Assert.AreEqual(url1.GetHashCode(), url2.GetHashCode());
+        }
     }
 }

--- a/src/AngleSharp/Url.cs
+++ b/src/AngleSharp/Url.cs
@@ -321,7 +321,19 @@ namespace AngleSharp
         /// <returns>A hash code for the current url.</returns>
         public override Int32 GetHashCode()
         {
-            return base.GetHashCode();
+            unchecked
+            {
+                var hashCode =  _fragment != null ? StringComparer.Ordinal.GetHashCode(_fragment) : 0;
+                hashCode = (hashCode * 397) ^ (_query != null ? StringComparer.Ordinal.GetHashCode(_query) : 0);
+                hashCode = (hashCode * 397) ^ (_path != null ? StringComparer.Ordinal.GetHashCode(_path) : 0);
+                hashCode = (hashCode * 397) ^ (_scheme != null ? StringComparer.OrdinalIgnoreCase.GetHashCode(_scheme) : 0);
+                hashCode = (hashCode * 397) ^ (_port != null ? StringComparer.Ordinal.GetHashCode(_port) : 0);
+                hashCode = (hashCode * 397) ^ (_host != null ?  StringComparer.OrdinalIgnoreCase.GetHashCode(_host) : 0);
+                hashCode = (hashCode * 397) ^ (_username != null ? StringComparer.Ordinal.GetHashCode(_username) : 0);
+                hashCode = (hashCode * 397) ^ (_password != null ? StringComparer.Ordinal.GetHashCode(_password) : 0);
+                hashCode = (hashCode * 397) ^ (_schemeData != null ? StringComparer.Ordinal.GetHashCode(_schemeData) : 0);
+                return hashCode;
+            }
         }
 
         /// <summary>
@@ -336,7 +348,7 @@ namespace AngleSharp
         /// </returns>
         public override Boolean Equals(Object obj)
         {
-            return obj is Url url ? Equals(url) : false;
+            return ReferenceEquals(this, obj) || obj is Url other && Equals(other);
         }
 
         /// <summary>
@@ -351,7 +363,7 @@ namespace AngleSharp
         /// </returns>
         public Boolean Equals(Url other)
         {
-            return _fragment.Is(other._fragment) && _query.Is(other._query) &&
+            return other != null && _fragment.Is(other._fragment) && _query.Is(other._query) &&
                 _path.Is(other._path) && _scheme.Isi(other._scheme) &&
                 _port.Is(other._port) && _host.Isi(other._host) &&
                 _username.Is(other._username) && _password.Is(other._password) &&
@@ -936,9 +948,9 @@ namespace AngleSharp
                         break;
                     }
                 }
-                else if (c == Symbols.Percent && 
-                         index + 2 < length && 
-                         input[index + 1].IsHex() && 
+                else if (c == Symbols.Percent &&
+                         index + 2 < length &&
+                         input[index + 1].IsHex() &&
                          input[index + 2].IsHex())
                 {
                     buffer.Append(input[index++]);


### PR DESCRIPTION
# Types of Changes

## Prerequisites

Please make sure you can check the following two boxes:

- [x] I have read the **CONTRIBUTING** document
- [x] My code follows the code style of this project

## Contribution Type

What types of changes does your code introduce? Put an `x` in all the boxes that apply:

- [x] Bug fix (non-breaking change which fixes an issue, please reference the issue id)
- [x] I have added tests to cover my changes
- [x] All new and existing tests passed

## Description
Fixing #850 

`Url.GetHashCode()` returns `base.GetHashCode()` which is based on object reference, while Equals actually compare url's parts.
