### PR TITLE
[WIP] Introduce ValueStringBuilder to improve performance under load

### DIFF
--- a/src/AngleSharp/AngleSharp.Core.csproj
+++ b/src/AngleSharp/AngleSharp.Core.csproj
@@ -25,7 +25,7 @@
 
   <ItemGroup>
     <PackageReference Include="System.Text.Encoding.CodePages" Version="5.0.0" />
-    <PackageReference Include="System.Buffers" Version="4.5.1" />
+    <PackageReference Include="System.Memory" Version="4.5.4" />
   </ItemGroup>
 
   <PropertyGroup Condition=" '$(OS)' == 'Windows_NT' ">

--- a/src/AngleSharp/Css/CssUtilities.cs
+++ b/src/AngleSharp/Css/CssUtilities.cs
@@ -1,5 +1,5 @@
-using AngleSharp.Text;
 using System;
+using System.Text;
 
 namespace AngleSharp.Css
 {
@@ -19,7 +19,7 @@ namespace AngleSharp.Css
             {
                 var length = text.Length;
                 var index = -1;
-                var result = StringBuilderPool.Obtain();
+                var result = new ValueStringBuilder(100);
                 var firstCodeUnit = (Int32)text[0];
 
                 while (++index < length)
@@ -52,14 +52,17 @@ namespace AngleSharp.Css
                     )
                     {
                         // https://drafts.csswg.org/cssom/#escape-a-character-as-code-point
-                        result.Append('\\').Append(codeUnit.ToString("X")).Append(' ');
+                        result.Append('\\');
+                        result.Append(codeUnit.ToString("X"));
+                        result.Append(' ');
                         continue;
                     }
 
                     // If the character is the first character and is a `-` (U+002D), and there is no second character, […]
                     if (index == 0 && length == 1 && codeUnit == 0x002D)
                     {
-                        result.Append('\\').Append(text[index]);
+                        result.Append('\\');
+                        result.Append(text[index]);
                         continue;
                     }
 
@@ -83,10 +86,11 @@ namespace AngleSharp.Css
 
                     // Otherwise, the escaped character.
                     // https://drafts.csswg.org/cssom/#escape-a-character
-                    result.Append('\\').Append(Char.ConvertFromUtf32(text[index]));
+                    result.Append('\\');
+                    result.Append(Char.ConvertFromUtf32(text[index]));
                 }
 
-                return result.ToPool();
+                return result.ToString();
             }
 
             return text;

