### PR TITLE
Removed the ConditionalWeakTable from ImportLinkRelation.  See issue …

### DIFF
--- a/src/AngleSharp/Dom/IDocument.cs
+++ b/src/AngleSharp/Dom/IDocument.cs
@@ -569,6 +569,20 @@ namespace AngleSharp.Dom
         IDocument? ImportAncestor { get; }
 
         /// <summary>
+        /// Adds a Uri to the list of imported Uris.
+        /// </summary>
+        /// <param name="uri">The Uri to add.</param>
+        /// <returns>True if uri is not null or previously added, false otherwise.</returns>
+        Boolean AddImportUrl(Uri uri);
+
+        /// <summary>
+        /// Checks if a document has already imported a Uri.
+        /// </summary>
+        /// <param name="uri">The Uri to check.</param>
+        /// <returns>True if already imported.</returns>
+        bool HasImported(Uri uri);
+
+        /// <summary>
         /// Gets the underlying source.
         /// </summary>
         TextSource Source { get; }
@@ -582,5 +596,6 @@ namespace AngleSharp.Dom
         /// Gets the associated entity provider.
         /// </summary>
         IEntityProvider Entities { get; }
+
     }
 }


### PR DESCRIPTION
…#918

# Bug Fix

## Prerequisites

Please make sure you can check the following two boxes:

- [X ] I have read the **CONTRIBUTING** document
- [ X] My code follows the code style of this project

## Contribution Type

What types of changes does your code introduce? Put an `x` in all the boxes that apply:

- [ X] Bug fix (non-breaking change which fixes an issue, please reference the issue id)
- [ ] New feature (non-breaking change which adds functionality, make sure to open an associated issue first)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] My change requires a change to the documentation
- [ ] I have updated the documentation accordingly
- [ ] I have added tests to cover my changes
- [X ] All new and existing tests passed

## Description

The ConditionalWeakTable used by ImportLinkRelation can become corrupted, permanently breaking AngleSharp.
This change removes the CWT and moves the functionality to check for Cycles to the Document class.
