### PR TITLE
Reduce allocations + add new mime types

### DIFF
--- a/src/AngleSharp.Core.Tests/Io/MimeTypeNameTests.cs
+++ b/src/AngleSharp.Core.Tests/Io/MimeTypeNameTests.cs
@@ -1,0 +1,21 @@
+namespace AngleSharp.Core.Tests.Io
+{
+    using AngleSharp.Io;
+    using NUnit.Framework;
+
+    [TestFixture]
+    public class MimeTypeNameTests
+    {
+        [Test]
+        public void CommonMimeTypesAreCorrectlyDefined()
+        {
+            Assert.AreEqual("image/avif", MimeTypeNames.FromExtension(".avif"));
+            Assert.AreEqual("image/gif", MimeTypeNames.FromExtension(".gif"));
+            Assert.AreEqual("image/jpeg", MimeTypeNames.FromExtension(".jpeg"));
+            Assert.AreEqual("image/jpeg", MimeTypeNames.FromExtension(".jpg"));
+            Assert.AreEqual("image/png", MimeTypeNames.FromExtension(".png"));
+            Assert.AreEqual("image/svg+xml", MimeTypeNames.FromExtension(".svg"));
+            Assert.AreEqual("image/webp", MimeTypeNames.FromExtension(".webp"));
+        }
+    }
+}

--- a/src/AngleSharp.Core.Tests/Io/MimeTypeNameTests.cs
+++ b/src/AngleSharp.Core.Tests/Io/MimeTypeNameTests.cs
@@ -9,6 +9,7 @@ namespace AngleSharp.Core.Tests.Io
         [Test]
         public void CommonMimeTypesAreCorrectlyDefined()
         {
+            Assert.AreEqual("image/apng", MimeTypeNames.FromExtension(".apng"));
             Assert.AreEqual("image/avif", MimeTypeNames.FromExtension(".avif"));
             Assert.AreEqual("image/gif", MimeTypeNames.FromExtension(".gif"));
             Assert.AreEqual("image/jpeg", MimeTypeNames.FromExtension(".jpeg"));

--- a/src/AngleSharp.nuspec
+++ b/src/AngleSharp.nuspec
@@ -15,16 +15,20 @@
     <tags>html html5 css css3 xml dom dom4 parser engine hypertext markup language query selector attributes linq angle bracket web internet text headless browser</tags>
     <dependencies>
       <group targetFramework="netstandard2.0">
+        <dependency id="System.Buffers" version="4.5.1" />
         <dependency id="System.Text.Encoding.CodePages" version="5.0.0" />
       </group>
       <group targetFramework="net46">
+        <dependency id="System.Buffers" version="4.5.1" />
         <dependency id="System.Text.Encoding.CodePages" version="5.0.0" />
       </group>
       <group targetFramework="net461">
+        <dependency id="System.Buffers" version="4.5.1" />
         <dependency id="System.Text.Encoding.CodePages" version="5.0.0" />
       </group>
       <group targetFramework="net472">
-          <dependency id="System.Text.Encoding.CodePages" version="5.0.0" />
+        <dependency id="System.Buffers" version="4.5.1" />
+        <dependency id="System.Text.Encoding.CodePages" version="5.0.0" />
       </group>
     </dependencies>
   </metadata>

--- a/src/AngleSharp/AngleSharp.Core.csproj
+++ b/src/AngleSharp/AngleSharp.Core.csproj
@@ -25,6 +25,7 @@
 
   <ItemGroup>
     <PackageReference Include="System.Text.Encoding.CodePages" Version="5.0.0" />
+    <PackageReference Include="System.Buffers" Version="4.5.1" />
   </ItemGroup>
 
   <PropertyGroup Condition=" '$(OS)' == 'Windows_NT' ">

--- a/src/AngleSharp/Common/BaseTokenizer.cs
+++ b/src/AngleSharp/Common/BaseTokenizer.cs
@@ -115,7 +115,7 @@ namespace AngleSharp.Common
             {
                 var disposable = _source as IDisposable;
                 disposable?.Dispose();
-                StringBuffer!.Clear().ToPool();
+                StringBuffer!.Clear().ReturnToPool();
                 _buffer = null!;
             }
         }