--- a/src/AngleSharp/Css/CssUtilities.cs
+++ b/src/AngleSharp/Css/CssUtilities.cs
@@ -19,7 +19,7 @@ namespace AngleSharp.Css
             {
                 var length = text.Length;
                 var index = -1;
-                var result = new ValueStringBuilder(100);
+                var result = new ValueStringBuilder(128);
                 var firstCodeUnit = (Int32)text[0];
 
                 while (++index < length)

--- a/src/AngleSharp/Css/Parser/CssTokenizer.cs
+++ b/src/AngleSharp/Css/Parser/CssTokenizer.cs
@@ -348,7 +348,7 @@ namespace AngleSharp.Css.Parser
         /// </summary>
         private CssSelectorToken StringDQ()
         {
-            using var buffer = new ValueStringBuilder(100);
+            using var buffer = new ValueStringBuilder(128);
 
             while (true)
             {
@@ -396,7 +396,7 @@ namespace AngleSharp.Css.Parser
         /// </summary>
         private CssSelectorToken StringSQ()
         {
-            using var buffer = new ValueStringBuilder(100);
+            using var buffer = new ValueStringBuilder(128);
 
             while (true)
             {
@@ -550,15 +550,13 @@ namespace AngleSharp.Css.Parser
         /// </summary>
         private CssSelectorToken IdentStart(Char current)
         {
-            const int estimatedIdentLength = 20;
-
             if (current == Symbols.Minus)
             {
                 current = _source.Next();
 
                 if (current.IsNameStart() || _source.IsValidEscape())
                 {
-                    var sb = new ValueStringBuilder(stackalloc char[estimatedIdentLength]);
+                    var sb = new ValueStringBuilder(32);
 
                     sb.Append(Symbols.Minus);
                     return IdentRest(current, ref sb);
@@ -568,13 +566,13 @@ namespace AngleSharp.Css.Parser
             }
             else if (current.IsNameStart())
             {
-                var sb = new ValueStringBuilder(stackalloc char[estimatedIdentLength]);
+                var sb = new ValueStringBuilder(32);
                 sb.Append(current);
                 return IdentRest(_source.Next(), ref sb);
             }
             else if (current == Symbols.ReverseSolidus && _source.IsValidEscape())
             {
-                var sb = new ValueStringBuilder(stackalloc char[estimatedIdentLength]);
+                var sb = new ValueStringBuilder(32);
                 sb.Append(_source.ConsumeEscape());
                 return IdentRest(_source.Next(), ref sb);
             }

--- a/src/AngleSharp/Css/Parser/CssTokenizer.cs
+++ b/src/AngleSharp/Css/Parser/CssTokenizer.cs
@@ -348,7 +348,7 @@ namespace AngleSharp.Css.Parser
         /// </summary>
         private CssSelectorToken StringDQ()
         {
-            var buffer = StringBuilderPool.Obtain();
+            using var buffer = new ValueStringBuilder(100);
 
             while (true)
             {
@@ -359,18 +359,18 @@ namespace AngleSharp.Css.Parser
                     case Symbols.DoubleQuote:
                     case Symbols.EndOfFile:
                         _source.Next();
-                        return NewString(buffer.ToPool());
+                        return NewString(buffer.ToString());
 
                     case Symbols.FormFeed:
                     case Symbols.LineFeed:
-                        return NewString(buffer.ToPool());
+                        return NewString(buffer.ToString());
 
                     case Symbols.ReverseSolidus:
                         current = _source.Next();
 
                         if (current.IsLineBreak())
                         {
-                            buffer.AppendLine();
+                            buffer.Append(Environment.NewLine);
                         }
                         else if (current != Symbols.EndOfFile)
                         {
@@ -379,7 +379,7 @@ namespace AngleSharp.Css.Parser
                         }
                         else
                         {
-                            return NewString(buffer.ToPool());
+                            return NewString(buffer.ToString());
                         }
 
                         break;
@@ -396,7 +396,7 @@ namespace AngleSharp.Css.Parser
         /// </summary>
         private CssSelectorToken StringSQ()
         {
-            var buffer = StringBuilderPool.Obtain();
+            using var buffer = new ValueStringBuilder(100);
 
             while (true)
             {
@@ -407,18 +407,18 @@ namespace AngleSharp.Css.Parser
                     case Symbols.SingleQuote:
                     case Symbols.EndOfFile:
                         _source.Next();
-                        return NewString(buffer.ToPool());
+                        return NewString(buffer.ToString());
 
                     case Symbols.FormFeed:
                     case Symbols.LineFeed:
-                        return NewString(buffer.ToPool());
+                        return NewString(buffer.ToString());
 
                     case Symbols.ReverseSolidus:
                         current = _source.Next();
 
                         if (current.IsLineBreak())
                         {
-                            buffer.AppendLine();
+                            buffer.Append(Environment.NewLine);
                         }
                         else if (current != Symbols.EndOfFile)
                         {
@@ -427,7 +427,7 @@ namespace AngleSharp.Css.Parser
                         }
                         else
                         {
-                            return NewString(buffer.ToPool());
+                            return NewString(buffer.ToString());
                         }
 
                         break;

--- a/src/AngleSharp/Dom/Internal/TextNode.cs
+++ b/src/AngleSharp/Dom/Internal/TextNode.cs
@@ -2,6 +2,7 @@ namespace AngleSharp.Dom
 {
     using AngleSharp.Text;
     using System;
+    using System.Text;
 
     /// <summary>
     /// Represents a text node.
@@ -46,7 +47,7 @@ namespace AngleSharp.Dom
             {
                 var previous = PreviousSibling;
                 var start = this;
-                var sb = StringBuilderPool.Obtain();
+                using var sb = new ValueStringBuilder(1_024);
 
                 while (previous is TextNode)
                 {
@@ -61,7 +62,7 @@ namespace AngleSharp.Dom
                 }
                 while (start != null);
 
-                return sb.ToPool();
+                return sb.ToString();
             }
         }
 

--- a/src/AngleSharp/Dom/Url.cs
+++ b/src/AngleSharp/Dom/Url.cs
@@ -172,7 +172,7 @@ namespace AngleSharp.Dom
                 }
                 else if (ProtocolNames.IsOriginable(_scheme))
                 {
-                    var output = new ValueStringBuilder(100);
+                    var output = new ValueStringBuilder(128);
 
                     if (!String.IsNullOrEmpty(_host))
                     {
@@ -493,7 +493,7 @@ namespace AngleSharp.Dom
         /// <returns>The string that equals the hyper reference.</returns>
         private String Serialize()
         {
-            var sb = new ValueStringBuilder(200);
+            var sb = new ValueStringBuilder(256);
 
             if (!String.IsNullOrEmpty(_scheme))
             {
@@ -1245,7 +1245,7 @@ namespace AngleSharp.Dom
                 return false;
             }
 
-            using var buffer = new ValueStringBuilder(100);
+            using var buffer = new ValueStringBuilder(128);
 
             // https://anglesharp.github.io/Specification-Url/#host-parsing 3.5.7
             // forbidden host code point check

--- a/src/AngleSharp/Dom/UrlSearchParams.cs
+++ b/src/AngleSharp/Dom/UrlSearchParams.cs
@@ -5,6 +5,7 @@ namespace AngleSharp.Dom
     using System;
     using System.Collections.Generic;
     using System.Linq;
+    using System.Text;
 
     /// <summary>
     /// Represents a list of query parameters.
@@ -164,7 +165,7 @@ namespace AngleSharp.Dom
 
         private static String Encode(String value)
         {
-            var sb = StringBuilderPool.Obtain();
+            var sb = new ValueStringBuilder(value.Length + 10);
 
             foreach (var chr in value)
             {
@@ -179,12 +180,14 @@ namespace AngleSharp.Dom
                 }
             }
 
-            return sb.ToPool();
+            return sb.ToString();
         }
 
         private static String Decode(String value)
         {
-            var sb = StringBuilderPool.Obtain();
+            var sb = value.Length < 24
+                ? new ValueStringBuilder(stackalloc char[24])
+                : new ValueStringBuilder(value.Length);
 
             for (var i = 0; i < value.Length; i++)
             {
@@ -202,7 +205,7 @@ namespace AngleSharp.Dom
                 }
             }
 
-            return sb.ToPool();
+            return sb.ToString();
         }
 
         private void RaiseChanged() => Changed?.Invoke(ToString());

--- a/src/AngleSharp/Html/Forms/Submitters/Json/JsonArray.cs
+++ b/src/AngleSharp/Html/Forms/Submitters/Json/JsonArray.cs
@@ -5,6 +5,7 @@ namespace AngleSharp.Html.Forms.Submitters.Json
     using System.Collections;
     using System.Collections.Generic;
     using System.Linq;
+    using System.Text;
 
     sealed class JsonArray : JsonElement, IEnumerable<JsonElement>
     {
@@ -48,7 +49,9 @@ namespace AngleSharp.Html.Forms.Submitters.Json
 
         public override String ToString()
         {
-            var sb = StringBuilderPool.Obtain().Append(Symbols.SquareBracketOpen);
+            var sb = new ValueStringBuilder(100);
+
+            sb.Append(Symbols.SquareBracketOpen);
             var needsComma = false;
 
             foreach (var element in _elements)
@@ -60,7 +63,9 @@ namespace AngleSharp.Html.Forms.Submitters.Json
                 needsComma = true;
             }
 
-            return sb.Append(Symbols.SquareBracketClose).ToPool();
+            sb.Append(Symbols.SquareBracketClose);
+
+            return sb.ToString();
         }
 
         public IEnumerator<JsonElement> GetEnumerator()

--- a/src/AngleSharp/Html/Forms/Submitters/Json/JsonArray.cs
+++ b/src/AngleSharp/Html/Forms/Submitters/Json/JsonArray.cs
@@ -49,7 +49,7 @@ namespace AngleSharp.Html.Forms.Submitters.Json
 
         public override String ToString()
         {
-            var sb = new ValueStringBuilder(100);
+            var sb = new ValueStringBuilder(128);
 
             sb.Append(Symbols.SquareBracketOpen);
             var needsComma = false;

--- a/src/AngleSharp/Html/Forms/Submitters/Json/JsonObject.cs
+++ b/src/AngleSharp/Html/Forms/Submitters/Json/JsonObject.cs
@@ -1,12 +1,12 @@
 namespace AngleSharp.Html.Forms.Submitters.Json
 {
-    using AngleSharp.Text;
     using System;
     using System.Collections.Generic;
+    using System.Text;
 
     sealed class JsonObject : JsonElement
     {
-        private readonly Dictionary<String, JsonElement> _properties = new Dictionary<String, JsonElement>();
+        private readonly Dictionary<String, JsonElement> _properties = new ();
 
         public override JsonElement this[String key]
         {
@@ -20,22 +20,31 @@ namespace AngleSharp.Html.Forms.Submitters.Json
 
         public override String ToString()
         {
-            var sb = StringBuilderPool.Obtain().Append(Symbols.CurlyBracketOpen);
+            var sb = new ValueStringBuilder(_properties.Count * 20);
+
             var needsComma = false;
+
+            sb.Append('{');
 
             foreach (var property in _properties)
             {
                 if (needsComma)
                 {
-                    sb.Append(Symbols.Comma);
+                    sb.Append(',');
                 }
 
-                sb.Append(Symbols.DoubleQuote).Append(property.Key).Append(Symbols.DoubleQuote);
-                sb.Append(Symbols.Colon).Append(property.Value.ToString());
+                sb.Append('"');
+                sb.Append(property.Key);
+                sb.Append('"');
+
+                sb.Append(':');
+                sb.Append(property.Value.ToString());
                 needsComma = true;
             }
 
-            return sb.Append(Symbols.CurlyBracketClose).ToPool();
+            sb.Append('}');
+
+            return sb.ToString();
         }
     }
 }

--- a/src/AngleSharp/Html/HtmlMarkupFormatter.cs
+++ b/src/AngleSharp/Html/HtmlMarkupFormatter.cs
@@ -51,23 +51,26 @@ namespace AngleSharp.Html
         /// <inheritdoc />
         public virtual String OpenTag(IElement element, Boolean selfClosing)
         {
-            var temp = StringBuilderPool.Obtain();
+            var temp = new ValueStringBuilder(100);
+
             temp.Append(Symbols.LessThan);
 
             if (!String.IsNullOrEmpty(element.Prefix))
             {
-                temp.Append(element.Prefix).Append(Symbols.Colon);
+                temp.Append(element.Prefix);
+                temp.Append(Symbols.Colon);
             }
 
             temp.Append(element.LocalName);
 
             foreach (var attribute in element.Attributes)
             {
-                temp.Append(' ').Append(Attribute(attribute));
+                temp.Append(' ');
+                temp.Append(Attribute(attribute));
             }
 
             temp.Append(Symbols.GreaterThan);
-            return temp.ToPool();
+            return temp.ToString();
         }
 
         /// <inheritdoc />
@@ -86,48 +89,53 @@ namespace AngleSharp.Html
         /// <returns>The string representation.</returns>
         protected virtual String Attribute(IAttr attr)
         {
-            var temp = StringBuilderPool.Obtain();
+            var sb = new ValueStringBuilder(100);
 
-            WriteAttributeName(attr, temp);
+            WriteAttributeName(attr, ref sb);
 
             if (attr.Value != null)
             {
-                temp.Append(Symbols.Equality).Append(Symbols.DoubleQuote);
-                WriteAttributeValue(attr, temp);
-                return temp.Append(Symbols.DoubleQuote).ToPool();
+                sb.Append(Symbols.Equality);
+                sb.Append(Symbols.DoubleQuote);
+                WriteAttributeValue(attr, ref sb);
+                sb.Append(Symbols.DoubleQuote);
             }
 
-            return temp.ToPool();
+            return sb.ToString();
         }
 
-        internal static void WriteAttributeName(IAttr attr, StringBuilder stringBuilder)
+        internal static void WriteAttributeName(IAttr attr, ref ValueStringBuilder sb)
         {
             var namespaceUri = attr.NamespaceUri;
             var localName = attr.LocalName;
 
             if (String.IsNullOrEmpty(namespaceUri))
             {
-                stringBuilder.Append(localName);
+                sb.Append(localName);
             }
             else if (namespaceUri.Is(NamespaceNames.XmlUri))
             {
-                stringBuilder.Append(NamespaceNames.XmlPrefix).Append(Symbols.Colon).Append(localName);
+                sb.Append(NamespaceNames.XmlPrefix);
+                sb.Append(Symbols.Colon);
+                sb.Append(localName);
             }
             else if (namespaceUri.Is(NamespaceNames.XLinkUri))
             {
-                stringBuilder.Append(NamespaceNames.XLinkPrefix).Append(Symbols.Colon).Append(localName);
+                sb.Append(NamespaceNames.XLinkPrefix);
+                sb.Append(Symbols.Colon);
+                sb.Append(localName);
             }
             else if (namespaceUri.Is(NamespaceNames.XmlNsUri))
             {
-                stringBuilder.Append(XmlNamespaceLocalName(localName));
+                sb.Append(XmlNamespaceLocalName(localName));
             }
             else
             {
-                stringBuilder.Append(attr.Name);
+                sb.Append(attr.Name);
             }
         }
 
-        internal static void WriteAttributeValue(IAttr attr, StringBuilder stringBuilder)
+        internal static void WriteAttributeValue(IAttr attr, ref ValueStringBuilder sb)
         {
             var value = attr.Value ?? String.Empty;
 
@@ -135,10 +143,10 @@ namespace AngleSharp.Html
             {
                 switch (value[i])
                 {
-                    case Symbols.Ampersand: stringBuilder.Append("&amp;"); break;
-                    case Symbols.NoBreakSpace: stringBuilder.Append("&nbsp;"); break;
-                    case Symbols.DoubleQuote: stringBuilder.Append("&quot;"); break;
-                    default: stringBuilder.Append(value[i]); break;
+                    case Symbols.Ampersand: sb.Append("&amp;"); break;
+                    case Symbols.NoBreakSpace: sb.Append("&nbsp;"); break;
+                    case Symbols.DoubleQuote: sb.Append("&quot;"); break;
+                    default: sb.Append(value[i]); break;
                 }
             }
         }
@@ -155,7 +163,7 @@ namespace AngleSharp.Html
         /// <returns>The altered string.</returns>
         public static String EscapeText(String content)
         {
-            var temp = StringBuilderPool.Obtain();
+            var temp = new ValueStringBuilder(content.Length + 20);
 
             for (var i = 0; i < content.Length; i++)
             {
@@ -169,7 +177,7 @@ namespace AngleSharp.Html
                 }
             }
 
-            return temp.ToPool();
+            return temp.ToString();
         }
 
         /// <summary>

--- a/src/AngleSharp/Html/HtmlMarkupFormatter.cs
+++ b/src/AngleSharp/Html/HtmlMarkupFormatter.cs
@@ -51,7 +51,7 @@ namespace AngleSharp.Html
         /// <inheritdoc />
         public virtual String OpenTag(IElement element, Boolean selfClosing)
         {
-            var temp = new ValueStringBuilder(100);
+            var temp = new ValueStringBuilder(128);
 
             temp.Append(Symbols.LessThan);
 
@@ -89,7 +89,7 @@ namespace AngleSharp.Html
         /// <returns>The string representation.</returns>
         protected virtual String Attribute(IAttr attr)
         {
-            var sb = new ValueStringBuilder(100);
+            var sb = new ValueStringBuilder(128);
 
             WriteAttributeName(attr, ref sb);
 

--- a/src/AngleSharp/Html/MinifyMarkupFormatter.cs
+++ b/src/AngleSharp/Html/MinifyMarkupFormatter.cs
@@ -121,7 +121,7 @@ namespace AngleSharp.Html
         {
             if (!CanBeRemoved(element))
             {
-                var temp = new ValueStringBuilder(100);
+                var temp = new ValueStringBuilder(128);
 
                 temp.Append(Symbols.LessThan);
 
@@ -186,7 +186,7 @@ namespace AngleSharp.Html
 
             if (ShouldKeepEmptyAttributes || !String.IsNullOrEmpty(value))
             {
-                var sb = new ValueStringBuilder(100);
+                var sb = new ValueStringBuilder(128);
 
                 WriteAttributeName(attr, ref sb);
 

--- a/src/AngleSharp/Html/MinifyMarkupFormatter.cs
+++ b/src/AngleSharp/Html/MinifyMarkupFormatter.cs
@@ -7,6 +7,7 @@ namespace AngleSharp.Html
     using System;
     using System.Collections.Generic;
     using System.Linq;
+    using System.Text;
 
     /// <summary>
     /// Represents the an HTML5 markup formatter with a normalization scheme.
@@ -120,12 +121,14 @@ namespace AngleSharp.Html
         {
             if (!CanBeRemoved(element))
             {
-                var temp = StringBuilderPool.Obtain();
+                var temp = new ValueStringBuilder(100);
+
                 temp.Append(Symbols.LessThan);
 
                 if (!String.IsNullOrEmpty(element.Prefix))
                 {
-                    temp.Append(element.Prefix).Append(Symbols.Colon);
+                    temp.Append(element.Prefix);
+                    temp.Append(Symbols.Colon);
                 }
 
                 temp.Append(element.LocalName);
@@ -140,12 +143,14 @@ namespace AngleSharp.Html
 
                             if (!String.IsNullOrEmpty(value))
                             {
-                                temp.Append(' ').Append(value);
+                                temp.Append(' ');
+                                temp.Append(value);
                             }
                         }
                         else
                         {
-                            temp.Append(' ').Append(attribute.Name);
+                            temp.Append(' ');
+                            temp.Append(attribute.Name);
                         }
                     }
                 }
@@ -157,7 +162,7 @@ namespace AngleSharp.Html
                 }
 
                 temp.Append(Symbols.GreaterThan);
-                return temp.ToPool();
+                return temp.ToString();
             }
 
             return String.Empty;
@@ -181,29 +186,29 @@ namespace AngleSharp.Html
 
             if (ShouldKeepEmptyAttributes || !String.IsNullOrEmpty(value))
             {
-                var temp = StringBuilderPool.Obtain();
+                var sb = new ValueStringBuilder(100);
 
-                WriteAttributeName(attr, temp);
+                WriteAttributeName(attr, ref sb);
 
                 if (value != null)
                 {
-                    temp.Append(Symbols.Equality);
+                    sb.Append(Symbols.Equality);
                     var needQuotes = ShouldKeepAttributeQuotes || value.Any(MustBeQuotedAttributeValue);
 
                     if (needQuotes)
                     {
-                        temp.Append(Symbols.DoubleQuote);
+                        sb.Append(Symbols.DoubleQuote);
                     }
 
-                    WriteAttributeValue(attr, temp);
+                    WriteAttributeValue(attr, ref sb);
 
                     if (needQuotes)
                     {
-                        temp.Append(Symbols.DoubleQuote);
+                        sb.Append(Symbols.DoubleQuote);
                     }
                 }
 
-                return temp.ToPool();
+                return sb.ToString();
             }
 
             return String.Empty;

--- a/src/AngleSharp/Internal/ValueStringBuilder.cs
+++ b/src/AngleSharp/Internal/ValueStringBuilder.cs
@@ -1,0 +1,257 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+
+// Via: https://github.com/dotnet/runtime/blob/ab7492c4a77f0315d384b4c7648d0cefa36b18d1/src/libraries/Common/src/System/Text/ValueStringBuilder.cs
+
+#pragma warning disable IDE0057 // Use range operator
+
+using System.Buffers;
+using System.Collections.Generic;
+using System.Diagnostics;
+using System.Runtime.CompilerServices;
+
+namespace System.Text
+{
+    internal ref struct ValueStringBuilder
+    {
+        private char[]? _arrayToReturnToPool;
+        private Span<char> _chars;
+        private int _pos;
+
+        public ValueStringBuilder(Span<char> initialBuffer)
+        {
+            _arrayToReturnToPool = null;
+            _chars = initialBuffer;
+            _pos = 0;
+        }
+
+        public ValueStringBuilder(int initialCapacity)
+        {
+            _arrayToReturnToPool = ArrayPool<char>.Shared.Rent(initialCapacity);
+            _chars = _arrayToReturnToPool;
+            _pos = 0;
+        }
+
+        public int Length
+        {
+            get => _pos;
+            set
+            {
+                Debug.Assert(value >= 0);
+                Debug.Assert(value <= _chars.Length);
+                _pos = value;
+            }
+        }
+
+        public int Capacity => _chars.Length;
+
+        public ref char this[int index]
+        {
+            get
+            {
+                Debug.Assert(index < _pos);
+                return ref _chars[index];
+            }
+        }
+
+        public override string ToString()
+        {
+            string s = _chars.Slice(0, _pos).ToString();
+            Dispose();
+            return s;
+        }
+
+        public ReadOnlySpan<char> AsSpan() => _chars.Slice(0, _pos);
+        public ReadOnlySpan<char> AsSpan(int start) => _chars.Slice(start, _pos - start);
+        public ReadOnlySpan<char> AsSpan(int start, int length) => _chars.Slice(start, length);
+
+        public bool TryCopyTo(Span<char> destination, out int charsWritten)
+        {
+            if (_chars.Slice(0, _pos).TryCopyTo(destination))
+            {
+                charsWritten = _pos;
+                Dispose();
+                return true;
+            }
+            else
+            {
+                charsWritten = 0;
+                Dispose();
+                return false;
+            }
+        }
+
+        public void Insert(int index, char value, int count)
+        {
+            if (_pos > _chars.Length - count)
+            {
+                Grow(count);
+            }
+
+            int remaining = _pos - index;
+            _chars.Slice(index, remaining).CopyTo(_chars.Slice(index + count));
+            _chars.Slice(index, count).Fill(value);
+            _pos += count;
+        }
+
+        public void Insert(int index, string? s)
+        {
+            if (s == null)
+            {
+                return;
+            }
+
+            int count = s.Length;
+
+            if (_pos > (_chars.Length - count))
+            {
+                Grow(count);
+            }
+
+            int remaining = _pos - index;
+            _chars.Slice(index, remaining).CopyTo(_chars.Slice(index + count));
+            s
+#if !NET6_0_OR_GREATER
+                .AsSpan()
+#endif
+                .CopyTo(_chars.Slice(index));
+            _pos += count;
+        }
+
+        [MethodImpl(MethodImplOptions.AggressiveInlining)]
+        public void Append(char c)
+        {
+            int pos = _pos;
+            if ((uint)pos < (uint)_chars.Length)
+            {
+                _chars[pos] = c;
+                _pos = pos + 1;
+            }
+            else
+            {
+                GrowAndAppend(c);
+            }
+        }
+
+        [MethodImpl(MethodImplOptions.AggressiveInlining)]
+        public void Append(string? s)
+        {
+            if (s == null)
+            {
+                return;
+            }
+
+            int pos = _pos;
+            if (s.Length == 1 && (uint)pos < (uint)_chars.Length) // very common case, e.g. appending strings from NumberFormatInfo like separators, percent symbols, etc.
+            {
+                _chars[pos] = s[0];
+                _pos = pos + 1;
+            }
+            else
+            {
+                AppendSlow(s);
+            }
+        }
+
+        private void AppendSlow(string s)
+        {
+            int pos = _pos;
+            if (pos > _chars.Length - s.Length)
+            {
+                Grow(s.Length);
+            }
+
+            s
+#if !NET6_0_OR_GREATER
+                .AsSpan()
+#endif
+                .CopyTo(_chars.Slice(pos));
+            _pos += s.Length;
+        }
+
+        public void Append(char c, int count)
+        {
+            if (_pos > _chars.Length - count)
+            {
+                Grow(count);
+            }
+
+            Span<char> dst = _chars.Slice(_pos, count);
+            for (int i = 0; i < dst.Length; i++)
+            {
+                dst[i] = c;
+            }
+            _pos += count;
+        }
+
+        public void Append(ReadOnlySpan<char> value)
+        {
+            int pos = _pos;
+            if (pos > _chars.Length - value.Length)
+            {
+                Grow(value.Length);
+            }
+
+            value.CopyTo(_chars.Slice(_pos));
+            _pos += value.Length;
+        }
+
+        [MethodImpl(MethodImplOptions.AggressiveInlining)]
+        public Span<char> AppendSpan(int length)
+        {
+            int origPos = _pos;
+            if (origPos > _chars.Length - length)
+            {
+                Grow(length);
+            }
+
+            _pos = origPos + length;
+            return _chars.Slice(origPos, length);
+        }
+
+        [MethodImpl(MethodImplOptions.NoInlining)]
+        private void GrowAndAppend(char c)
+        {
+            Grow(1);
+            Append(c);
+        }
+
+        /// <summary>
+        /// Resize the internal buffer either by doubling current buffer size or
+        /// by adding <paramref name="additionalCapacityBeyondPos"/> to
+        /// <see cref="_pos"/> whichever is greater.
+        /// </summary>
+        /// <param name="additionalCapacityBeyondPos">
+        /// Number of chars requested beyond current position.
+        /// </param>
+        [MethodImpl(MethodImplOptions.NoInlining)]
+        private void Grow(int additionalCapacityBeyondPos)
+        {
+            Debug.Assert(additionalCapacityBeyondPos > 0);
+            Debug.Assert(_pos > _chars.Length - additionalCapacityBeyondPos, "Grow called incorrectly, no resize is needed.");
+
+            // Make sure to let Rent throw an exception if the caller has a bug and the desired capacity is negative
+            char[] poolArray = ArrayPool<char>.Shared.Rent((int)Math.Max((uint)(_pos + additionalCapacityBeyondPos), (uint)_chars.Length * 2));
+
+            _chars.Slice(0, _pos).CopyTo(poolArray);
+
+            char[]? toReturn = _arrayToReturnToPool;
+            _chars = _arrayToReturnToPool = poolArray;
+            if (toReturn != null)
+            {
+                ArrayPool<char>.Shared.Return(toReturn);
+            }
+        }
+
+        [MethodImpl(MethodImplOptions.AggressiveInlining)]
+        public void Dispose()
+        {
+            char[]? toReturn = _arrayToReturnToPool;
+            this = default; // for safety, to avoid using pooled array if this instance is erroneously appended to again
+            if (toReturn != null)
+            {
+                ArrayPool<char>.Shared.Return(toReturn);
+            }
+        }
+    }
+}

--- a/src/AngleSharp/Text/StringExtensions.cs
+++ b/src/AngleSharp/Text/StringExtensions.cs
@@ -296,8 +296,8 @@ namespace AngleSharp.Text
         /// <returns>The modified string with collapsed spaces.</returns>
         public static String Collapse(this String str)
         {
-            var sb = str.Length < 48
-                ? new ValueStringBuilder(stackalloc char[48])
+            var sb = str.Length < 32
+                ? new ValueStringBuilder(stackalloc char[32])
                 : new ValueStringBuilder(str.Length);
 
             var hasSpace = false;

--- a/src/AngleSharp/Xhtml/XhtmlMarkupFormatter.cs
+++ b/src/AngleSharp/Xhtml/XhtmlMarkupFormatter.cs
@@ -3,6 +3,7 @@ namespace AngleSharp.Xhtml
     using AngleSharp.Dom;
     using AngleSharp.Text;
     using System;
+    using System.Text;
 
     /// <summary>
     /// Represents the standard XHTML markup formatter.
@@ -49,28 +50,30 @@ namespace AngleSharp.Xhtml
         public virtual String OpenTag(IElement element, Boolean selfClosing)
         {
             var prefix = element.Prefix;
-            var temp = StringBuilderPool.Obtain();
-            temp.Append(Symbols.LessThan);
+            var sb = new ValueStringBuilder(100);
+            sb.Append(Symbols.LessThan);
 
             if (!String.IsNullOrEmpty(prefix))
             {
-                temp.Append(prefix).Append(Symbols.Colon);
+                sb.Append(prefix);
+                sb.Append(Symbols.Colon);
             }
 
-            temp.Append(element.LocalName);
+            sb.Append(element.LocalName);
 
             foreach (var attribute in element.Attributes)
             {
-                temp.Append(' ').Append(Attribute(attribute));
+                sb.Append(' ');
+                sb.Append(Attribute(attribute));
             }
 
             if (selfClosing || !element.HasChildNodes)
             {
-                temp.Append(" /");
+                sb.Append(" /");
             }
 
-            temp.Append(Symbols.GreaterThan);
-            return temp.ToPool();
+            sb.Append(Symbols.GreaterThan);
+            return sb.ToString();
         }
 
         /// <inheritdoc />
@@ -96,44 +99,51 @@ namespace AngleSharp.Xhtml
             var namespaceUri = attribute.NamespaceUri;
             var localName = attribute.LocalName;
             var value = attribute.Value;
-            var temp = StringBuilderPool.Obtain();
+            var sb = new ValueStringBuilder(100);
 
             if (String.IsNullOrEmpty(namespaceUri))
             {
-                temp.Append(localName);
+                sb.Append(localName);
             }
             else if (namespaceUri.Is(NamespaceNames.XmlUri))
             {
-                temp.Append(NamespaceNames.XmlPrefix).Append(Symbols.Colon).Append(localName);
+                sb.Append(NamespaceNames.XmlPrefix);
+                sb.Append(Symbols.Colon);
+                sb.Append(localName);
             }
             else if (namespaceUri.Is(NamespaceNames.XLinkUri))
             {
-                temp.Append(NamespaceNames.XLinkPrefix).Append(Symbols.Colon).Append(localName);
+                sb.Append(NamespaceNames.XLinkPrefix);
+                sb.Append(Symbols.Colon);
+                sb.Append(localName);
             }
             else if (namespaceUri.Is(NamespaceNames.XmlNsUri))
             {
-                temp.Append(XmlNamespaceLocalName(localName));
+                sb.Append(XmlNamespaceLocalName(localName));
             }
             else
             {
-                temp.Append(attribute.Name);
+                sb.Append(attribute.Name);
             }
 
-            temp.Append(Symbols.Equality).Append(Symbols.DoubleQuote);
+            sb.Append(Symbols.Equality);
+            sb.Append(Symbols.DoubleQuote);
 
             for (var i = 0; i < value.Length; i++)
             {
                 switch (value[i])
                 {
-                    case Symbols.Ampersand: temp.Append("&amp;"); break;
-                    case Symbols.NoBreakSpace: temp.Append("&#160;"); break;
-                    case Symbols.LessThan: temp.Append("&lt;"); break;
-                    case Symbols.DoubleQuote: temp.Append("&quot;"); break;
-                    default: temp.Append(value[i]); break;
+                    case Symbols.Ampersand: sb.Append("&amp;"); break;
+                    case Symbols.NoBreakSpace: sb.Append("&#160;"); break;
+                    case Symbols.LessThan: sb.Append("&lt;"); break;
+                    case Symbols.DoubleQuote: sb.Append("&quot;"); break;
+                    default: sb.Append(value[i]); break;
                 }
             }
 
-            return temp.Append(Symbols.DoubleQuote).ToPool();
+            sb.Append(Symbols.DoubleQuote);
+
+            return sb.ToString();
         }
 
         #endregion
@@ -148,21 +158,21 @@ namespace AngleSharp.Xhtml
         /// <returns>The altered string.</returns>
         public static String EscapeText(String content)
         {
-            var temp = StringBuilderPool.Obtain();
+            var sb = new ValueStringBuilder(content.Length + 10);
 
             for (var i = 0; i < content.Length; i++)
             {
                 switch (content[i])
                 {
-                    case Symbols.Ampersand: temp.Append("&amp;"); break;
-                    case Symbols.NoBreakSpace: temp.Append("&#160;"); break;
-                    case Symbols.GreaterThan: temp.Append("&gt;"); break;
-                    case Symbols.LessThan: temp.Append("&lt;"); break;
-                    default: temp.Append(content[i]); break;
+                    case Symbols.Ampersand: sb.Append("&amp;"); break;
+                    case Symbols.NoBreakSpace: sb.Append("&#160;"); break;
+                    case Symbols.GreaterThan: sb.Append("&gt;"); break;
+                    case Symbols.LessThan: sb.Append("&lt;"); break;
+                    default : sb.Append(content[i]); break;
                 }
             }
 
-            return temp.ToPool();
+            return sb.ToString();
         }
 
         /// <summary>

--- a/src/AngleSharp/Xhtml/XhtmlMarkupFormatter.cs
+++ b/src/AngleSharp/Xhtml/XhtmlMarkupFormatter.cs
@@ -49,11 +49,10 @@ namespace AngleSharp.Xhtml
         /// <inheritdoc />
         public virtual String OpenTag(IElement element, Boolean selfClosing)
         {
-            var prefix = element.Prefix;
-            var sb = new ValueStringBuilder(100);
+            var sb = new ValueStringBuilder(64);
             sb.Append(Symbols.LessThan);
 
-            if (!String.IsNullOrEmpty(prefix))
+            if (element.Prefix is { Length: > 0 } prefix)
             {
                 sb.Append(prefix);
                 sb.Append(Symbols.Colon);
@@ -99,7 +98,7 @@ namespace AngleSharp.Xhtml
             var namespaceUri = attribute.NamespaceUri;
             var localName = attribute.LocalName;
             var value = attribute.Value;
-            var sb = new ValueStringBuilder(100);
+            var sb = new ValueStringBuilder(128);
 
             if (String.IsNullOrEmpty(namespaceUri))
             {


### PR DESCRIPTION
Posting for early feedback.

This PR reduces the chance of the StringBuilderPool waiting on a lock or allocating when the project is used in a high-concurrency environment by utilizing a non-allocating ValueStringBuilder (via the .NET runtime).

Seeing a ~4% throughput improvement parsing 32 concurrent documents on an 8 core processor this change. I would also expect we can replace additional uses of StringBuilderPool.Obtain() to improve this further.

This does introduce a dependency on System.Memory, which does complicate things.

## Prerequisites

Please make sure you can check the following two boxes:

- [x] I have read the **CONTRIBUTING** document
- [x] My code follows the code style of this project

## Contribution Type

What types of changes does your code introduce? Put an `x` in all the boxes that apply:

- [x] All new and existing tests passed