### PR TITLE
Provide SPDX license identifier

### DIFF
--- a/src/AngleSharp.nuspec
+++ b/src/AngleSharp.nuspec
@@ -5,6 +5,7 @@
     <version>$version$</version>
     <authors>AngleSharp</authors>
     <owners>Florian Rappl</owners>
+    <license type="expression">MIT</license>
     <licenseUrl>https://github.com/AngleSharp/AngleSharp/blob/master/LICENSE</licenseUrl>
     <projectUrl>https://anglesharp.github.io</projectUrl>
     <iconUrl>https://raw.github.com/AngleSharp/AngleSharp/master/logo.png</iconUrl>


### PR DESCRIPTION
This change adds the SPDX license identifier to the generated NuGet packages by adding the appropriate [license](https://docs.microsoft.com/en-us/nuget/reference/nuspec#license) tag.

**Why?** Companies use the license information provided by package managers to ensure compliance across large projects. Providing an SPDX license identifier makes it simpler for people to work with automated tools like [LicenseFinder](https://github.com/pivotal/LicenseFinder) or GitLab's license scanning feature.# Types of Changes