### PR TITLE
Allow DocumentUri to be changed

### DIFF
--- a/src/AngleSharp/Dom/IDocument.cs
+++ b/src/AngleSharp/Dom/IDocument.cs
@@ -48,7 +48,7 @@ namespace AngleSharp.Dom
         /// Gets the URI of the current document.
         /// </summary>
         [DomName("documentURI")]
-        String DocumentUri { get; }
+        String DocumentUri { get; set; }
 
         /// <summary>
         /// Gets the character encoding of the current document.

--- a/src/AngleSharp/Dom/Internal/Document.cs
+++ b/src/AngleSharp/Dom/Internal/Document.cs
@@ -645,7 +645,7 @@ namespace AngleSharp.Dom
         public String DocumentUri
         {
             get => _location.Href;
-            protected set
+            set
             {
                 _location.Changed -= LocationChanged;
                 _location.Href = value;


### PR DESCRIPTION
# Types of Changes

## Prerequisites

Please make sure you can check the following two boxes:

- [x] I have read the **CONTRIBUTING** document
- [x] My code follows the code style of this project

## Contribution Type

What types of changes does your code introduce? Put an `x` in all the boxes that apply:

- [ ] Bug fix (non-breaking change which fixes an issue, please reference the issue id)
- [x] New feature (non-breaking change which adds functionality, make sure to open an associated issue first)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] My change requires a change to the documentation
- [ ] I have updated the documentation accordingly
- [ ] I have added tests to cover my changes
- [ ] All new and existing tests passed

## Description

After loading a document from static HTML with `HtmlParser` there doesn't seem to be an easy way to change the documentUri to location where the html was retrieved from. This becomes a problem when we try to create a form request through `HtmlFormElement.GetSubmission()` , because the documentUri is 'about:blank'. Dependent on if the action property is present in the form, either the DocumentUri gets used directly our indirectly through the BaseUrl of the `HtmlFormElement` in `HtmlFormElement.SubmitForm(...)`. This issue can be resolved by a little bit of a dirty hack, namely always making sure the action property is always an absolute link, however I feel like this isn't a proper solution. Thoughts?