--- a/src/AngleSharp/Css/Parser/CssTokenizer.cs
+++ b/src/AngleSharp/Css/Parser/CssTokenizer.cs
@@ -1,4 +1,4 @@
-﻿namespace AngleSharp.Css.Parser
+namespace AngleSharp.Css.Parser
 {
     using AngleSharp.Common;
     using AngleSharp.Text;
@@ -622,7 +622,7 @@
         {
             while (true)
             {
-                if (current.IsOneOf(Symbols.Plus, Symbols.Minus))
+                if (current is Symbols.Plus or Symbols.Minus)
                 {
                     var buffer = StringBuilderPool.Obtain();
                     buffer.Append(current);
@@ -921,12 +921,12 @@
                 {
                     return UrlEnd();
                 }
-                else if (current.IsOneOf(Symbols.RoundBracketClose, Symbols.EndOfFile))
+                else if (current is Symbols.RoundBracketClose or Symbols.EndOfFile)
                 {
                     _source.Next();
                     return NewInvalid();
                 }
-                else if (current.IsOneOf(Symbols.DoubleQuote, Symbols.SingleQuote, Symbols.RoundBracketOpen) || current.IsNonPrintable())
+                else if (current is Symbols.DoubleQuote or Symbols.SingleQuote or Symbols.RoundBracketOpen || current.IsNonPrintable())
                 {
                     return UrlBad();
                 }

--- a/src/AngleSharp/Dom/ElementExtensions.cs
+++ b/src/AngleSharp/Dom/ElementExtensions.cs
@@ -399,7 +399,7 @@ namespace AngleSharp.Dom
             {
                 var type = inputElement.Type;
 
-                if (type == InputTypeNames.Submit || type == InputTypeNames.Image)
+                if (type.IsOneOf(InputTypeNames.Submit, InputTypeNames.Image))
                 {
                     var form = inputElement.Form;
 

--- a/src/AngleSharp/Dom/Internal/CharacterData.cs
+++ b/src/AngleSharp/Dom/Internal/CharacterData.cs
@@ -1,7 +1,6 @@
 namespace AngleSharp.Dom
 {
     using System;
-    using System.IO;
 
     /// <summary>
     /// The base class for all characterdata implementations.
@@ -47,9 +46,9 @@ namespace AngleSharp.Dom
                         {
                             found = true;
                         }
-                        else if (found && parent.ChildNodes[i] is IElement)
+                        else if (found && parent.ChildNodes[i] is IElement childEl)
                         {
-                            return (IElement)parent.ChildNodes[i];
+                            return childEl;
                         }
                     }
                 }

--- a/src/AngleSharp/Dom/Internal/Node.cs
+++ b/src/AngleSharp/Dom/Internal/Node.cs
@@ -381,7 +381,7 @@ namespace AngleSharp.Dom
             NodeIsRemoved(node, oldPreviousSibling);
         }
 
-        internal INode ReplaceChild(Node node, Node child, Boolean suppressObservers)
+        internal Node ReplaceChild(Node node, Node child, Boolean suppressObservers)
         {
             if (this.IsEndPoint() || node.IsHostIncludingInclusiveAncestor(this))
                 throw new DomException(DomError.HierarchyRequest);
@@ -735,7 +735,7 @@ namespace AngleSharp.Dom
 
         #region Helpers
 
-        private static Boolean IsChangeForbidden(Node node, IDocument parent, INode child)
+        private static Boolean IsChangeForbidden(Node node, IDocument parent, Node child)
         {
             switch (node._type)
             {

--- a/src/AngleSharp/Dom/Internal/Range.cs
+++ b/src/AngleSharp/Dom/Internal/Range.cs
@@ -21,8 +21,8 @@ namespace AngleSharp.Dom
 
         public Range(IDocument document)
         {
-            _start = new Boundary { Offset = 0, Node = document };
-            _end = new Boundary { Offset = 0, Node = document };
+            _start = new Boundary(document, 0);
+            _end = new Boundary(document, 0);
         }
 
         private Range(Boundary start, Boundary end)
@@ -79,7 +79,7 @@ namespace AngleSharp.Dom
             if (offset > refNode.ChildNodes.Length)
                 throw new DomException(DomError.IndexSizeError);
 
-            var bp = new Boundary { Node = refNode, Offset = offset };
+            var bp = new Boundary(refNode, offset);
 
             if (bp > _end || Root != refNode.GetRoot())
             {
@@ -98,7 +98,7 @@ namespace AngleSharp.Dom
             if (offset > refNode.ChildNodes.Length)
                 throw new DomException(DomError.IndexSizeError);
 
-            var bp = new Boundary { Node = refNode, Offset = offset };
+            var bp = new Boundary(refNode, offset);
 
             if (bp < _start || Root != refNode.GetRoot())
             {
@@ -116,7 +116,7 @@ namespace AngleSharp.Dom
             if (parent is null)
                 throw new DomException(DomError.InvalidNodeType);
 
-            _start = new Boundary { Node = parent, Offset = parent.ChildNodes.Index(refNode) };
+            _start = new Boundary(parent, parent.ChildNodes.Index(refNode));
         }
 
         public void EndBefore(INode refNode)
@@ -129,7 +129,7 @@ namespace AngleSharp.Dom
             if (parent is null)
                 throw new DomException(DomError.InvalidNodeType);
 
-            _end = new Boundary { Node = parent, Offset = parent.ChildNodes.Index(refNode) };
+            _end = new Boundary(parent, parent.ChildNodes.Index(refNode));
         }
 
         public void StartAfter(INode refNode)
@@ -142,7 +142,7 @@ namespace AngleSharp.Dom
             if (parent is null)
                 throw new DomException(DomError.InvalidNodeType);
 
-            _start = new Boundary { Node = parent, Offset = parent.ChildNodes.Index(refNode) + 1 };
+            _start = new Boundary(parent, parent.ChildNodes.Index(refNode) + 1);
         }
 
         public void EndAfter(INode refNode)
@@ -155,7 +155,7 @@ namespace AngleSharp.Dom
             if (parent is null)
                 throw new DomException(DomError.InvalidNodeType);
 
-            _end = new Boundary { Node = parent, Offset = parent.ChildNodes.Index(refNode) + 1 };
+            _end = new Boundary(parent, parent.ChildNodes.Index(refNode) + 1);
         }
 
         public void Collapse(Boolean toStart)
@@ -181,8 +181,8 @@ namespace AngleSharp.Dom
                 throw new DomException(DomError.InvalidNodeType);
 
             var index = parent.ChildNodes.Index(refNode);
-            _start = new Boundary { Node = parent, Offset = index };
-            _end = new Boundary { Node = parent, Offset = index + 1 };
+            _start = new Boundary(parent, index);
+            _end = new Boundary(parent, index + 1);
         }
 
         public void SelectContent(INode refNode)
@@ -194,8 +194,8 @@ namespace AngleSharp.Dom
                 throw new DomException(DomError.InvalidNodeType);
 
             var length = refNode.ChildNodes.Length;
-            _start = new Boundary { Node = refNode, Offset = 0 };
-            _end = new Boundary { Node = refNode, Offset = length };
+            _start = new Boundary(refNode, 0);
+            _end = new Boundary(refNode, length);
         }
 
         public void ClearContent()
@@ -226,7 +226,7 @@ namespace AngleSharp.Dom
                             referenceNode = referenceNode.Parent;
                         }
 
-                        newBoundary = new Boundary { Node = referenceNode.Parent!, Offset = referenceNode.Parent!.ChildNodes.Index(referenceNode) + 1 };
+                        newBoundary = new Boundary(referenceNode.Parent!, referenceNode.Parent!.ChildNodes.Index(referenceNode) + 1);
                     }
                     else
                     {
@@ -307,7 +307,7 @@ namespace AngleSharp.Dom
                             referenceNode = referenceNode.Parent;
                         }
 
-                        newBoundary = new Boundary { Node = referenceNode, Offset = referenceNode.Parent!.ChildNodes.Index(referenceNode) + 1 };
+                        newBoundary = new Boundary(referenceNode, referenceNode.Parent!.ChildNodes.Index(referenceNode) + 1);
                     }
 
                     if (firstPartiallyContainedChild is ICharacterData)
