### PR TITLE
Drop .NETSTANDARD1.3, cross target NETCOREAPP3.1, and prepare to introduce span

### DIFF
--- a/build.cake
+++ b/build.cake
@@ -6,8 +6,8 @@ var frameworks = new Dictionary<String, String>
     { "net46", "net46" },
     { "net461", "net461" },
     { "net472", "net472" },
-    { "netstandard1.3", "netstandard1.3" },
     { "netstandard2.0", "netstandard2.0" },
+    { "netcoreapp3.1", "netcoreapp3.1" },
 };
 
 #load tools/anglesharp.cake

--- a/src/AngleSharp.Core.Tests/AngleSharp.Core.Tests.csproj
+++ b/src/AngleSharp.Core.Tests/AngleSharp.Core.Tests.csproj
@@ -1,10 +1,10 @@
-﻿<Project Sdk="Microsoft.NET.Sdk">
+<Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
-    <TargetFrameworks>netcoreapp2.1</TargetFrameworks>
+    <TargetFrameworks>netcoreapp3.1</TargetFrameworks>
     <SignAssembly>true</SignAssembly>
     <AssemblyOriginatorKeyFile>Key.snk</AssemblyOriginatorKeyFile>
     <IsPackable>false</IsPackable>
-    <LangVersion>7.1</LangVersion>
+    <LangVersion>9</LangVersion>
     <AssemblyName>AngleSharp.Core.Tests</AssemblyName>
   </PropertyGroup>
 
@@ -15,11 +15,11 @@
   </ItemGroup>
 
   <ItemGroup>
-    <PackageReference Include="Newtonsoft.Json" Version="12.0.1" />
-    <PackageReference Include="NUnit" Version="3.11.0" />
-    <PackageReference Include="NUnit3TestAdapter" Version="3.11.0" />
+    <PackageReference Include="Newtonsoft.Json" Version="13.0.1" />
+    <PackageReference Include="NUnit" Version="3.13.1" />
+    <PackageReference Include="NUnit3TestAdapter" Version="3.17.0" />
     <PackageReference Include="Appveyor.TestLogger" Version="2.0.0" />
-    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="15.9.0" />
+    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="16.9.4" />
   </ItemGroup>
 
   <ItemGroup>

--- a/src/AngleSharp.nuspec
+++ b/src/AngleSharp.nuspec
@@ -14,22 +14,20 @@
     <copyright>Copyright 2013-2020, AngleSharp.</copyright>
     <tags>html html5 css css3 xml dom dom4 parser engine hypertext markup language query selector attributes linq angle bracket web internet text headless browser</tags>
     <dependencies>
-      <group targetFramework="netstandard1.3">
-        <dependency id="System.Text.Encoding.CodePages" version="4.5.0" />
-        <dependency id="System.Net.Requests" version="4.3.0" />
-        <dependency id="System.Reflection.TypeExtensions" version="4.5.1" />
-      </group>
       <group targetFramework="netstandard2.0">
-        <dependency id="System.Text.Encoding.CodePages" version="4.5.0" />
+        <dependency id="System.Text.Encoding.CodePages" version="5.0.0" />
       </group>
       <group targetFramework="net46">
-        <dependency id="System.Text.Encoding.CodePages" version="4.5.0" />
+        <dependency id="System.Text.Encoding.CodePages" version="5.0.0" />
       </group>
       <group targetFramework="net461">
-        <dependency id="System.Text.Encoding.CodePages" version="4.5.0" />
+        <dependency id="System.Text.Encoding.CodePages" version="5.0.0" />
       </group>
       <group targetFramework="net472">
-          <dependency id="System.Text.Encoding.CodePages" version="4.5.0" />
+          <dependency id="System.Text.Encoding.CodePages" version="5.0.0" />
+      </group>
+      <group targetFramework="netcoreapp3.1">
+         <dependency id="System.Text.Encoding.CodePages" version="5.0.0" />
       </group>
     </dependencies>
   </metadata>

--- a/src/AngleSharp/AngleSharp.Core.csproj
+++ b/src/AngleSharp/AngleSharp.Core.csproj
@@ -2,12 +2,12 @@
   <PropertyGroup>
     <AssemblyName>AngleSharp</AssemblyName>
     <RootNamespace>AngleSharp</RootNamespace>
