### PR TITLE
Remove reflection use in DefaultHttpRequester

### DIFF
--- a/src/AngleSharp/Css/Parser/CssSelectorConstructor.cs
+++ b/src/AngleSharp/Css/Parser/CssSelectorConstructor.cs
@@ -322,7 +322,7 @@ namespace AngleSharp.Css.Parser
 
         private void OnAttributeEnd(CssSelectorToken token)
         {
-            if (!_attrInsensitive && token.Type == CssTokenType.Ident && token.Data == "i")
+            if (!_attrInsensitive && token.Type == CssTokenType.Ident && token.Data is "i")
             {
                 _attrInsensitive = true;
             }
@@ -1071,13 +1071,12 @@ namespace AngleSharp.Css.Parser
                 }
                 else if (token.Type == CssTokenType.Delim && token.Data.IsOneOf("+", "-"))
                 {
-                    _sign = token.Data == "-" ? -1 : +1;
+                    _sign = token.Data is "-" ? -1 : +1;
                     _state = ParseState.AfterInitialSign;
                     return false;
                 }
 
                 return OnAfterInitialSign(token);
-
             }
 
             private enum ParseState : byte

--- a/src/AngleSharp/Io/RequesterExtensions.cs
+++ b/src/AngleSharp/Io/RequesterExtensions.cs
@@ -45,7 +45,7 @@ namespace AngleSharp.Io
             var setting = cors.Setting;
             var url = request.Target;
 
-            if (request.Origin == url.Origin || url.Scheme == ProtocolNames.Data || url.Href == "about:blank")
+            if (request.Origin == url.Origin || url.Scheme == ProtocolNames.Data || url.Href is "about:blank")
             {
                 return loader.FetchFromSameOriginAsync(url, cors);
             }


### PR DESCRIPTION
# Types of Changes

This PR removes the use of reflection in DefaultHttpRequester now that we've dropped support for profile78.

## Prerequisites

Please make sure you can check the following two boxes:

- [x] I have read the **CONTRIBUTING** document
- [x] My code follows the code style of this project

## Contribution Type

What types of changes does your code introduce? Put an `x` in all the boxes that apply:

- [ ] Bug fix (non-breaking change which fixes an issue, please reference the issue id)
- [ ] New feature (non-breaking change which adds functionality, make sure to open an associated issue first)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] My change requires a change to the documentation
- [ ] I have updated the documentation accordingly
- [ ] I have added tests to cover my changes
- [x] All new and existing tests passed
