### PR TITLE
Fix for issue #991

### DIFF
--- a/src/AngleSharp/Dom/Internal/Node.cs
+++ b/src/AngleSharp/Dom/Internal/Node.cs
@@ -508,6 +508,10 @@ namespace AngleSharp.Dom
                 {
                     writer.Write(formatter.Comment(comment));
                 }
+                else if (node is IProcessingInstruction processingInstruction)
+                {
+                    writer.Write(formatter.Processing(processingInstruction));
+                }
                 else if (node is ICharacterData characterData)
                 {
                     if (characterData.Parent?.Flags.HasFlag(NodeFlags.LiteralText) ?? false)
@@ -522,10 +526,6 @@ namespace AngleSharp.Dom
                 else if (node is IDocumentType docType)
                 {
                     writer.Write(formatter.Doctype(docType));
-                }
-                else if (node is IProcessingInstruction processingInstruction)
-                {
-                    writer.Write(formatter.Processing(processingInstruction));
                 }
                 else if (node is IElement element)
                 {


### PR DESCRIPTION
# Types of Changes

## Prerequisites

Please make sure you can check the following two boxes:

- [X] I have read the **CONTRIBUTING** document
- [X] My code follows the code style of this project

## Contribution Type

What types of changes does your code introduce? Put an `x` in all the boxes that apply:

- [X] Bug fix (non-breaking change which fixes an issue, please reference the issue id)
- [ ] New feature (non-breaking change which adds functionality, make sure to open an associated issue first)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] My change requires a change to the documentation
- [ ] I have updated the documentation accordingly
- [ ] I have added tests to cover my changes
- [ ] All new and existing tests passed

## Description

Node.ToHtml works by testing each Node object against various interfaces (IComment, ICharacterData, etc.) to determine how to write it (i.e. which method to call from the provided Markup Formatter object).

The implementation of IProcessingInstruction is class ProcessingInstruction. ProcessingInstruction is a subclass of CharacterData, therefore implements ICharacterData.
Therefore, if a ProcessingInstruction instance is tested against "is IChararacterData", the result will be true.

In the current Master code, "is ICharacterData" is tested BEFORE "is IProcessingInstruction", therefore ProcessingInstructions are treated as ICharacterData objects and the code specifically for IProcessingInstructions (a subsequent branch in the if-else list) is never reached.

The fix is to test for "is IProcessingInstruction" BEFORE testing "is ICharacterData".

The exact same consideration applies for IComment (class Comment is also a subclass of CharacterData), but that test already preceded the ICharacterData test, so there was no issue there.

resolves #991 
