### PR TITLE
Replace ForEachRange with one-time loops

### DIFF
--- a/src/AngleSharp/Dom/DocumentExtensions.cs
+++ b/src/AngleSharp/Dom/DocumentExtensions.cs
@@ -15,26 +15,6 @@ namespace AngleSharp.Dom
     public static class DocumentExtensions
     {
         /// <summary>
-        /// Iterates over all ranges in the document, applying the provided
-        /// action when the given condition is fulfilled.
-        /// </summary>
-        /// <param name="document">The document that hosts the ranges.</param>
-        /// <param name="condition">
-        /// The condition that needs to be fulfilled.
-        /// </param>
-        /// <param name="action">The action to apply to the range.</param>
-        internal static void ForEachRange(this Document document, Predicate<Range> condition, Action<Range> action)
-        {
-            foreach (var range in document.GetAttachedReferences<Range>())
-            {
-                if (condition.Invoke(range))
-                {
-                    action.Invoke(range);
-                }
-            }
-        }
-
-        /// <summary>
         /// Creates an element of the given type or throws an exception, if
         /// there is no such type.
         /// </summary>

--- a/src/AngleSharp/Dom/Internal/CharacterData.cs
+++ b/src/AngleSharp/Dom/Internal/CharacterData.cs
@@ -63,7 +63,7 @@ namespace AngleSharp.Dom
             get
             {
                 var parent = Parent;
-                
+
                 if (parent != null)
                 {
                     var n = parent.ChildNodes.Length;
@@ -164,7 +164,7 @@ namespace AngleSharp.Dom
             {
                 count = length - offset;
             }
-            
+
             var previous = _content;
             var deleteOffset = offset + data.Length;
             _content = _content.Insert(offset, data);
@@ -175,10 +175,25 @@ namespace AngleSharp.Dom
             }
 
             owner.QueueMutation(MutationRecord.CharacterData(target: this, previousValue: previous));
-            owner.ForEachRange(m => m.Head == this && m.Start > offset && m.Start <= offset + count, m => m.StartWith(this, offset));
-            owner.ForEachRange(m => m.Tail == this && m.End > offset && m.End <= offset + count, m => m.EndWith(this, offset));
-            owner.ForEachRange(m => m.Head == this && m.Start > offset + count, m => m.StartWith(this, m.Start + data.Length - count));
-            owner.ForEachRange(m => m.Tail == this && m.End > offset + count, m => m.EndWith(this, m.End + data.Length - count));
+            foreach (var m in owner.GetAttachedReferences<Range>())
+            {
+                if (m.Head == this && m.Start > offset && m.Start <= offset + count)
+                {
+                    m.StartWith(this, offset);
+                }
+                if (m.Tail == this && m.End > offset && m.End <= offset + count)
+                {
+                    m.EndWith(this, offset);
+                }
+                if (m.Head == this && m.Start > offset + count)
+                {
+                    m.StartWith(this, m.Start + data.Length - count);
+                }
+                if (m.Tail == this && m.End > offset + count)
+                {
+                    m.EndWith(this, m.End + data.Length - count);
+                }
+            }
         }
 
         public void Before(params INode[] nodes) => this.InsertBefore(nodes);

--- a/src/AngleSharp/Dom/Internal/Node.cs
+++ b/src/AngleSharp/Dom/Internal/Node.cs
@@ -270,8 +270,17 @@ namespace AngleSharp.Dom
             if (referenceElement != null && document != null)
             {
                 var childIndex = referenceElement.Index();
-                document.ForEachRange(m => m.Head == this && m.Start > childIndex, m => m.StartWith(this, m.Start + count));
-                document.ForEachRange(m => m.Tail == this && m.End > childIndex, m => m.EndWith(this, m.End + count));
+                foreach (var m in document.GetAttachedReferences<Range>())
+                {
+                    if (m.Head == this && m.Start > childIndex)
+                    {
+                        m.StartWith(this, m.Start + count);
+                    }
+                    if (m.Tail == this && m.End > childIndex)
+                    {
+                        m.EndWith(this, m.End + count);
+                    }
+                }
             }
 
             if (newElement.NodeType == NodeType.Document || newElement.Contains(this))
@@ -332,10 +341,25 @@ namespace AngleSharp.Dom
 
             if (document != null)
             {
-                document.ForEachRange(m => m.Head.IsInclusiveDescendantOf(node), m => m.StartWith(this, index));
-                document.ForEachRange(m => m.Tail.IsInclusiveDescendantOf(node), m => m.EndWith(this, index));
-                document.ForEachRange(m => m.Head == this && m.Start > index, m => m.StartWith(this, m.Start - 1));
-                document.ForEachRange(m => m.Tail == this && m.End > index, m => m.EndWith(this, m.End - 1));
+                foreach (var m in document.GetAttachedReferences<Range>())
+                {
+                    if (m.Head.IsInclusiveDescendantOf(node))
+                    {
+                        m.StartWith(this, index);
+                    }
+                    if (m.Tail.IsInclusiveDescendantOf(node))
+                    {
+                        m.EndWith(this, index);
+                    }
+                    if (m.Head == this && m.Start > index)
+                    {
+                        m.StartWith(this, m.Start - 1);
+                    }
+                    if (m.Tail == this && m.End > index)
+                    {
+                        m.EndWith(this, m.End - 1);
+                    }
+                }
             }
 
             var oldPreviousSibling = index > 0 ? _children[index - 1] : null;
@@ -617,11 +641,25 @@ namespace AngleSharp.Dom
                             sb.Append(sibling.Data);
                             end++;
 
-                            owner.ForEachRange(m => m.Head == sibling, m => m.StartWith(text, length));
-                            owner.ForEachRange(m => m.Tail == sibling, m => m.EndWith(text, length));
-                            owner.ForEachRange(m => m.Head == sibling.Parent && m.Start == end, m => m.StartWith(text, length));
-                            owner.ForEachRange(m => m.Tail == sibling.Parent && m.End == end, m => m.EndWith(text, length));
-
+                            foreach (var m in owner.GetAttachedReferences<Range>())
+                            {
+                                if (m.Head == sibling)
+                                {
+                                    m.StartWith(text, length);
+                                }
+                                if (m.Tail == sibling)
+                                {
+                                    m.EndWith(text, length);
+                                }
+                                if (m.Head == sibling.Parent && m.Start == end)
+                                {
+                                    m.StartWith(text, length);
+                                }
+                                if (m.Tail == sibling.Parent && m.End == end)
+                                {
+                                    m.EndWith(text, length);
+                                }
+                            }
                             length += sibling.Length;
                         }
 

