### PR TITLE
IBrowsingContext now derives from IDisposable

### DIFF
--- a/src/AngleSharp.Core.Tests/Library/BrowsingContextTests.cs
+++ b/src/AngleSharp.Core.Tests/Library/BrowsingContextTests.cs
@@ -1,0 +1,15 @@
+namespace AngleSharp.Core.Tests.Library
+{
+    using NUnit.Framework;
+    using System;
+
+    [TestFixture]
+    public class BrowsingContextTests
+    {
+        [Test]
+        public void BrowsingContextAbstractionShouldBeDisposable()
+        {
+            Assert.Contains(typeof(IDisposable), typeof(IBrowsingContext).GetInterfaces());
+        }
+    }
+}

--- a/src/AngleSharp/IBrowsingContext.cs
+++ b/src/AngleSharp/IBrowsingContext.cs
@@ -1,4 +1,4 @@
-﻿namespace AngleSharp
+namespace AngleSharp
 {
     using AngleSharp.Browser;
     using AngleSharp.Browser.Dom;
@@ -9,7 +9,7 @@
     /// <summary>
     /// Represents the browsing context interface.
     /// </summary>
-    public interface IBrowsingContext : IEventTarget
+    public interface IBrowsingContext : IEventTarget, IDisposable
     {
         /// <summary>
         /// Gets the current window proxy.


### PR DESCRIPTION
`BrowsingContext` itself is disposable, thus this should be reflected in the abstraction as well.

# Types of Changes

## Prerequisites

Please make sure you can check the following two boxes:

- [x] I have read the **CONTRIBUTING** document
- [x] My code follows the code style of this project

## Contribution Type

What types of changes does your code introduce? Put an `x` in all the boxes that apply:

- [ ] Bug fix (non-breaking change which fixes an issue, please reference the issue id)
- [ ] New feature (non-breaking change which adds functionality, make sure to open an associated issue first)
- [x] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] My change requires a change to the documentation
- [ ] I have updated the documentation accordingly
- [x] I have added tests to cover my changes
- [x] All new and existing tests passed

## Description

As discussed with @FlorianRappl in Skype, `IBrowsingContext` now derives from `IDisposable`. The implementing class `BrowsingContext` itself is disposable, and thus disposing of an instance should also be possible via the interface.