### PR TITLE
Reduce memory allocations on hot path

### DIFF
--- a/src/AngleSharp/Dom/EventTarget.cs
+++ b/src/AngleSharp/Dom/EventTarget.cs
@@ -148,6 +148,8 @@
             return false;
         }
 
+        internal Boolean HasEventListeners => _listeners != null && _listeners.Count > 0;
+
         /// <summary>
         /// Dispatch an event to this Node.
         /// </summary>

--- a/src/AngleSharp/Dom/Internal/NodeList.cs
+++ b/src/AngleSharp/Dom/Internal/NodeList.cs
@@ -78,7 +78,9 @@
 
         #region IEnumerable Implementation
 
-        public IEnumerator<INode> GetEnumerator() => _entries.GetEnumerator();
+        public List<Node>.Enumerator GetEnumerator() => _entries.GetEnumerator();
+
+        IEnumerator<INode> IEnumerable<INode>.GetEnumerator() => _entries.GetEnumerator();
 
         IEnumerator IEnumerable.GetEnumerator() => _entries.GetEnumerator();
 

--- a/src/AngleSharp/Html/Parser/HtmlParser.cs
+++ b/src/AngleSharp/Html/Parser/HtmlParser.cs
@@ -1,3 +1,5 @@
+using System.Runtime.CompilerServices;
+
 namespace AngleSharp.Html.Parser
 {
     using AngleSharp.Dom;
@@ -203,19 +205,28 @@ namespace AngleSharp.Html.Parser
         private IHtmlDocument Parse(HtmlDocument document)
         {
             var parser = CreateBuilder(document);
-            InvokeEventListener(new HtmlParseEvent(document, completed: false));
+            InvokeHtmlParseEvent(document, completed: false);
             parser.Parse(_options);
-            InvokeEventListener(new HtmlParseEvent(document, completed: true));
+            InvokeHtmlParseEvent(document, completed: true);
             return document;
         }
 
         private async Task<IHtmlDocument> ParseAsync(HtmlDocument document, CancellationToken cancel)
         {
             var parser = CreateBuilder(document);
-            InvokeEventListener(new HtmlParseEvent(document, completed: false));
+            InvokeHtmlParseEvent(document, completed: false);
             await parser.ParseAsync(_options, cancel).ConfigureAwait(false);
-            InvokeEventListener(new HtmlParseEvent(document, completed: true));
+            InvokeHtmlParseEvent(document, completed: true);
             return document;
+        }
+
+        [MethodImpl(MethodImplOptions.AggressiveInlining)]
+        private void InvokeHtmlParseEvent(HtmlDocument document, bool completed)
+        {
+            if (HasEventListeners)
+            {
+                InvokeEventListener(new HtmlParseEvent(document, completed));
+            }
         }
 
         private INodeList ParseFragment(HtmlDocument document, IElement contextElement)


### PR DESCRIPTION
# Types of Changes

## Prerequisites

Please make sure you can check the following two boxes:

- [ ] I have read the **CONTRIBUTING** document - didn't find it?
- [x] My code follows the code style of this project

## Contribution Type

What types of changes does your code introduce? Put an `x` in all the boxes that apply:

- [ ] Bug fix (non-breaking change which fixes an issue, please reference the issue id)
- [ ] New feature (non-breaking change which adds functionality, make sure to open an associated issue first)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] My change requires a change to the documentation
- [ ] I have updated the documentation accordingly
- [ ] I have added tests to cover my changes
- [x] All new and existing tests passed - except for the SubmittingToGoogleWithCookiesShouldWork , seems to be broken

## Description

While profiling Orchard Core CMS I saw considerable amount of allocations made by AngleSharp. With these changes I'm trying to alleviate the situation:

* Only allocate `HtmlParseEvent` if someone is listening
* Add separate GetEnumerator implementation that returns concrete type, no need to box via interface (CLR knows how to bind to concrete `GetEnumerator` method)

/cc @sebastienros