@@ -324,7 +324,7 @@ namespace AngleSharp.Dom
                     {
                         var clone = firstPartiallyContainedChild.Clone();
                         fragment.AppendChild(clone);
-                        var subrange = new Range(originalStart, new Boundary { Node = firstPartiallyContainedChild, Offset = firstPartiallyContainedChild.ChildNodes.Length });
+                        var subrange = new Range(originalStart, new Boundary(firstPartiallyContainedChild, firstPartiallyContainedChild.ChildNodes.Length));
                         var subfragment = subrange.ExtractContent();
                         fragment.AppendChild(subfragment);
                     }
@@ -346,7 +346,7 @@ namespace AngleSharp.Dom
                     {
                         var clone = lastPartiallyContainedchild.Clone();
                         fragment.AppendChild(clone);
-                        var subrange = new Range(new Boundary { Node = lastPartiallyContainedchild, Offset = 0 }, originalEnd);
+                        var subrange = new Range(new Boundary(lastPartiallyContainedchild, 0), originalEnd);
                         var subfragment = subrange.ExtractContent();
                         fragment.AppendChild(subfragment);
                     }
@@ -409,7 +409,7 @@ namespace AngleSharp.Dom
                     {
                         var clone = firstPartiallyContainedChild.Clone();
                         fragment.AppendChild(clone);
-                        var subrange = new Range(originalStart, new Boundary { Node = firstPartiallyContainedChild, Offset = firstPartiallyContainedChild.ChildNodes.Length });
+                        var subrange = new Range(originalStart, new Boundary(firstPartiallyContainedChild, firstPartiallyContainedChild.ChildNodes.Length));
                         var subfragment = subrange.CopyContent();
                         fragment.AppendChild(subfragment);
                     }
@@ -430,7 +430,7 @@ namespace AngleSharp.Dom
                     {
                         var clone = lastPartiallyContainedchild.Clone();
                         fragment.AppendChild(clone);
-                        var subrange = new Range(new Boundary { Node = lastPartiallyContainedchild, Offset = 0 }, originalEnd);
+                        var subrange = new Range(new Boundary(lastPartiallyContainedchild, 0), originalEnd);
                         var subfragment = subrange.CopyContent();
                         fragment.AppendChild(subfragment);
                     }
@@ -474,7 +474,7 @@ namespace AngleSharp.Dom
 
             if (_start.Equals(_end))
             {
-                _end = new Boundary { Node = parent, Offset = newOffset };
+                _end = new Boundary(parent, newOffset);
             }
         }
 
