### PR TITLE
Update test runtime to netcoreapp3.1

### DIFF
--- a/src/AngleSharp.Core.Tests/AngleSharp.Core.Tests.csproj
+++ b/src/AngleSharp.Core.Tests/AngleSharp.Core.Tests.csproj
@@ -1,10 +1,10 @@
 <Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
-    <TargetFrameworks>netcoreapp2.1</TargetFrameworks>
+    <TargetFrameworks>netcoreapp3.1</TargetFrameworks>
     <SignAssembly>true</SignAssembly>
     <AssemblyOriginatorKeyFile>Key.snk</AssemblyOriginatorKeyFile>
     <IsPackable>false</IsPackable>
-    <LangVersion>7.1</LangVersion>
+    <LangVersion>9</LangVersion>
     <AssemblyName>AngleSharp.Core.Tests</AssemblyName>
     <CopyLocalLockFileAssemblies>true</CopyLocalLockFileAssemblies> <!-- https://github.com/Tyrrrz/GitHubActionsTestLogger/issues/5 -->
   </PropertyGroup>


### PR DESCRIPTION
Checking if there are additional changes we need to make to CI to update the testing runtime to netcoreapp3.1.

## Prerequisites

- [x] I have read the **CONTRIBUTING** document
- [x] My code follows the code style of this project

## Contribution Type

- [x] All new and existing tests passed