-    <TargetFrameworks Condition=" '$(OS)' != 'Windows_NT' ">netstandard1.3;netstandard2.0</TargetFrameworks>
-    <TargetFrameworks Condition=" '$(OS)' == 'Windows_NT' ">netstandard1.3;netstandard2.0;net46;net461;net472</TargetFrameworks>
+    <TargetFrameworks Condition=" '$(OS)' != 'Windows_NT' ">netstandard2.0;netcoreapp3.1;</TargetFrameworks>
+    <TargetFrameworks Condition=" '$(OS)' == 'Windows_NT' ">netstandard2.0;netcoreapp3.1;net46;net461;net472</TargetFrameworks>
     <SignAssembly>true</SignAssembly>
     <AssemblyOriginatorKeyFile>Key.snk</AssemblyOriginatorKeyFile>
     <GenerateDocumentationFile>true</GenerateDocumentationFile>
-    <LangVersion>7.1</LangVersion>
+    <LangVersion>9</LangVersion>
     <RepositoryUrl>https://github.com/AngleSharp/AngleSharp</RepositoryUrl>
     <RepositoryType>git</RepositoryType>
     <PublishRepositoryUrl>true</PublishRepositoryUrl>
@@ -17,16 +17,11 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="Microsoft.SourceLink.GitHub" Version="1.0.0" PrivateAssets="All"/>
+    <PackageReference Include="Microsoft.SourceLink.GitHub" Version="1.0.0" PrivateAssets="All" />
   </ItemGroup>
 
   <ItemGroup>
-    <PackageReference Include="System.Text.Encoding.CodePages" Version="4.5.0" />
-  </ItemGroup>
-
-  <ItemGroup Condition="'$(TargetFramework)' == 'netstandard1.3'">
-    <PackageReference Include="System.Net.Requests" Version="4.3.0" />
-    <PackageReference Include="System.Reflection.TypeExtensions" Version="4.5.1" />
+    <PackageReference Include="System.Text.Encoding.CodePages" Version="5.0.0" />
   </ItemGroup>
 
   <PropertyGroup Condition=" '$(OS)' == 'Windows_NT' ">

--- a/src/AngleSharp/AngleSharp.Core.csproj
+++ b/src/AngleSharp/AngleSharp.Core.csproj
@@ -1,4 +1,4 @@
-﻿<Project Sdk="Microsoft.NET.Sdk">
+<Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
     <AssemblyName>AngleSharp</AssemblyName>
     <RootNamespace>AngleSharp</RootNamespace>
@@ -18,6 +18,7 @@
 
   <ItemGroup>
     <PackageReference Include="Microsoft.SourceLink.GitHub" Version="1.0.0" PrivateAssets="All" />
+    <PackageReference Include="System.Memory" Version="4.5.4" />
   </ItemGroup>
 
   <ItemGroup>

--- a/src/AngleSharp/Dom/DocumentExtensions.cs
+++ b/src/AngleSharp/Dom/DocumentExtensions.cs
@@ -9,11 +9,6 @@ namespace AngleSharp.Dom
     using System.Threading;
     using System.Threading.Tasks;
 
-#if NETSTANDARD1_3
-    // Assembly.GetTypes is available as an extension in System.Reflection from NS1.3
-    using System.Reflection;
-#endif
-
     /// <summary>
     /// Useful methods for document objects.
     /// </summary>
@@ -52,9 +47,9 @@ namespace AngleSharp.Dom
             if (document == null)
                 throw new ArgumentNullException(nameof(document));
 
-            var type = typeof(BrowsingContext).GetAssembly().GetTypes()
+            var type = typeof(BrowsingContext).Assembly.GetTypes()
                 .Where(m => m.Implements<TElement>())