@@ -547,22 +547,22 @@ namespace AngleSharp.Dom
             {
                 case RangeType.StartToStart:
                     thisPoint = _start;
-                    otherPoint = new Boundary { Node = sourceRange.Head, Offset = sourceRange.Start };
+                    otherPoint = new Boundary(sourceRange.Head, sourceRange.Start);
                     break;
 
                 case RangeType.StartToEnd:
                     thisPoint = _end;
-                    otherPoint = new Boundary { Node = sourceRange.Head, Offset = sourceRange.Start };
+                    otherPoint = new Boundary(sourceRange.Head, sourceRange.Start);
                     break;
 
                 case RangeType.EndToEnd:
                     thisPoint = _start;
-                    otherPoint = new Boundary { Node = sourceRange.Tail, Offset = sourceRange.End };
+                    otherPoint = new Boundary(sourceRange.Tail, sourceRange.End);
                     break;
 
                 case RangeType.EndToStart:
                     thisPoint = _end;
-                    otherPoint = new Boundary { Node = sourceRange.Tail, Offset = sourceRange.End };
+                    otherPoint = new Boundary(sourceRange.Tail, sourceRange.End);
                     break;
 
                 default:
@@ -660,22 +660,22 @@ namespace AngleSharp.Dom
 
         private Boolean IsStartBefore(INode node, Int32 offset)
         {
-            return _start < new Boundary { Node = node, Offset = offset };
+            return _start < new Boundary(node, offset);
         }
 
         private Boolean IsStartAfter(INode node, Int32 offset)
         {
-            return _start > new Boundary { Node = node, Offset = offset };
+            return _start > new Boundary(node, offset);
         }
 
         private Boolean IsEndBefore(INode node, Int32 offset)
         {
-            return _end < new Boundary { Node = node, Offset = offset };
+            return _end < new Boundary(node, offset);
         }
 
         private Boolean IsEndAfter(INode node, Int32 offset)
         {
-            return _end > new Boundary { Node = node, Offset = offset };
+            return _end > new Boundary(node, offset);
         }
 
         private Boolean IsPartiallyContained(INode node)
@@ -690,10 +690,16 @@ namespace AngleSharp.Dom
 
         #region Boundary
 
-        private struct Boundary : IEquatable<Boundary>
+        private readonly struct Boundary : IEquatable<Boundary>
         {
-            public INode Node;
-            public Int32 Offset;
+            public Boundary(INode node, Int32 offset)
+            {
+                Node = node;
+                Offset = offset;
+            }
+
+            public readonly INode Node;
+            public readonly Int32 Offset;
 
             public static Boolean operator >(Boundary a, Boundary b)
             {

--- a/src/AngleSharp/Dom/Internal/Range.cs
+++ b/src/AngleSharp/Dom/Internal/Range.cs
@@ -4,6 +4,7 @@ namespace AngleSharp.Dom
     using System;
     using System.Collections.Generic;
     using System.Linq;
+    using System.Text;
 
     /// <summary>
     /// A DOM range to gather DOM tree information.
@@ -621,20 +622,25 @@ namespace AngleSharp.Dom
 
         public override String ToString()
         {
-            var s = StringBuilderPool.Obtain();
+            var sb = default(StringBuilder);
             var offset = Start;
             var dest = End;
-            var startText = Head as IText;
-            var endText = Tail as IText;
 
-            if (startText != null && Head == Tail)
+            if (Head is IText startText)
             {
-                return startText.Substring(offset, dest - offset);
+                if (Head == Tail)
+                {
+                    return startText.Substring(offset, dest - offset);
+                }
+                else
+                {
+                    sb ??= StringBuilderPool.Obtain();
+
+                    sb.Append(startText.Substring(offset, startText.Length - offset));
+                }
             }
-            else if (startText != null)
-            {
-                s.Append(startText.Substring(offset, startText.Length - offset));
-            }
+
+            sb ??= StringBuilderPool.Obtain();
 
             var nodes = CommonAncestor.Descendents<IText>();
 
@@ -642,16 +648,16 @@ namespace AngleSharp.Dom
             {
                 if (IsStartBefore(node, 0) && IsEndAfter(node, node.Length))
                 {
-                    s.Append(node.Text);
+                    sb.Append(node.Text);
                 }
             }
 
-            if (endText != null)
+            if (Tail is IText endText)
             {
-                s.Append(endText.Substring(0, dest));
+                sb.Append(endText.Substring(0, dest));
             }
 
-            return s.ToPool();
+            return sb.ToPool();
         }
 
         #endregion

--- a/src/AngleSharp/Html/Dom/Internal/HtmlInputElement.cs
+++ b/src/AngleSharp/Html/Dom/Internal/HtmlInputElement.cs
@@ -45,7 +45,7 @@ namespace AngleSharp.Html.Dom
 
         public Boolean IsChecked
         {
-            get => _checked.HasValue ? _checked.Value : IsDefaultChecked;
+            get => _checked ?? IsDefaultChecked;
             set => _checked = value;
         }
 

--- a/src/AngleSharp/Html/Dom/Internal/HtmlOptionElement.cs
+++ b/src/AngleSharp/Html/Dom/Internal/HtmlOptionElement.cs
@@ -84,7 +84,7 @@ namespace AngleSharp.Html.Dom
 
         public Boolean IsSelected
         {
-            get => _selected.HasValue ? _selected.Value : IsDefaultSelected;
+            get => _selected ?? IsDefaultSelected;
             set => _selected = value;
         }
 

--- a/src/AngleSharp/Html/Dom/Internal/HtmlScriptElement.cs
+++ b/src/AngleSharp/Html/Dom/Internal/HtmlScriptElement.cs
@@ -3,6 +3,8 @@ namespace AngleSharp.Html.Dom
     using AngleSharp.Dom;
     using AngleSharp.Io;
     using AngleSharp.Io.Processors;
+    using AngleSharp.Text;
+
     using System;
     using System.Threading;
     using System.Threading.Tasks;
@@ -164,8 +166,8 @@ namespace AngleSharp.Html.Dom
                     eventAttr = eventAttr.Substring(0, eventAttr.Length - 2);
                 }
 
-                var isWindow = forAttr.Equals(AttributeNames.Window, StringComparison.OrdinalIgnoreCase);
-                var isLoadEvent = eventAttr.Equals("onload", StringComparison.OrdinalIgnoreCase);
+                var isWindow = forAttr.Isi(AttributeNames.Window);
+                var isLoadEvent = eventAttr.Isi("onload");
 
                 if (!isWindow || !isLoadEvent)
                 {

--- a/src/AngleSharp/Html/MinifyMarkupFormatter.cs
+++ b/src/AngleSharp/Html/MinifyMarkupFormatter.cs
@@ -106,6 +106,8 @@ namespace AngleSharp.Html
                         return sb.ToPool();
                     }
 
+                    _= sb.ToPool();
+
                     return String.Empty;
                 }
 

--- a/src/AngleSharp/Html/MinifyMarkupFormatter.cs
+++ b/src/AngleSharp/Html/MinifyMarkupFormatter.cs
@@ -106,7 +106,7 @@ namespace AngleSharp.Html
                         return sb.ToPool();
                     }
 
-                    _= sb.ToPool();
+                    sb.ReturnToPool();
 
                     return String.Empty;
                 }

--- a/src/AngleSharp/Io/DefaultHttpRequester.cs
+++ b/src/AngleSharp/Io/DefaultHttpRequester.cs
@@ -223,8 +223,8 @@ namespace AngleSharp.Io
                 if (_serverString is null)
                 {
                     var methods = typeof(Cookie).GetMethods();
-                    var func = methods.FirstOrDefault(m => m.Name.Equals("ToServerString"));
-                    _serverString = func ?? methods.FirstOrDefault(m => m.Name.Equals("ToString"));
+                    var func = methods.FirstOrDefault(m => m.Name.Is("ToServerString"));
+                    _serverString = func ?? methods.FirstOrDefault(m => m.Name.Is("ToString"));
                 }
 
                 return _serverString.Invoke(cookie, null).ToString();

--- a/src/AngleSharp/Io/MimeTypeNames.cs
+++ b/src/AngleSharp/Io/MimeTypeNames.cs
@@ -65,6 +65,8 @@ namespace AngleSharp.Io
             { ".asx", "application/x-mplayer2" },
             { ".au", "audio/basic" },
             { ".avi", "video/avi" },
+            { ".avif", "image/avif" },
+            { ".avifs", "image/avif-sequence" },
             { ".avs", "video/avs-video" },
             { ".bcpio", "application/x-bcpio" },
             { ".bin", "application/octet-stream" },

--- a/src/AngleSharp/Io/MimeTypeNames.cs
+++ b/src/AngleSharp/Io/MimeTypeNames.cs
@@ -55,6 +55,7 @@ namespace AngleSharp.Io
             { ".aip", "text/x-audiosoft-intra" },
             { ".ani", "application/x-navi-animation" },
             { ".aos", "application/x-nokia-9000-communicator-add-on-software" },
+            { ".apng", "image/apng" },
             { ".aps", "application/mime" },
             { ".arc", "application/octet-stream" },
             { ".arj", "application/arj" },

--- a/src/AngleSharp/Io/MimeTypeNames.cs
+++ b/src/AngleSharp/Io/MimeTypeNames.cs
@@ -36,7 +36,7 @@ namespace AngleSharp.Io
 
         #region Map File extensions to Mime types
 
