### PR TITLE
Add interface for picture element

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,7 @@
 # 0.16.1
 
 - Fixed `namespaceUri` parameters to allow nullable values when possible (#975)
+- Add missing `IHtmlPictureElement` to picture element (#978)
 
 # 0.16.0
 

--- a/src/AngleSharp/Html/Dom/IHtmlPictureElement.cs
+++ b/src/AngleSharp/Html/Dom/IHtmlPictureElement.cs
@@ -1,0 +1,13 @@
+namespace AngleSharp.Html.Dom
+{
+    using AngleSharp.Attributes;
+    using System;
+
+    /// <summary>
+    /// Represents the HTML picture element.
+    /// </summary>
+    [DomName("HTMLPictureElement")]
+    public interface IHtmlPictureElement : IHtmlElement
+    {
+    }
+}

--- a/src/AngleSharp/Html/Dom/Internal/HtmlPictureElement.cs
+++ b/src/AngleSharp/Html/Dom/Internal/HtmlPictureElement.cs
@@ -1,4 +1,4 @@
-﻿namespace AngleSharp.Html.Dom
+namespace AngleSharp.Html.Dom
 {
     using AngleSharp.Dom;
     using System;
@@ -6,7 +6,7 @@
     /// <summary>
     /// Represents the HTML picture element.
     /// </summary>
-    sealed class HtmlPictureElement : HtmlElement
+    sealed class HtmlPictureElement : HtmlElement, IHtmlPictureElement
     {
         public HtmlPictureElement(Document owner, String? prefix = null)
             : base(owner, TagNames.Picture, prefix)


### PR DESCRIPTION
# Types of Changes

## Prerequisites

Please make sure you can check the following two boxes:

- [x] I have read the **CONTRIBUTING** document
- [x] My code follows the code style of this project

## Contribution Type

What types of changes does your code introduce? Put an `x` in all the boxes that apply:

- [ ] Bug fix (non-breaking change which fixes an issue, please reference the issue id)
- [x] New feature (non-breaking change which adds functionality, make sure to open an associated issue first)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] My change requires a change to the documentation
- [ ] I have updated the documentation accordingly
- [ ] I have added tests to cover my changes
- [ ] All new and existing tests passed

## Description

Closes #977

Adds an interface to `HtmlPictureElement` to allow support for `myElement is IHtmlPictureElement`. This would match behaviour for other elements.