-                .FirstOrDefault(m => !m.IsAbstractClass());
+                .FirstOrDefault(m => !m.IsAbstract);
 
             if (type != null)
             {

--- a/src/AngleSharp/Helpers/NumberHelper.cs
+++ b/src/AngleSharp/Helpers/NumberHelper.cs
@@ -1,0 +1,19 @@
+using System;
+using System.Globalization;
+using System.Runtime.CompilerServices;
+
+namespace AngleSharp
+{
+    internal static class NumberHelper
+    {
+        [MethodImpl(MethodImplOptions.AggressiveInlining)]
+        public static int ParseInt32(ReadOnlySpan<char> text)
+        {
+#if NETSTANDARD2_1 || NETCOREAPP3_1_OR_GREATER
+            return int.Parse(text, provider: CultureInfo.InvariantCulture);
+#else
+            return int.Parse(text.ToString(), CultureInfo.InvariantCulture);
+#endif
+        }
+    }
+}

--- a/src/AngleSharp/Html/InputTypes/BaseInputType.cs
+++ b/src/AngleSharp/Html/InputTypes/BaseInputType.cs
@@ -334,7 +334,7 @@ namespace AngleSharp.Html.InputTypes
         /// <summary>
         /// Tries to convert the value to a time starting at the given position.
         /// </summary>
-        protected static TimeSpan? ToTime(String value, ref Int32 position)
+        protected static TimeSpan? ToTime(ReadOnlySpan<char> value, ref Int32 position)
         {
             var offset = position;
             var second = 0;
@@ -345,14 +345,14 @@ namespace AngleSharp.Html.InputTypes
                 value[position++].IsDigit() && 
                 value[position++] == Symbols.Colon)
             {
-                var hour = Int32.Parse(value.Substring(offset, 2), CultureInfo.InvariantCulture);
+                var hour = NumberHelper.ParseInt32(value.Slice(offset, 2));
 
                 if (!IsLegalHour(hour) || !value[position++].IsDigit() || !value[position++].IsDigit())
                 {
                     return null;
                 }
 
-                var minute = Int32.Parse(value.Substring(3 + offset, 2), CultureInfo.InvariantCulture);
+                var minute = NumberHelper.ParseInt32(value.Slice(3 + offset, 2));
 
                 if (!IsLegalMinute(minute))
                 {
@@ -368,7 +368,7 @@ namespace AngleSharp.Html.InputTypes
                         return null;
                     }
 
-                    second = Int32.Parse(value.Substring(6 + offset, 2), CultureInfo.InvariantCulture);
+                    second = NumberHelper.ParseInt32(value.Slice(6 + offset, 2));
 
                     if (!IsLegalSecond(second))
                     {
@@ -385,8 +385,8 @@ namespace AngleSharp.Html.InputTypes
                             position++;
                         }
 
-                        var fraction = value.Substring(start, position - start);
-                        ms = Int32.Parse(fraction, CultureInfo.InvariantCulture) * (Int32)Math.Pow(10, 3 - fraction.Length);
+                        var fraction = value.Slice(start, position - start);
+                        ms = NumberHelper.ParseInt32(fraction) * (Int32)Math.Pow(10, 3 - fraction.Length);
                     }
                 }
 
@@ -484,7 +484,7 @@ namespace AngleSharp.Html.InputTypes
         /// <summary>
         /// Skips all legit digits while returning the final position.
         /// </summary>