-        private static Dictionary<String, String> Extensions = new Dictionary<String, String>(StringComparer.OrdinalIgnoreCase)
+        private static readonly Dictionary<String, String> Extensions = new Dictionary<String, String>(StringComparer.OrdinalIgnoreCase)
         {
             { ".3dm", "x-world/x-3dmf" },
             { ".3dmf", "x-world/x-3dmf" },
@@ -380,6 +380,7 @@ namespace AngleSharp.Io
             { ".sv4cpio", "application/x-sv4cpio" },
             { ".sv4crc", "application/x-sv4crc" },
             { ".svf", "image/vnd.dwg" },
+            { ".svg", "image/svg+xml" },
             { ".swf", "application/x-shockwave-flash" },
             { ".t", "application/x-troff" },
             { ".talk", "text/x-speech" },
@@ -436,6 +437,7 @@ namespace AngleSharp.Io
             { ".wb1", "application/x-qpro" },
             { ".wbmp", "image/vnd.wap.wbmp" },
             { ".web", "application/vnd.xara" },
+            { ".webp", "image/webp" },
             { ".wiz", "application/msword" },
             { ".wk1", "application/x-123" },
             { ".wmf", "windows/metafile" },

--- a/src/AngleSharp/Text/CharExtensions.cs
+++ b/src/AngleSharp/Text/CharExtensions.cs
@@ -280,47 +280,5 @@ namespace AngleSharp.Text
         {
             return c == 0 || c > Symbols.MaximumCodepoint || (c > 0xD800 && c < 0xDFFF);
         }
-
-        /// <summary>
-        /// Determines if the given character is one of the two others.
-        /// </summary>
-        /// <param name="c">The character to test.</param>
-        /// <param name="a">The first option.</param>
-        /// <param name="b">The second option.</param>
-        /// <returns>The result of the test.</returns>
-        [MethodImpl(MethodImplOptions.AggressiveInlining)]
-        public static Boolean IsOneOf(this Char c, Char a, Char b)
-        {
-            return a == c || b == c;
-        }
-
-        /// <summary>
-        /// Determines if the given character is one of the three others.
-        /// </summary>
-        /// <param name="c">The character to test.</param>
-        /// <param name="o1">The first option.</param>
-        /// <param name="o2">The second option.</param>
-        /// <param name="o3">The third option.</param>
-        /// <returns>The result of the test.</returns>
-        [MethodImpl(MethodImplOptions.AggressiveInlining)]
-        public static Boolean IsOneOf(this Char c, Char o1, Char o2, Char o3)
-        {
-            return c == o1 || c == o2 || c == o3;
-        }
-
-        /// <summary>
-        /// Determines if the given character is one of the four others.
-        /// </summary>
-        /// <param name="c">The character to test.</param>
-        /// <param name="o1">The first option.</param>
-        /// <param name="o2">The second option.</param>
-        /// <param name="o3">The third option.</param>
-        /// <param name="o4">The fourth option.</param>
-        /// <returns>The result of the test.</returns>
-        [MethodImpl(MethodImplOptions.AggressiveInlining)]
-        public static Boolean IsOneOf(this Char c, Char o1, Char o2, Char o3, Char o4)
-        {
-            return c == o1 || c == o2 || c == o3 || c == o4;
-        }
     }
 }

--- a/src/AngleSharp/Text/CharExtensions.cs
+++ b/src/AngleSharp/Text/CharExtensions.cs
@@ -280,5 +280,50 @@ namespace AngleSharp.Text
         {
             return c == 0 || c > Symbols.MaximumCodepoint || (c > 0xD800 && c < 0xDFFF);
         }
+
+        /// <summary>
+        /// Determines if the given character is one of the two others.
+        /// </summary>
+        /// <param name="c">The character to test.</param>
+        /// <param name="a">The first option.</param>
+        /// <param name="b">The second option.</param>
+        /// <returns>The result of the test.</returns>
+        [Obsolete("Use pattern matching instead. This will be removed from a future release.")]
+        [MethodImpl(MethodImplOptions.AggressiveInlining)]
+        public static Boolean IsOneOf(this Char c, Char a, Char b)
+        {
+            return a == c || b == c;
+        }
+
+        /// <summary>
+        /// Determines if the given character is one of the three others.
+        /// </summary>
+        /// <param name="c">The character to test.</param>
+        /// <param name="o1">The first option.</param>
+        /// <param name="o2">The second option.</param>
+        /// <param name="o3">The third option.</param>
+        /// <returns>The result of the test.</returns>
+        [Obsolete("Use pattern matching instead. This will be removed from a future release.")]
+        [MethodImpl(MethodImplOptions.AggressiveInlining)]
+        public static Boolean IsOneOf(this Char c, Char o1, Char o2, Char o3)
+        {
+            return c == o1 || c == o2 || c == o3;
+        }
+
+        /// <summary>
+        /// Determines if the given character is one of the four others.
+        /// </summary>
+        /// <param name="c">The character to test.</param>
+        /// <param name="o1">The first option.</param>
+        /// <param name="o2">The second option.</param>
+        /// <param name="o3">The third option.</param>
+        /// <param name="o4">The fourth option.</param>
+        /// <returns>The result of the test.</returns>
+        [Obsolete("Use pattern matching instead. This will be removed from a future release.")]
+        [MethodImpl(MethodImplOptions.AggressiveInlining)]
+        public static Boolean IsOneOf(this Char c, Char o1, Char o2, Char o3, Char o4)
+        {
+            return c == o1 || c == o2 || c == o3 || c == o4;
+        }
     }
 }

