### PR TITLE
Make Configuration.Default reuse same configuration instance

### DIFF
--- a/src/AngleSharp/Configuration.cs
+++ b/src/AngleSharp/Configuration.cs
@@ -58,7 +58,7 @@ namespace AngleSharp
                 Creator<ICssSelectorParser>(ctx => new CssSelectorParser(ctx)),
                 Creator<IHtmlParser>(ctx => new HtmlParser(ctx)),
                 Creator<INavigationHandler>(ctx => new DefaultNavigationHandler(ctx)),
-            }; ;
+            };
         }
 
         #endregion
@@ -69,7 +69,7 @@ namespace AngleSharp
         /// Gets the default configuration to use. The default configuration
         /// can be overriden by calling the SetDefault method.
         /// </summary>
-        public static IConfiguration Default => new Configuration();
+        public static IConfiguration Default { get; } = new Configuration();
 
         #endregion
 


### PR DESCRIPTION
# Types of Changes

## Prerequisites

Please make sure you can check the following two boxes:

- [x] I have read the **CONTRIBUTING** document
- [x] My code follows the code style of this project

## Contribution Type

What types of changes does your code introduce? Put an `x` in all the boxes that apply:

- [ ] Bug fix (non-breaking change which fixes an issue, please reference the issue id)
- [ ] New feature (non-breaking change which adds functionality, make sure to open an associated issue first)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] My change requires a change to the documentation
- [ ] I have updated the documentation accordingly
- [ ] I have added tests to cover my changes
- [x] All new and existing tests passed

## Description

The Configuration.Default getter always allocates a new instance of configuration. As configuration is meant to be immutable (which is very cool) there should be no need to create new one each time. Getter-like service can also be surprising to end users when it allocates every time.