-        protected static Int32 FetchDigits(String value)
+        protected static Int32 FetchDigits(ReadOnlySpan<char> value)
         {
             var position = 0;
 
@@ -499,7 +499,7 @@ namespace AngleSharp.Html.InputTypes
         /// <summary>
         /// Checks the assumption that the string continues with a date time.
         /// </summary>
-        protected static Boolean PositionIsValidForDateTime(String value, Int32 position)
+        protected static Boolean PositionIsValidForDateTime(ReadOnlySpan<char> value, Int32 position)
         {
             return position >= 4 && position <= value.Length - 13 &&
                     value[position + 0] == Symbols.Minus &&

--- a/src/AngleSharp/Html/InputTypes/DateInputType.cs
+++ b/src/AngleSharp/Html/InputTypes/DateInputType.cs
@@ -1,4 +1,4 @@
-﻿namespace AngleSharp.Html.InputTypes
+namespace AngleSharp.Html.InputTypes
 {
     using AngleSharp.Html.Dom;
     using AngleSharp.Text;
@@ -21,15 +21,15 @@
         public override ValidationErrors Check(IValidityState current)
         {
             var value = Input.Value;
-            var date = ConvertFromDate(value);
-            var min = ConvertFromDate(Input.Minimum);
-            var max = ConvertFromDate(Input.Maximum);
+            var date = ConvertFromDate(value.AsSpan());
+            var min = ConvertFromDate(Input.Minimum.AsSpan());
+            var max = ConvertFromDate(Input.Maximum.AsSpan());
             return CheckTime(current, value, date, min, max);
         }
 
         public override Double? ConvertToNumber(String value)
         {
-            var dt = ConvertFromDate(value);
+            var dt = ConvertFromDate(value.AsSpan());
 
             if (dt.HasValue)
             {
@@ -47,7 +47,7 @@
 
         public override DateTime? ConvertToDate(String value)
         {
-            return ConvertFromDate(value);
+            return ConvertFromDate(value.AsSpan());
         }
 
         public override String ConvertFromDate(DateTime value)
@@ -57,13 +57,13 @@
 
         public override void DoStep(Int32 n)
         {
-            var dt = ConvertFromDate(Input.Value);
+            var dt = ConvertFromDate(Input.Value.AsSpan());
 
             if (dt.HasValue)
             {
                 var date = dt.Value.AddMilliseconds(GetStep() * n);
-                var min = ConvertFromDate(Input.Minimum);
-                var max = ConvertFromDate(Input.Maximum);
+                var min = ConvertFromDate(Input.Minimum.AsSpan());
+                var max = ConvertFromDate(Input.Maximum.AsSpan());
 
                 if ((!min.HasValue || min.Value <= date) && (!max.HasValue || max.Value >= date))
                 {
@@ -95,20 +95,20 @@
 
         #region Helper
 
-        protected static DateTime? ConvertFromDate(String value)
+        protected static DateTime? ConvertFromDate(ReadOnlySpan<char> value)
         {
-            if (!String.IsNullOrEmpty(value))
+            if (value.Length > 0)
             {
                 var position = FetchDigits(value);
 
                 if (IsLegalPosition(value, position))
                 {
-                    var yearString = value.Substring(0, position);
-                    var year = Int32.Parse(yearString, CultureInfo.InvariantCulture);
-                    var monthString = value.Substring(position + 1, 2);
-                    var month = Int32.Parse(monthString, CultureInfo.InvariantCulture);
-                    var dayString = value.Substring(position + 4, 2);
-                    var day = Int32.Parse(dayString, CultureInfo.InvariantCulture);
+                    var yearString = value.Slice(0, position);
+                    var year = NumberHelper.ParseInt32(yearString);
+                    var monthString = value.Slice(position + 1, 2);
+                    var month = NumberHelper.ParseInt32(monthString);
+                    var dayString = value.Slice(position + 4, 2);
+                    var day = NumberHelper.ParseInt32(dayString);
 
                     if (IsLegalDay(day, month, year))
                     {
@@ -120,7 +120,7 @@
             return null;
         }
 
-        private static Boolean IsLegalPosition(String value, Int32 position)
+        private static Boolean IsLegalPosition(ReadOnlySpan<char> value, Int32 position)
         {
             return position >= 4 && position == value.Length - 6 &&
                     value[position + 0] == Symbols.Minus &&

--- a/src/AngleSharp/Html/InputTypes/DateTimeInputType.cs
+++ b/src/AngleSharp/Html/InputTypes/DateTimeInputType.cs
@@ -1,4 +1,4 @@
-﻿namespace AngleSharp.Html.InputTypes
+namespace AngleSharp.Html.InputTypes
 {
     using AngleSharp.Html.Dom;
     using AngleSharp.Text;
@@ -21,15 +21,15 @@
         public override ValidationErrors Check(IValidityState current)
         {
             var value = Input.Value;
-            var date = ConvertFromDateTime(value);
-            var min = ConvertFromDateTime(Input.Minimum);
-            var max = ConvertFromDateTime(Input.Maximum);
+            var date = ConvertFromDateTime(value.AsSpan());
+            var min = ConvertFromDateTime(Input.Minimum.AsSpan());
+            var max = ConvertFromDateTime(Input.Maximum.AsSpan());
             return CheckTime(current, value, date, min, max);
         }
 
         public override Double? ConvertToNumber(String value)
         {
-            var dt = ConvertFromDateTime(value);
+            var dt = ConvertFromDateTime(value.AsSpan());
 
             if (dt.HasValue)
             {
@@ -47,7 +47,7 @@
 
         public override DateTime? ConvertToDate(String value)
         {
-            return ConvertFromDateTime(value);
+            return ConvertFromDateTime(value.AsSpan());
         }
 
         public override String ConvertFromDate(DateTime value)
@@ -59,13 +59,13 @@
 
         public override void DoStep(Int32 n)
         {
-            var dt = ConvertFromDateTime(Input.Value);
+            var dt = ConvertFromDateTime(Input.Value.AsSpan());
 
             if (dt.HasValue)
             {
                 var date = dt.Value.AddMilliseconds(GetStep() * n);
-                var min = ConvertFromDateTime(Input.Minimum);
-                var max = ConvertFromDateTime(Input.Maximum);
+                var min = ConvertFromDateTime(Input.Minimum.AsSpan());
+                var max = ConvertFromDateTime(Input.Maximum.AsSpan());
 
                 if ((!min.HasValue || min.Value <= date) && (!max.HasValue || max.Value >= date))
                 {
@@ -97,20 +97,20 @@
 
         #region Helper
 
-        protected static DateTime? ConvertFromDateTime(String value)
+        protected static DateTime? ConvertFromDateTime(ReadOnlySpan<char> value)
         {
-            if (!String.IsNullOrEmpty(value))
+            if (value.Length > 0)
             {
                 var position = FetchDigits(value);
 
                 if (PositionIsValidForDateTime(value, position))
                 {
-                    var yearString = value.Substring(0, position);
-                    var year = Int32.Parse(yearString, CultureInfo.InvariantCulture);
-                    var monthString = value.Substring(position + 1, 2);
-                    var month = Int32.Parse(monthString, CultureInfo.InvariantCulture);
-                    var dayString = value.Substring(position + 4, 2);
-                    var day = Int32.Parse(dayString, CultureInfo.InvariantCulture);
+                    var yearString = value.Slice(0, position);
+                    var year = NumberHelper.ParseInt32(yearString);
+                    var monthString = value.Slice(position + 1, 2);
+                    var month = NumberHelper.ParseInt32(monthString);
+                    var dayString = value.Slice(position + 4, 2);
+                    var day = NumberHelper.ParseInt32(dayString);
                     position += 6;
 
                     if (IsLegalDay(day, month, year) && IsTimeSeparator(value[position]))
@@ -137,10 +137,10 @@
                             {
                                 if (IsLegalPosition(value, position))
                                 {
-                                    var hoursString = value.Substring(position + 1, 2);
-                                    var hours = Int32.Parse(hoursString, CultureInfo.InvariantCulture);
-                                    var minutesString = value.Substring(position + 4, 2);
-                                    var minutes = Int32.Parse(minutesString, CultureInfo.InvariantCulture);
+                                    var hoursString = value.Slice(position + 1, 2);
+                                    var hours = NumberHelper.ParseInt32(hoursString);
+                                    var minutesString = value.Slice(position + 4, 2);
+                                    var minutes = NumberHelper.ParseInt32(minutesString);
                                     var offset = new TimeSpan(hours, minutes, 0);
 
                                     if (value[position] == '+')
@@ -179,7 +179,7 @@
             return null;
         }
 
-        private static Boolean IsLegalPosition(String value, Int32 position)
+        private static Boolean IsLegalPosition(ReadOnlySpan<char> value, Int32 position)
         {
             return position == value.Length - 6 &&
                     value[position + 1].IsDigit() &&

--- a/src/AngleSharp/Html/InputTypes/DatetimeLocalInputType.cs
+++ b/src/AngleSharp/Html/InputTypes/DatetimeLocalInputType.cs
@@ -1,4 +1,4 @@
-﻿namespace AngleSharp.Html.InputTypes
+namespace AngleSharp.Html.InputTypes
 {
     using AngleSharp.Html.Dom;
     using System;
@@ -20,15 +20,15 @@
         public override ValidationErrors Check(IValidityState current)
         {
             var value = Input.Value;
-            var date = ConvertFromDateTime(value);
-            var min = ConvertFromDateTime(Input.Minimum);
-            var max = ConvertFromDateTime(Input.Maximum);
+            var date = ConvertFromDateTime(value.AsSpan());
+            var min = ConvertFromDateTime(Input.Minimum.AsSpan());
+            var max = ConvertFromDateTime(Input.Maximum.AsSpan());
             return CheckTime(current, value, date, min, max);
         }
 
         public override Double? ConvertToNumber(String value)
         {
-            var dt = ConvertFromDateTime(value);
+            var dt = ConvertFromDateTime(value.AsSpan());
 
             if (dt.HasValue)
             {
@@ -46,7 +46,7 @@
 
         public override DateTime? ConvertToDate(String value)
         {
-            return ConvertFromDateTime(value);
+            return ConvertFromDateTime(value.AsSpan());
         }
 
         public override String ConvertFromDate(DateTime value)
@@ -59,13 +59,13 @@
 
         public override void DoStep(Int32 n)
         {
-            var dt = ConvertFromDateTime(Input.Value);
+            var dt = ConvertFromDateTime(Input.Value.AsSpan());
 
             if (dt.HasValue)
             {
                 var date = dt.Value.AddMilliseconds(GetStep() * n);
-                var min = ConvertFromDateTime(Input.Minimum);
-                var max = ConvertFromDateTime(Input.Maximum);
+                var min = ConvertFromDateTime(Input.Minimum.AsSpan());
+                var max = ConvertFromDateTime(Input.Maximum.AsSpan());
 
                 if ((!min.HasValue || min.Value <= date) && (!max.HasValue || max.Value >= date))
                 {
@@ -97,20 +97,20 @@
 
         #region Helper
 
-        protected static DateTime? ConvertFromDateTime(String value)
+        protected static DateTime? ConvertFromDateTime(ReadOnlySpan<char> value)
         {
-            if (!String.IsNullOrEmpty(value))
+            if (value.Length > 0)
             {
                 var position = FetchDigits(value);
 
                 if (PositionIsValidForDateTime(value, position))
                 {
-                    var yearString = value.Substring(0, position);
-                    var year = Int32.Parse(yearString, CultureInfo.InvariantCulture);
-                    var monthString = value.Substring(position + 1, 2);
-                    var month = Int32.Parse(monthString, CultureInfo.InvariantCulture);
-                    var dayString = value.Substring(position + 4, 2);
-                    var day = Int32.Parse(dayString, CultureInfo.InvariantCulture);
+                    var yearString = value.Slice(0, position);
+                    var year = NumberHelper.ParseInt32(yearString);
+                    var monthString = value.Slice(position + 1, 2);
+                    var month = NumberHelper.ParseInt32(monthString);
+                    var dayString = value.Slice(position + 4, 2);
+                    var day = NumberHelper.ParseInt32(dayString);
                     position += 6;
 
                     if (IsLegalDay(day, month, year) && IsTimeSeparator(value[position]))

--- a/src/AngleSharp/Html/InputTypes/MonthInputType.cs
+++ b/src/AngleSharp/Html/InputTypes/MonthInputType.cs
@@ -1,4 +1,4 @@
-﻿namespace AngleSharp.Html.InputTypes
+namespace AngleSharp.Html.InputTypes
 {
     using AngleSharp.Html.Dom;
     using AngleSharp.Text;
@@ -21,15 +21,15 @@
         public override ValidationErrors Check(IValidityState current)
         {
             var value = Input.Value;
-            var date = ConvertFromMonth(value);
-            var min = ConvertFromMonth(Input.Minimum);
-            var max = ConvertFromMonth(Input.Maximum);
+            var date = ConvertFromMonth(value.AsSpan());
+            var min = ConvertFromMonth(Input.Minimum.AsSpan());
+            var max = ConvertFromMonth(Input.Maximum.AsSpan());
             return CheckTime(current, value, date, min, max);
         }
 
         public override Double? ConvertToNumber(String value)
         {
-            var dt = ConvertFromMonth(value);
+            var dt = ConvertFromMonth(value.AsSpan());
 
             if (dt.HasValue)
             {
@@ -47,7 +47,7 @@
 
         public override DateTime? ConvertToDate(String value)
         {
-            return ConvertFromMonth(value);
+            return ConvertFromMonth(value.AsSpan());
         }
 
         public override String ConvertFromDate(DateTime value)
@@ -57,13 +57,13 @@
 
         public override void DoStep(Int32 n)
         {
-            var dt = ConvertFromMonth(Input.Value);
+            var dt = ConvertFromMonth(Input.Value.AsSpan());
 
             if (dt.HasValue)
             {
                 var date = dt.Value.AddMilliseconds(GetStep() * n);
-                var min = ConvertFromMonth(Input.Minimum);
-                var max = ConvertFromMonth(Input.Maximum);
+                var min = ConvertFromMonth(Input.Minimum.AsSpan());
+                var max = ConvertFromMonth(Input.Maximum.AsSpan());
 
                 if ((!min.HasValue || min.Value <= date) && (!max.HasValue || max.Value >= date))
                 {
@@ -95,18 +95,18 @@
 
         #region Helper
 
-        protected static DateTime? ConvertFromMonth(String value)
+        protected static DateTime? ConvertFromMonth(ReadOnlySpan<char> value)
         {
-            if (!String.IsNullOrEmpty(value))
+            if (value.Length > 0)
             {
                 var position = FetchDigits(value);
 
                 if (IsLegalPosition(value, position))
                 {
-                    var yearString = value.Substring(0, position);
-                    var year = Int32.Parse(yearString, CultureInfo.InvariantCulture);
-                    var monthString = value.Substring(position + 1);
-                    var month = Int32.Parse(monthString, CultureInfo.InvariantCulture);
+                    var yearString = value.Slice(0, position);
+                    var year = NumberHelper.ParseInt32(yearString);
+                    var monthString = value.Slice(position + 1);
+                    var month = NumberHelper.ParseInt32(monthString);
 
                     if (IsLegalDay(1, month, year))
                     {
@@ -118,7 +118,7 @@
             return null;
         }
 
-        private static Boolean IsLegalPosition(String value, Int32 position)
+        private static Boolean IsLegalPosition(ReadOnlySpan<char> value, Int32 position)
         {
             return position >= 4 && position == value.Length - 3 &&
                     value[position + 0] == Symbols.Minus &&

--- a/src/AngleSharp/Html/InputTypes/TimeInputType.cs
+++ b/src/AngleSharp/Html/InputTypes/TimeInputType.cs
@@ -1,4 +1,4 @@
-﻿namespace AngleSharp.Html.InputTypes
+namespace AngleSharp.Html.InputTypes
 {
     using AngleSharp.Html.Dom;
     using System;
@@ -20,15 +20,15 @@
         public override ValidationErrors Check(IValidityState current)
         {
             var value = Input.Value;
-            var date = ConvertFromTime(value);
-            var min = ConvertFromTime(Input.Minimum);
-            var max = ConvertFromTime(Input.Maximum);
+            var date = ConvertFromTime(value.AsSpan());
+            var min = ConvertFromTime(Input.Minimum.AsSpan());
+            var max = ConvertFromTime(Input.Maximum.AsSpan());
             return CheckTime(current, value, date, min, max);
         }
 
         public override Double? ConvertToNumber(String value)
         {
-            var dt = ConvertFromTime(value);
+            var dt = ConvertFromTime(value.AsSpan());
 
             if (dt.HasValue)
             {
@@ -46,7 +46,7 @@
 
         public override DateTime? ConvertToDate(String value)
         {
-            var time = ConvertFromTime(value);
+            var time = ConvertFromTime(value.AsSpan());
 
             if (time != null)
             {
@@ -63,13 +63,13 @@
 
         public override void DoStep(Int32 n)
         {
-            var dt = ConvertFromTime(Input.Value);
+            var dt = ConvertFromTime(Input.Value.AsSpan());
 
             if (dt.HasValue)
             {
                 var date = dt.Value.AddMilliseconds(GetStep() * n);
-                var min = ConvertFromTime(Input.Minimum);
-                var max = ConvertFromTime(Input.Maximum);
+                var min = ConvertFromTime(Input.Minimum.AsSpan());
+                var max = ConvertFromTime(Input.Maximum.AsSpan());
 
                 if ((!min.HasValue || min.Value <= date) && (!max.HasValue || max.Value >= date))
                 {
@@ -101,9 +101,9 @@
 
         #region Helper
 
-        protected static DateTime? ConvertFromTime(String value)
+        protected static DateTime? ConvertFromTime(ReadOnlySpan<char> value)
         {
-            if (!String.IsNullOrEmpty(value))
+            if (value.Length > 0)
             {
                 var position = 0;
                 var ts = ToTime(value, ref position);

--- a/src/AngleSharp/Html/InputTypes/WeekInputType.cs
+++ b/src/AngleSharp/Html/InputTypes/WeekInputType.cs
@@ -1,4 +1,4 @@
-﻿namespace AngleSharp.Html.InputTypes
+namespace AngleSharp.Html.InputTypes
 {
     using AngleSharp.Html.Dom;
     using AngleSharp.Text;
@@ -21,15 +21,15 @@
         public override ValidationErrors Check(IValidityState current)
         {
             var value = Input.Value;
-            var date = ConvertFromWeek(value);
-            var min = ConvertFromWeek(Input.Minimum);
-            var max = ConvertFromWeek(Input.Maximum);
+            var date = ConvertFromWeek(value.AsSpan());
+            var min = ConvertFromWeek(Input.Minimum.AsSpan());
+            var max = ConvertFromWeek(Input.Maximum.AsSpan());
             return CheckTime(current, value, date, min, max);
         }
 
         public override Double? ConvertToNumber(String value)
         {
-            var dt = ConvertFromWeek(value);
+            var dt = ConvertFromWeek(value.AsSpan());
 
             if (dt.HasValue)
             {
@@ -47,7 +47,7 @@
 
         public override DateTime? ConvertToDate(String value)
         {
-            return ConvertFromWeek(value);
+            return ConvertFromWeek(value.AsSpan());
         }
 
         public override String ConvertFromDate(DateTime value)
@@ -58,13 +58,13 @@
 
         public override void DoStep(Int32 n)
         {
-            var dt = ConvertFromWeek(Input.Value);
+            var dt = ConvertFromWeek(Input.Value.AsSpan());
 
             if (dt.HasValue)
             {
                 var date = dt.Value.AddMilliseconds(GetStep() * n);
-                var min = ConvertFromWeek(Input.Minimum);
-                var max = ConvertFromWeek(Input.Maximum);
+                var min = ConvertFromWeek(Input.Minimum.AsSpan());
+                var max = ConvertFromWeek(Input.Maximum.AsSpan());
 
                 if ((!min.HasValue || min.Value <= date) && (!max.HasValue || max.Value >= date))
                 {
@@ -96,16 +96,16 @@
 
         #region Helper
 
-        protected static DateTime? ConvertFromWeek(String value)
+        protected static DateTime? ConvertFromWeek(ReadOnlySpan<char> value)
         {
-            if (!String.IsNullOrEmpty(value))
+            if (value.Length > 0)
             {
                 var position = FetchDigits(value);
 
                 if (IsLegalPosition(value, position))
                 {
-                    var year = Int32.Parse(value.Substring(0, position));
-                    var week = Int32.Parse(value.Substring(position + 2)) - 1;
+                    var year = NumberHelper.ParseInt32(value.Slice(0, position));
+                    var week = NumberHelper.ParseInt32(value.Slice(position + 2)) - 1;
 
                     if (IsLegalWeek(week, year))
                     {
@@ -129,7 +129,7 @@
             return null;
         }
 
-        private static Boolean IsLegalPosition(String value, Int32 position)
+        private static Boolean IsLegalPosition(ReadOnlySpan<char> value, Int32 position)
         {
             return position >= 4 && position == value.Length - 4 &&
                     value[position + 0] == Symbols.Minus &&

--- a/src/AngleSharp/Io/DefaultHttpRequester.cs
+++ b/src/AngleSharp/Io/DefaultHttpRequester.cs
@@ -22,7 +22,7 @@ namespace AngleSharp.Io
 
         private const Int32 BufferSize = 4096;
 
-        private static readonly String Version = typeof(DefaultHttpRequester).GetTypeInfo().Assembly.GetCustomAttribute<AssemblyFileVersionAttribute>().Version;
+        private static readonly String Version = typeof(DefaultHttpRequester).Assembly.GetCustomAttribute<AssemblyFileVersionAttribute>().Version;
         private static readonly String AgentName = "AngleSharp/" + Version;
         private static readonly Dictionary<String, PropertyInfo> PropCache = new Dictionary<String, PropertyInfo>();
         private static readonly List<String> Restricted = new List<String>();

--- a/src/AngleSharp/PortableExtensions.cs
+++ b/src/AngleSharp/PortableExtensions.cs
@@ -10,9 +10,5 @@ namespace AngleSharp
     static class PortableExtensions
     {
         public static Boolean Implements<T>(this Type type) => type.GetTypeInfo().ImplementedInterfaces.Contains(typeof(T));
-
-        public static Boolean IsAbstractClass(this Type type) => type.GetTypeInfo().IsAbstract;
-
-        public static Assembly GetAssembly(this Type type) => type.GetTypeInfo().Assembly;
     }
 }

--- a/src/AngleSharp/Text/Punycode.cs
+++ b/src/AngleSharp/Text/Punycode.cs
@@ -21,7 +21,7 @@ namespace AngleSharp.Text
         /// <summary>
         /// A list of available punycode character mappings.
         /// </summary>
-        public static IDictionary<Char, Char> Symbols = new Dictionary<Char, Char>
+        public static Dictionary<Char, Char> Symbols = new Dictionary<Char, Char>
         {
             { '。', '.' },
             { '．', '.' },

--- a/src/AngleSharp/Text/StringExtensions.cs
+++ b/src/AngleSharp/Text/StringExtensions.cs
@@ -240,7 +240,11 @@ namespace AngleSharp.Text
                 return text;
             }
 
+#if NETCOREAPP3_1_OR_GREATER
+            return String.Concat(text.AsSpan(0, pos), replace, text.AsSpan(pos + search.Length));
+#else
             return String.Concat(text.Substring(0, pos), replace, text.Substring(pos + search.Length));
+#endif
         }
 
         /// <summary>


### PR DESCRIPTION
# Types of Changes

This PR is to gather feedback and interest in dropping support for NETSTANDARD1.3 in preparation to take a dependency on System.Memory and introduce Span into the library. There's many paths that we utilize span in to reduce allocations and improve performance.

## Prerequisites

Please make sure you can check the following two boxes:

- [x] I have read the **CONTRIBUTING** document
- [x] My code follows the code style of this project

## Contribution Type

What types of changes does your code introduce? Put an `x` in all the boxes that apply:

- [ ] Bug fix (non-breaking change which fixes an issue, please reference the issue id)
- [ ] New feature (non-breaking change which adds functionality, make sure to open an associated issue first)
- [x] Breaking change (fix or feature that would cause existing functionality to change)
- [x] My change requires a change to the documentation
- [ ] I have updated the documentation accordingly
- [ ] I have added tests to cover my changes
- [x] All new and existing tests passed