--- a/src/AngleSharp/Text/Punycode.cs
+++ b/src/AngleSharp/Text/Punycode.cs
@@ -170,7 +170,7 @@ namespace AngleSharp.Text
                 else
                 {
                     // If it has some non-basic code points the input cannot start with xn--
-                    if (text.Length - iAfterLastDot >= acePrefix.Length && text.Substring(iAfterLastDot, acePrefix.Length).Equals(acePrefix, StringComparison.OrdinalIgnoreCase))
+                    if (text.Length - iAfterLastDot >= acePrefix.Length && text.Substring(iAfterLastDot, acePrefix.Length).Isi(acePrefix))
                     {
                         break;
                     }

--- a/src/AngleSharp/Text/StringBuilderPool.cs
+++ b/src/AngleSharp/Text/StringBuilderPool.cs
@@ -1,4 +1,4 @@
-﻿namespace AngleSharp.Text
+namespace AngleSharp.Text
 {
     using System;
     using System.Collections.Generic;
@@ -78,6 +78,31 @@
             }
 
             return result;
+        }
+
+        /// <summary>
+        /// Returns the given stringbuilder to the pool.
+        /// </summary>
+        /// <param name="sb">The stringbuilder to recycle.</param>
+        internal static void ReturnToPool(this StringBuilder sb)
+        {
+            lock (_lock)
+            {
+                var current = _builder.Count;
+
+                if (sb.Capacity > _limit)
+                {
+                    // Drop large instances
+                }
+                else if (current == _count)
+                {
+                    DropMinimum(sb);
+                }
+                else if (current < Math.Min(2, _count) || _builder.Peek().Capacity < sb.Capacity)
+                {
+                    _builder.Push(sb);
+                }
+            }
         }
 
         private static void DropMinimum(StringBuilder sb)

--- a/src/AngleSharp/Text/StringExtensions.cs
+++ b/src/AngleSharp/Text/StringExtensions.cs
@@ -648,7 +648,11 @@ namespace AngleSharp.Text
                     var character = value[i];
 
                     if (character == Symbols.Null)
+                    {
+                        builder.ReturnToPool();
+
                         throw new DomException(DomError.InvalidCharacter);
+                    }
 
                     if (character == Symbols.DoubleQuote || character == Symbols.ReverseSolidus)
                     {

--- a/src/AngleSharp/Text/StringExtensions.cs
+++ b/src/AngleSharp/Text/StringExtensions.cs
@@ -316,7 +316,7 @@ namespace AngleSharp.Text
                 }
             }
 
-            return StringBuilderPool.ToPool(sb);
+            return sb.ToPool();
         }
 
         /// <summary>

--- a/src/AngleSharp/Text/StringExtensions.cs
+++ b/src/AngleSharp/Text/StringExtensions.cs
@@ -442,7 +442,7 @@ namespace AngleSharp.Text
         /// <summary>
         /// Strips all leading and trailing space characters from the given char array.
         /// </summary>
-        /// <param name="str">The array of characters to examine.</param>
+        /// <param name="str">The string to examine.</param>
         /// <returns>A new string, which excludes the leading and tailing spaces.</returns>
         [MethodImpl(MethodImplOptions.AggressiveInlining)]
         public static String StripLeadingTrailingSpaces(this string str)

--- a/src/AngleSharp/Text/StringExtensions.cs
+++ b/src/AngleSharp/Text/StringExtensions.cs
@@ -6,6 +6,7 @@ namespace AngleSharp.Text
     using AngleSharp.Html;
     using AngleSharp.Io;
     using System;
+    using System.Buffers;
     using System.Collections.Generic;
     using System.Diagnostics.CodeAnalysis;
     using System.Globalization;
@@ -251,7 +252,10 @@ namespace AngleSharp.Text
         /// <returns>The modified string with collapsed and stripped spaces.</returns>
         public static String CollapseAndStrip(this String str)
         {
-            var chars = new Char[str.Length];
+            if (str.Length == 0) return str;
+
+            var buffer = ArrayPool<Char>.Shared.Rent(str.Length);
+
             var hasSpace = true;
             var index = 0;
 
@@ -262,13 +266,13 @@ namespace AngleSharp.Text
                     if (!hasSpace)
                     {
                         hasSpace = true;
-                        chars[index++] = Symbols.Space;
+                        buffer[index++] = Symbols.Space;
                     }
                 }
                 else
                 {
                     hasSpace = false;
-                    chars[index++] = str[i];
+                    buffer[index++] = str[i];
                 }
             }
 
@@ -277,7 +281,11 @@ namespace AngleSharp.Text
                 index--;
             }
 
-            return new String(chars, 0, index);
+            var result = new String(buffer, 0, index);
+
+            ArrayPool<char>.Shared.Return(buffer);
+
+            return result;
         }
 
         /// <summary>
@@ -432,75 +440,56 @@ namespace AngleSharp.Text
         }
 
         /// <summary>
-        /// Strips all leading and trailing space characters from the given string.
-        /// </summary>
-        /// <param name="str">The string to examine.</param>
-        /// <returns>A new string, which excludes the leading and tailing spaces.</returns>
-        [MethodImpl(MethodImplOptions.AggressiveInlining)]
-        public static String StripLeadingTrailingSpaces(this String str) =>
-            StripLeadingTrailingSpaces(str.ToCharArray());
-
-        /// <summary>
         /// Strips all leading and trailing space characters from the given char array.
         /// </summary>
-        /// <param name="array">The array of characters to examine.</param>
+        /// <param name="str">The array of characters to examine.</param>
         /// <returns>A new string, which excludes the leading and tailing spaces.</returns>
         [MethodImpl(MethodImplOptions.AggressiveInlining)]
-        public static String StripLeadingTrailingSpaces(this Char[] array)
+        public static String StripLeadingTrailingSpaces(this string str)
         {
             var start = 0;
-            var end = array.Length - 1;
+            var end = str.Length - 1;
 
-            while (start < array.Length && array[start].IsSpaceCharacter())
+            while (start < str.Length && str[start].IsSpaceCharacter())
             {
                 start++;
             }
 
-            while (end > start && array[end].IsSpaceCharacter())
+            while (end > start && str[end].IsSpaceCharacter())
             {
                 end--;
             }
 
-            return new String(array, start, 1 + end - start);
+            return str.Substring(start, 1 + end - start);
         }