--- a/src/AngleSharp/Dom/Internal/TextNode.cs
+++ b/src/AngleSharp/Dom/Internal/TextNode.cs
@@ -103,18 +103,45 @@ namespace AngleSharp.Dom
                 var index = this.Index();
                 parent.InsertBefore(newNode, NextSibling);
 
-                owner.ForEachRange(m => m.Head == this && m.Start > offset, m => m.StartWith(newNode, m.Start - offset));
-                owner.ForEachRange(m => m.Tail == this && m.End > offset, m => m.EndWith(newNode, m.End - offset));
-                owner.ForEachRange(m => m.Head == parent && m.Start == index + 1, m => m.StartWith(parent, m.Start + 1));
-                owner.ForEachRange(m => m.Tail == parent && m.End == index + 1, m => m.StartWith(parent, m.End + 1));
+                foreach (var m in owner.GetAttachedReferences<Range>())
+                {
+                    if (m.Head == this && m.Start > offset)
+                    {
+                        m.StartWith(newNode, m.Start - offset);
+                    }
+
+                    if (m.Tail == this && m.End > offset)
+                    {
+                        m.EndWith(newNode, m.End - offset);
+                    }
+
+                    if (m.Head == parent && m.Start == index + 1)
+                    {
+                        m.StartWith(parent, m.Start + 1);
+                    }
+
+                    if (m.Tail == parent && m.End == index + 1)
+                    {
+                        m.StartWith(parent, m.End + 1);
+                    }
+                }
             }
 
             Replace(offset, count, String.Empty);
 
             if (parent != null)
             {
-                owner.ForEachRange(m => m.Head == this && m.Start > offset, m => m.StartWith(this, offset));
-                owner.ForEachRange(m => m.Tail == this && m.End > offset, m => m.EndWith(this, offset));
+                foreach (var m in owner.GetAttachedReferences<Range>())
+                {
+                    if (m.Head == this && m.Start > offset)
+                    {
+                        m.StartWith(this, offset);
+                    }
+                    if (m.Tail == this && m.End > offset)
+                    {
+                        m.EndWith(this, offset);
+                    }
+                }
             }
 
             return newNode;


### PR DESCRIPTION
# Types of Changes

## Prerequisites

Please make sure you can check the following two boxes:

- [x] I have read the **CONTRIBUTING** document
- [x] My code follows the code style of this project

## Contribution Type

What types of changes does your code introduce? Put an `x` in all the boxes that apply:

- [ ] Bug fix (non-breaking change which fixes an issue, please reference the issue id)
- [ ] New feature (non-breaking change which adds functionality, make sure to open an associated issue first)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] My change requires a change to the documentation
- [ ] I have updated the documentation accordingly
- [ ] I have added tests to cover my changes
- [x] All new and existing tests passed

## Description

`ForEachRange` was a bit of an anti-pattern as it led into doing loops against collections multiple times just to do separate things based on predicate. Switched to single loop that checks condition and executes the logic. 

I'll happily add performance results if you can give a description how you want them done.