-
-        /// <summary>
-        /// Splits the string with the given char delimiter.
-        /// </summary>
-        /// <param name="str">The string to examine.</param>
-        /// <param name="c">The delimiter character.</param>
-        /// <returns>The list of tokens.</returns>
-        [MethodImpl(MethodImplOptions.AggressiveInlining)]
-        public static String[] SplitWithoutTrimming(this String str, Char c) =>
-            SplitWithoutTrimming(str.ToCharArray(), c);
 
         /// <summary>
         /// Splits the char array with the given char delimiter.
         /// </summary>
-        /// <param name="chars">The char array to examine.</param>
+        /// <param name="str">The string to examine.</param>
         /// <param name="c">The delimiter character.</param>
         /// <returns>The list of tokens.</returns>
-        public static String[] SplitWithoutTrimming(this Char[] chars, Char c)
+        public static String[] SplitWithoutTrimming(this string str, Char c)
         {
             var list = new List<String>();
             var index = 0;
 
-            for (var i = 0; i < chars.Length; i++)
+            for (var i = 0; i < str.Length; i++)
             {
-                if (chars[i] == c)
+                if (str[i] == c)
                 {
                     if (i > index)
                     {
-                        list.Add(new String(chars, index, i - index));
+                        list.Add(str.Substring(index, i - index));
                     }
 
                     index = i + 1;
                 }
             }
 
-            if (chars.Length > index)
+            if (str.Length > index)
             {
-                list.Add(new String(chars, index, chars.Length - index));
+                list.Add(str.Substring(index, str.Length - index));
             }
 
             return list.ToArray();
@@ -536,30 +525,34 @@ namespace AngleSharp.Text
         public static String[] SplitSpaces(this String str)
         {
             var list = new List<String>();
-            var buffer = new List<Char>();
-            var chars = str.ToCharArray();
+            var buffer = ArrayPool<Char>.Shared.Rent(str.Length);
+            int c = 0;
 
-            for (var i = 0; i <= chars.Length; i++)
+            for (var i = 0; i <= str.Length; i++)
             {
-                if (i == chars.Length || chars[i].IsSpaceCharacter())
+                if (i == str.Length || str[i].IsSpaceCharacter())
                 {
-                    if (buffer.Count > 0)
+                    if (c > 0)
                     {
-                        var token = buffer.ToArray().StripLeadingTrailingSpaces();
+                        var token = new String(buffer, 0, c).StripLeadingTrailingSpaces();
 
                         if (token.Length != 0)
                         {
                             list.Add(token);
                         }
 
-                        buffer.Clear();
+                        c = 0;
                     }
                 }
                 else
                 {
-                    buffer.Add(chars[i]);
+                    buffer[c] = str[i];
+
+                    c++;
                 }
             }
+
+            ArrayPool<char>.Shared.Return(buffer);
 
             return list.ToArray();
         }
@@ -568,35 +561,39 @@ namespace AngleSharp.Text
         /// Splits the string with the given char delimiter and trims the leading and tailing spaces.
         /// </summary>
         /// <param name="str">The string to examine.</param>
-        /// <param name="c">The delimiter character.</param>
+        /// <param name="ch">The delimiter character.</param>
         /// <returns>The list of tokens.</returns>
-        public static String[] SplitWithTrimming(this String str, Char c)
+        public static String[] SplitWithTrimming(this String str, Char ch)
         {
             var list = new List<String>();
-            var buffer = new List<Char>();
-            var chars = str.ToCharArray();
+            var buffer = ArrayPool<Char>.Shared.Rent(str.Length);
+            int c = 0;
 
-            for (var i = 0; i <= chars.Length; i++)
+            for (var i = 0; i <= str.Length; i++)
             {
-                if (i == chars.Length || chars[i] == c)
+                if (i == str.Length || str[i] == ch)
                 {
-                    if (buffer.Count > 0)
+                    if (c > 0)
                     {
-                        var token = buffer.ToArray().StripLeadingTrailingSpaces();
+                        var token = new String(buffer, 0, c).StripLeadingTrailingSpaces();
 
                         if (token.Length != 0)
                         {
                             list.Add(token);
                         }
 
-                        buffer.Clear();
+                        c = 0;                        
                     }
                 }
                 else
                 {
-                    buffer.Add(chars[i]);
+                    buffer[c] = str[i];
+
+                    c++;
                 }
             }
+
+            ArrayPool<char>.Shared.Return(buffer);
 
             return list.ToArray();
         }

--- a/src/AngleSharp/Text/TextSource.cs
+++ b/src/AngleSharp/Text/TextSource.cs
@@ -180,7 +180,7 @@ namespace AngleSharp.Text
             if (!isDisposed)
             {
                 _raw.Dispose();
-                _content!.Clear().ToPool();
+                _content!.Clear().ReturnToPool();
                 _content = null;
             }
         }

--- a/src/AngleSharp/Url.cs
+++ b/src/AngleSharp/Url.cs
@@ -1138,7 +1138,6 @@ namespace AngleSharp
             // https://anglesharp.github.io/Specification-Url/#host-parsing 3.5.5
             // domain to ASCII
             string domainToAscii;
-            var buffer = StringBuilderPool.Obtain();
 
             try
             {
@@ -1149,6 +1148,8 @@ namespace AngleSharp
                 sanatizedHostName = hostName.Substring(start, length);
                 return false;
             }
+
+            var buffer = StringBuilderPool.Obtain();
 
             // https://anglesharp.github.io/Specification-Url/#host-parsing 3.5.7
             // forbidden host code point check

--- a/src/AngleSharp/Url.cs
+++ b/src/AngleSharp/Url.cs
@@ -717,7 +717,7 @@ namespace AngleSharp
                 index++;
             }
 
-            buffer.ToPool();
+            buffer.ReturnToPool();
             return ParseHostName(input, start, length);
         }
 
@@ -973,7 +973,7 @@ namespace AngleSharp
                 index++;
             }
 
-            buffer.ToPool();
+            buffer.ReturnToPool();
             _path = String.Join("/", paths);
 
             if (index < length)
@@ -1172,7 +1172,7 @@ namespace AngleSharp
                     case Symbols.SquareBracketOpen:
                     case Symbols.SquareBracketClose:
                     case Symbols.ReverseSolidus:
-                        buffer.ToPool();
+                        buffer.ReturnToPool();
                         sanatizedHostName = hostName.Substring(start, length);
                         return false;
                     default:

--- a/src/AngleSharp/Url.cs
+++ b/src/AngleSharp/Url.cs
@@ -613,7 +613,7 @@ namespace AngleSharp
                         {
                             var c = input[++index];
 
-                            if (c.IsOneOf(Symbols.Solidus, Symbols.ReverseSolidus))
+                            if (c is Symbols.Solidus or Symbols.ReverseSolidus)
                             {
                                 if (_scheme.Is(ProtocolNames.File))
                                 {
@@ -635,8 +635,8 @@ namespace AngleSharp
                 }
 
                 if (input[index].IsLetter() && _scheme.Is(ProtocolNames.File) && index + 1 < length &&
-                   (input[index + 1].IsOneOf(Symbols.Colon, Symbols.Solidus)) &&
-                   (index + 2 == length || input[index + 2].IsOneOf(Symbols.Solidus, Symbols.ReverseSolidus, Symbols.Num, Symbols.QuestionMark)))
+                   (input[index + 1] is Symbols.Colon or Symbols.Solidus) &&
+                   (index + 2 == length || input[index + 2] is Symbols.Solidus or Symbols.ReverseSolidus or Symbols.Num or Symbols.QuestionMark))
                 {
                     _host = String.Empty;
                     _path = String.Empty;
@@ -653,7 +653,7 @@ namespace AngleSharp
         {
             while (index < length)
             {
-                if (!input[index].IsOneOf(Symbols.ReverseSolidus, Symbols.Solidus))
+                if (!(input[index] is Symbols.ReverseSolidus or Symbols.Solidus))
                 {
                     return ParseAuthority(input, index, length);
                 }
@@ -701,7 +701,7 @@ namespace AngleSharp
                 {
                     buffer.Append(input[index++]).Append(input[index++]).Append(input[index]);
                 }
-                else if (c.IsOneOf(Symbols.Solidus, Symbols.ReverseSolidus, Symbols.Num, Symbols.QuestionMark))
+                else if (c is Symbols.Solidus or Symbols.ReverseSolidus or Symbols.Num or Symbols.QuestionMark)
                 {
                     break;
                 }
@@ -730,7 +730,7 @@ namespace AngleSharp
             {
                 var c = input[index];
 
-                if (c == Symbols.Solidus || c == Symbols.ReverseSolidus || c == Symbols.Num || c == Symbols.QuestionMark)
+                if (c is Symbols.Solidus or Symbols.ReverseSolidus or Symbols.Num or Symbols.QuestionMark)
                 {
                     break;
                 }
@@ -740,7 +740,7 @@ namespace AngleSharp
 
             var span = index - start;
 
-            if (span == 2 && input[start].IsLetter() && input[start + 1].IsOneOf(Symbols.Pipe, Symbols.Colon))
+            if (span == 2 && input[start].IsLetter() && input[start + 1] is Symbols.Pipe or Symbols.Colon)
             {
                 return ParsePath(input, index - 2, length);
             }

--- a/src/AngleSharp/Xhtml/XhtmlMarkupFormatter.cs
+++ b/src/AngleSharp/Xhtml/XhtmlMarkupFormatter.cs
@@ -170,7 +170,7 @@ namespace AngleSharp.Xhtml
         /// </summary>
         /// <param name="name">The name to be properly represented.</param>
         /// <returns>The string representation.</returns>
-        public static String XmlNamespaceLocalName(String name) => !string.Equals(name, NamespaceNames.XmlNsPrefix, StringComparison.Ordinal) ? String.Concat(NamespaceNames.XmlNsPrefix, ":") : name;
+        public static String XmlNamespaceLocalName(String name) => !name.Is(NamespaceNames.XmlNsPrefix) ? String.Concat(NamespaceNames.XmlNsPrefix, ":") : name;
 
         #endregion
     }

--- a/src/AngleSharp/Xhtml/XhtmlMarkupFormatter.cs
+++ b/src/AngleSharp/Xhtml/XhtmlMarkupFormatter.cs
@@ -61,7 +61,7 @@ namespace AngleSharp.Xhtml
 
             foreach (var attribute in element.Attributes)
             {
-                temp.Append(" ").Append(Attribute(attribute));
+                temp.Append(' ').Append(Attribute(attribute));
             }
 
             if (selfClosing || !element.HasChildNodes)
@@ -170,7 +170,7 @@ namespace AngleSharp.Xhtml
         /// </summary>
         /// <param name="name">The name to be properly represented.</param>
         /// <returns>The string representation.</returns>
-        public static String XmlNamespaceLocalName(String name) => name != NamespaceNames.XmlNsPrefix ? String.Concat(NamespaceNames.XmlNsPrefix, ":") : name;
+        public static String XmlNamespaceLocalName(String name) => !string.Equals(name, NamespaceNames.XmlNsPrefix, StringComparison.Ordinal) ? String.Concat(NamespaceNames.XmlNsPrefix, ":") : name;
 
         #endregion
     }


### PR DESCRIPTION
This PR:

- Reduces allocations in the string extension methods by using pooled buffers (via System.Buffers)
- Adds additional commonly used mime types and basic test coverage
- Replace IsOneOf(chars...) method calls with basic is + or pattern
- Makes Boundary readonly
- Eliminate various cases where we can leak a pooled StringBuilder instance
- Introduce a non-allocating method to return unused StringBuilder instances
- Fix a few cases where we are comparing strings using the current culture

Possible breaking changes:
- Removed public SplitWithoutTrimming(char[], ...) overload
- Removed public IsOneOf(char...) methods

## Prerequisites

Please make sure you can check the following two boxes:

- [x] I have read the **CONTRIBUTING** document
- [x] My code follows the code style of this project

## Contribution Type

What types of changes does your code introduce? Put an `x` in all the boxes that apply:

- [x] Breaking change (fix or feature that would cause existing functionality to change)
- [x] I have added tests to cover my changes
- [x] All new and existing tests passed
