### PR TITLE
Add .NET 6.0 target framework

### DIFF
--- a/src/AngleSharp.Core.Tests/AngleSharp.Core.Tests.csproj
+++ b/src/AngleSharp.Core.Tests/AngleSharp.Core.Tests.csproj
@@ -1,6 +1,6 @@
 <Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
-    <TargetFrameworks>netcoreapp3.1</TargetFrameworks>
+    <TargetFrameworks>net6.0</TargetFrameworks>
     <SignAssembly>true</SignAssembly>
     <AssemblyOriginatorKeyFile>Key.snk</AssemblyOriginatorKeyFile>
     <IsPackable>false</IsPackable>
@@ -19,8 +19,8 @@
     <PackageReference Include="GitHubActionsTestLogger" Version="1.2.0" />
     <PackageReference Include="Newtonsoft.Json" Version="13.0.1" />
     <PackageReference Include="NUnit" Version="3.13.2" />
-    <PackageReference Include="NUnit3TestAdapter" Version="3.17.0" />
-    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="16.10.0" />
+    <PackageReference Include="NUnit3TestAdapter" Version="4.1.0" />
+    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.0.0" />
   </ItemGroup>
 
   <ItemGroup>

--- a/src/AngleSharp.Core.Tests/Library/CookieHandling.cs
+++ b/src/AngleSharp.Core.Tests/Library/CookieHandling.cs
@@ -431,7 +431,7 @@ namespace AngleSharp.Core.Tests.Library
             var mcp = new MemoryCookieProvider();
             var config = Configuration.Default.With(mcp).With(requester).WithDefaultLoader();
             var context = BrowsingContext.New(config);
-            var receivedCookieHeader = "THECOOKIE=value1";
+            var receivedCookieHeader = "THECOOKIE=value1; Path=/path1";
             var url = new Url("http://example.com/path1");
             //request 1: /path1, set a cookie THECOOKIE=value1
             requester.BuildResponse(req => VirtualResponse.Create(r => r
@@ -441,11 +441,13 @@ namespace AngleSharp.Core.Tests.Library
             context.OpenAsync("http://example.com/path1");
             //request 2: /path1/somefile.jsp redirects to /path2/file2.jsp
             requester.BuildResponses(new Func<Request, IResponse>[] {
-                req => VirtualResponse.Create(r => r
+                req => {
+                    return VirtualResponse.Create(r => r
                     .Address("http://example.com/path1/somefile.jsp")
                     .Content("")
                     .Status(System.Net.HttpStatusCode.Redirect)
-                    .Header(HeaderNames.Location, "http://example.com/path2/file2.jsp")),
+                    .Header(HeaderNames.Location, "http://example.com/path2/file2.jsp"));
+                },
                 req => {
                     receivedCookieHeader = req.Headers.GetOrDefault(HeaderNames.Cookie, String.Empty);
                     return VirtualResponse.Create(r => r

--- a/src/AngleSharp/AngleSharp.Core.csproj
+++ b/src/AngleSharp/AngleSharp.Core.csproj
@@ -3,7 +3,7 @@
     <AssemblyName>AngleSharp</AssemblyName>
     <RootNamespace>AngleSharp</RootNamespace>
     <TargetFrameworks Condition=" '$(OS)' != 'Windows_NT' ">netstandard2.0</TargetFrameworks>
-    <TargetFrameworks Condition=" '$(OS)' == 'Windows_NT' ">netstandard2.0;net46;net461;net472</TargetFrameworks>
+    <TargetFrameworks Condition=" '$(OS)' == 'Windows_NT' ">netstandard2.0;net46;net461;net472;net6.0</TargetFrameworks>
     <SignAssembly>true</SignAssembly>
     <AssemblyOriginatorKeyFile>Key.snk</AssemblyOriginatorKeyFile>
     <GenerateDocumentationFile>true</GenerateDocumentationFile>
@@ -16,15 +16,23 @@
     <IncludeSymbols>true</IncludeSymbols>
     <SymbolPackageFormat>snupkg</SymbolPackageFormat>
     <TreatWarningsAsErrors>true</TreatWarningsAsErrors>
+    <NoWarn>$(NoWarn);SYSLIB0014</NoWarn>
   </PropertyGroup>
 
   <ItemGroup>
     <PackageReference Include="ConfigureAwaitChecker.Analyzer" Version="5.0.0" PrivateAssets="All" />
-    <PackageReference Include="Microsoft.SourceLink.GitHub" Version="1.0.0" PrivateAssets="All" />
+    <PackageReference Include="Microsoft.SourceLink.GitHub" Version="1.1.1" PrivateAssets="All" />
   </ItemGroup>
 
-  <ItemGroup>
+  <ItemGroup Condition=" '$(TargetFramework)' == 'netstandard2.0' or '$(TargetFramework)' == 'net461' or '$(TargetFramework)' == 'net472' or '$(TargetFramework)' == 'net6.0' ">
+    <PackageReference Include="System.Text.Encoding.CodePages" Version="6.0.0" />
+  </ItemGroup>
+
+  <ItemGroup Condition=" '$(TargetFramework)' == 'net46' ">
     <PackageReference Include="System.Text.Encoding.CodePages" Version="5.0.0" />
+  </ItemGroup>
+
+  <ItemGroup Condition=" '$(TargetFramework)' == 'netstandard2.0' or '$(TargetFramework)' == 'net46' or '$(TargetFramework)' == 'net461' or '$(TargetFramework)' == 'net472' ">
     <PackageReference Include="System.Buffers" Version="4.5.1" />
   </ItemGroup>
 

--- a/src/AngleSharp/Annotations/NullableAnnotations.cs
+++ b/src/AngleSharp/Annotations/NullableAnnotations.cs
@@ -1,3 +1,6 @@
+#if !NET5_0_OR_GREATER
+
+// ReSharper disable once CheckNamespace
 namespace System.Diagnostics.CodeAnalysis
 {
     internal sealed class AllowNullAttribute : Attribute { }
@@ -44,3 +47,5 @@ namespace System.Diagnostics.CodeAnalysis
         public string ParameterName { get; }
     }
 }
+
+#endif

--- a/src/AngleSharp/BrowsingContextExtensions.cs
+++ b/src/AngleSharp/BrowsingContextExtensions.cs
@@ -226,7 +226,7 @@ namespace AngleSharp
         /// <typeparam name="TProvider">The type of the provider service.</typeparam>
         /// <param name="context">The current context.</param>
         /// <returns>The provider instance or null.</returns>
-        public static TProvider GetProvider<TProvider>(this IBrowsingContext context)
+        public static TProvider? GetProvider<TProvider>(this IBrowsingContext context)
             where TProvider : class => context.GetServices<TProvider>().SingleOrDefault();
 
         /// <summary>

--- a/src/AngleSharp/Common/ObjectExtensions.cs
+++ b/src/AngleSharp/Common/ObjectExtensions.cs
@@ -27,7 +27,7 @@ namespace AngleSharp.Common
                 foreach (var property in properties)
                 {
                     var value = property.GetValue(values, null) ?? String.Empty;
-                    symbols.Add(property.Name, value.ToString());
+                    symbols.Add(property.Name, value.ToString() ?? String.Empty);
                 }
             }
 
@@ -121,7 +121,7 @@ namespace AngleSharp.Common
         /// <param name="values">The dictionary for the lookup.</param>
         /// <param name="key">The key to look for.</param>
         /// <returns>An object instance or null.</returns>
-        public static Object TryGet(this IDictionary<String, Object> values, String key)
+        public static Object? TryGet(this IDictionary<String, Object> values, String key)
         {
             values.TryGetValue(key, out var value);
             return value;
@@ -165,9 +165,23 @@ namespace AngleSharp.Common
         public static String GetMessage<T>(this T code)
             where T : struct
         {
-            var field = typeof(T).GetField(code.ToString());
-            var description = field.GetCustomAttribute<DomDescriptionAttribute>()?.Description;
-            return description ?? "An unknown error occurred.";
+            var description = "An unknown error occurred.";
+
+            var fieldName = code.ToString();
+
+            if (fieldName != null)
+            {
+                var field = typeof(T).GetField(fieldName);
+
+                if (field != null)
+                {
+                    var domDescriptionAttribute = field.GetCustomAttribute<DomDescriptionAttribute>();
+
+                    if (domDescriptionAttribute != null) description = domDescriptionAttribute.Description;
+                }
+            }
+
+            return description;
         }
     }
 }

--- a/src/AngleSharp/Css/DefaultAttributeSelectorFactory.cs
+++ b/src/AngleSharp/Css/DefaultAttributeSelectorFactory.cs
@@ -96,7 +96,7 @@ namespace AngleSharp.Css
         /// </summary>
         /// <param name="combinator">The used CSS combinator.</param>
         /// <returns>The registered creator, if any.</returns>
-        public Creator Unregister(String combinator)
+        public Creator? Unregister(String combinator)
         {
             if (_creators.TryGetValue(combinator, out var creator))
             {

--- a/src/AngleSharp/Css/DefaultPseudoClassSelectorFactory.cs
+++ b/src/AngleSharp/Css/DefaultPseudoClassSelectorFactory.cs
@@ -65,7 +65,7 @@ namespace AngleSharp.Css
         /// </summary>
         /// <param name="name">The name of the CSS pseudo class.</param>
         /// <returns>The registered selector, if any.</returns>
-        public ISelector Unregister(String name)
+        public ISelector? Unregister(String name)
         {
             if (_selectors.TryGetValue(name, out var selector))
             {

--- a/src/AngleSharp/Css/DefaultPseudoElementSelectorFactory.cs
+++ b/src/AngleSharp/Css/DefaultPseudoElementSelectorFactory.cs
@@ -39,7 +39,7 @@ namespace AngleSharp.Css
         /// </summary>
         /// <param name="name">The name of the CSS pseudo element.</param>
         /// <returns>The registered selector, if any.</returns>
-        public ISelector Unregister(String name)
+        public ISelector? Unregister(String name)
         {
             if (_selectors.TryGetValue(name, out var selector))
             {

--- a/src/AngleSharp/Css/Dom/StyleExtensions.cs
+++ b/src/AngleSharp/Css/Dom/StyleExtensions.cs
@@ -143,7 +143,7 @@ namespace AngleSharp.Css.Dom
 
             for (var i = 0; i < length && uri is null; i++)
             {
-                uri = sheets[i].LocateNamespace(prefix);
+                uri = sheets[i]?.LocateNamespace(prefix);
             }
 
             return uri;

--- a/src/AngleSharp/Css/Priority.cs
+++ b/src/AngleSharp/Css/Priority.cs
@@ -181,7 +181,11 @@ namespace AngleSharp.Css
         /// </summary>
         /// <param name="obj">The object to test with.</param>
         /// <returns>True if the two objects are equal, otherwise false.</returns>
-        public override Boolean Equals(Object obj) => (obj is Priority other) ? Equals(other) : false;
+#if NET5_0_OR_GREATER
+        public override Boolean Equals(Object? obj) => obj is Priority other && Equals(other);
+#else
+        public override Boolean Equals(Object obj) => obj is Priority other && Equals(other);
+#endif
 
         /// <summary>
         /// Returns a hash code that defines the current priority.

--- a/src/AngleSharp/Dom/DefaultDocumentFactory.cs
+++ b/src/AngleSharp/Dom/DefaultDocumentFactory.cs
@@ -46,7 +46,7 @@ namespace AngleSharp.Dom
         /// </summary>
         /// <param name="contentType">The content-type value.</param>
         /// <returns>The registered creator, if any.</returns>
-        public virtual Creator Unregister(String contentType)
+        public virtual Creator? Unregister(String contentType)
         {
             if (_creators.TryGetValue(contentType, out var creator))
             {

--- a/src/AngleSharp/Dom/DocumentExtensions.cs
+++ b/src/AngleSharp/Dom/DocumentExtensions.cs
@@ -39,7 +39,7 @@ namespace AngleSharp.Dom
                 foreach (var ctor in ctors)
                 {
                     var parameters = ctor.GetParameters();
-                    var arguments = new Object[parameters.Length];
+                    var arguments = new Object?[parameters.Length];
 
                     for (var i = 0; i < parameters.Length; i++)
                     {

--- a/src/AngleSharp/Dom/Events/DefaultEventFactory.cs
+++ b/src/AngleSharp/Dom/Events/DefaultEventFactory.cs
@@ -56,7 +56,7 @@ namespace AngleSharp.Dom.Events
         /// </summary>
         /// <param name="name">The name of the event.</param>
         /// <returns>The registered creator, if any.</returns>
-        public Creator Unregister(String name)
+        public Creator? Unregister(String name)
         {
             if (_creators.TryGetValue(name, out var creator))
             {

--- a/src/AngleSharp/Dom/IStyleSheetList.cs
+++ b/src/AngleSharp/Dom/IStyleSheetList.cs
@@ -1,4 +1,4 @@
-﻿namespace AngleSharp.Dom
+namespace AngleSharp.Dom
 {
     using AngleSharp.Attributes;
     using System;
@@ -19,7 +19,7 @@
         /// <returns>The stylesheet.</returns>
         [DomName("item")]
         [DomAccessor(Accessors.Getter)]
-        IStyleSheet this[Int32 index] { get; }
+        IStyleSheet? this[Int32 index] { get; }
         
         /// <summary>
         /// Gets the number of elements in the list of stylesheets.

--- a/src/AngleSharp/Dom/Internal/Attr.cs
+++ b/src/AngleSharp/Dom/Internal/Attr.cs
@@ -173,7 +173,11 @@ namespace AngleSharp.Dom
         /// </summary>
         /// <param name="other">The other attribute.</param>
         /// <returns>True if both are equivalent, otherwise false.</returns>
+#if NET5_0_OR_GREATER
+        public Boolean Equals(IAttr? other) =>  Prefix.Is(other?.Prefix) && NamespaceUri.Is(other?.NamespaceUri) && Value.Is(other?.Value);
+#else
         public Boolean Equals(IAttr other) => Prefix.Is(other.Prefix) && NamespaceUri.Is(other.NamespaceUri) && Value.Is(other.Value);
+#endif
 
         /// <summary>
         /// Computes the hash code of the attribute.

--- a/src/AngleSharp/Dom/Internal/Document.cs
+++ b/src/AngleSharp/Dom/Internal/Document.cs
@@ -1476,8 +1476,11 @@ namespace AngleSharp.Dom
             await _context.InteractAsync(EventNames.Print, new { Document = this }).ConfigureAwait(false);
             await this.QueueTaskAsync(_ => this.FireSimpleEvent(EventNames.AfterPrint)).ConfigureAwait(false);
         }
-
+#if NET5_0_OR_GREATER
+        private async void LocationChanged(Object? sender, Location.ChangedEventArgs e)
+#else
         private async void LocationChanged(Object sender, Location.ChangedEventArgs e)
+#endif
         {
             if (e.IsHashChanged)
             {
@@ -1564,6 +1567,6 @@ namespace AngleSharp.Dom
         {
             return _importedUris?.Contains(uri) ?? false;
         }
-        #endregion
+#endregion
     }
 }

--- a/src/AngleSharp/Dom/Internal/Element.cs
+++ b/src/AngleSharp/Dom/Internal/Element.cs
@@ -505,6 +505,19 @@ namespace AngleSharp.Dom
         }
 
         /// <inheritdoc />
+#if NET5_0_OR_GREATER
+        public override Boolean Equals(INode? otherNode)
+        {
+            if (otherNode is IElement otherElement)
+            {
+                return NamespaceUri.Is(otherElement.NamespaceUri) &&
+                    _attributes.SameAs(otherElement.Attributes) &&
+                    base.Equals(otherNode);
+            }
+
+            return false;
+        }
+#else
         public override Boolean Equals(INode otherNode)
         {
             if (otherNode is IElement otherElement)
@@ -516,6 +529,7 @@ namespace AngleSharp.Dom
 
             return false;
         }
+#endif
 
         /// <inheritdoc />
         public void Before(params INode[] nodes) => this.InsertBefore(nodes);

--- a/src/AngleSharp/Dom/Internal/Node.cs
+++ b/src/AngleSharp/Dom/Internal/Node.cs
@@ -712,7 +712,26 @@ namespace AngleSharp.Dom
             return namespaceUri.Is(defaultNamespace);
         }
 
-        /// <inheritdoc />
+        /// <inheritdoc cref="IEquatable{T}.Equals(T)" />
+#if NET5_0_OR_GREATER
+        public virtual Boolean Equals(INode? otherNode)
+        {
+            if (BaseUri.Is(otherNode?.BaseUri) && NodeName.Is(otherNode?.NodeName) && ChildNodes.Length == otherNode?.ChildNodes.Length)
+            {
+                for (var i = 0; i < _children.Length; i++)
+                {
+                    if (!_children[i].Equals(otherNode.ChildNodes[i]))
+                    {
+                        return false;
+                    }
+                }
+
+                return true;
+            }
+
+            return false;
+        }
+#else
         public virtual Boolean Equals(INode otherNode)
         {
             if (BaseUri.Is(otherNode.BaseUri) && NodeName.Is(otherNode.NodeName) && ChildNodes.Length == otherNode.ChildNodes.Length)
@@ -730,6 +749,7 @@ namespace AngleSharp.Dom
 
             return false;
         }
+#endif
 
         #endregion
 

--- a/src/AngleSharp/Dom/Internal/StyleSheetList.cs
+++ b/src/AngleSharp/Dom/Internal/StyleSheetList.cs
@@ -1,4 +1,4 @@
-﻿namespace AngleSharp.Dom
+namespace AngleSharp.Dom
 {
     using System;
     using System.Collections;
@@ -38,7 +38,7 @@
         /// </summary>
         /// <param name="index">The index of the element.</param>
         /// <returns>The stylesheet.</returns>
-        public IStyleSheet this[Int32 index] => _sheets.Skip(index).FirstOrDefault();
+        public IStyleSheet? this[Int32 index] => _sheets.Skip(index).FirstOrDefault();
 
         #endregion
 

--- a/src/AngleSharp/Dom/Url.cs
+++ b/src/AngleSharp/Dom/Url.cs
@@ -428,7 +428,11 @@ namespace AngleSharp.Dom
         /// <returns>
         /// True if the object is equal to the current object, otherwise false.
         /// </returns>
+#if NET5_0_OR_GREATER
+        public override Boolean Equals(Object? obj)
+#else
         public override Boolean Equals(Object obj)
+#endif
         {
             return ReferenceEquals(this, obj) || obj is Url other && Equals(other);
         }
@@ -443,6 +447,16 @@ namespace AngleSharp.Dom
         /// <returns>
         /// True if the given url is equal to the current url, otherwise false.
         /// </returns>
+#if NET5_0_OR_GREATER
+        public Boolean Equals(Url? other)
+        {
+            return other != null && _fragment.Is(other._fragment) && _query.Is(other._query) &&
+                   _path.Is(other._path) && _scheme.Isi(other._scheme) &&
+                   _port.Is(other._port) && _host.Isi(other._host) &&
+                   _username.Is(other._username) && _password.Is(other._password) &&
+                   _schemeData.Is(other._schemeData);
+        }
+#else
         public Boolean Equals(Url other)
         {
             return other != null && _fragment.Is(other._fragment) && _query.Is(other._query) &&
@@ -451,6 +465,7 @@ namespace AngleSharp.Dom
                 _username.Is(other._username) && _password.Is(other._password) &&
                 _schemeData.Is(other._schemeData);
         }
+#endif
 
         #endregion
 

--- a/src/AngleSharp/Html/DefaultInputTypeFactory.cs
+++ b/src/AngleSharp/Html/DefaultInputTypeFactory.cs
@@ -61,7 +61,7 @@ namespace AngleSharp.Html
         /// </summary>
         /// <param name="type">The input type value.</param>
         /// <returns>The registered creator, if any.</returns>
-        public Creator Unregister(String type)
+        public Creator? Unregister(String type)
         {
             if (_creators.TryGetValue(type, out var creator))
             {

--- a/src/AngleSharp/Html/DefaultLinkRelationFactory.cs
+++ b/src/AngleSharp/Html/DefaultLinkRelationFactory.cs
@@ -40,7 +40,7 @@ namespace AngleSharp.Html
         /// </summary>
         /// <param name="rel">The relation value.</param>
         /// <returns>The registered creator, if any.</returns>
-        public Creator Unregister(String rel)
+        public Creator? Unregister(String rel)
         {
             if (_creators.TryGetValue(rel, out var creator))
             {

--- a/src/AngleSharp/Html/Dom/IHtmlTableElement.cs
+++ b/src/AngleSharp/Html/Dom/IHtmlTableElement.cs
@@ -1,4 +1,4 @@
-﻿namespace AngleSharp.Html.Dom
+namespace AngleSharp.Html.Dom
 {
     using AngleSharp.Attributes;
     using AngleSharp.Dom;
@@ -14,7 +14,7 @@
         /// Gets or sets the assigned caption element.
         /// </summary>
         [DomName("caption")]
-        IHtmlTableCaptionElement Caption { get; set; }
+        IHtmlTableCaptionElement? Caption { get; set; }
 
         /// <summary>
         /// Creates a new table caption object or returns the existing one.
@@ -33,7 +33,7 @@
         /// Gets or sets the assigned head section.
         /// </summary>
         [DomName("tHead")]
-        IHtmlTableSectionElement Head { get; set; }
+        IHtmlTableSectionElement? Head { get; set; }
 
         /// <summary>
         /// Creates a new table header section or returns the existing one.
@@ -52,7 +52,7 @@
         /// Gets or sets the assigned foot section.
         /// </summary>
         [DomName("tFoot")]
-        IHtmlTableSectionElement Foot { get; set; }
+        IHtmlTableSectionElement? Foot { get; set; }
 
         /// <summary>
         /// Creates a table footer section or returns an existing one.

--- a/src/AngleSharp/Html/Dom/Internal/HtmlFormControlElement.cs
+++ b/src/AngleSharp/Html/Dom/Internal/HtmlFormControlElement.cs
@@ -96,7 +96,7 @@ namespace AngleSharp.Html.Dom
                 if (fieldSet.IsDisabled)
                 {
                     var firstLegend = fieldSet.ChildNodes.FirstOrDefault(m => m is IHtmlLegendElement);
-                    return !this.IsDescendantOf(firstLegend);
+                    return firstLegend == null || !this.IsDescendantOf(firstLegend);
                 }
             }
 

--- a/src/AngleSharp/Html/Dom/Internal/HtmlTableElement.cs
+++ b/src/AngleSharp/Html/Dom/Internal/HtmlTableElement.cs
@@ -29,24 +29,38 @@ namespace AngleSharp.Html.Dom
 
         #region Properties
 
-        public IHtmlTableCaptionElement Caption
+        public IHtmlTableCaptionElement? Caption
         {
             get => ChildNodes.OfType<IHtmlTableCaptionElement>().FirstOrDefault(m => m.LocalName.Is(TagNames.Caption));
-            set { DeleteCaption(); InsertChild(0, value); }
+            set
+            {
+                DeleteCaption();
+
+                if (value != null) InsertChild(0, value);
+            }
         }
 
-        public IHtmlTableSectionElement Head
+        public IHtmlTableSectionElement? Head
         {
             get => ChildNodes.OfType<IHtmlTableSectionElement>().FirstOrDefault(m => m.LocalName.Is(TagNames.Thead));
-            set { DeleteHead(); AppendChild(value); }
+            set
+            {
+                DeleteHead();
+
+                if (value != null) AppendChild(value);
+            }
         }
 
         public IHtmlCollection<IHtmlTableSectionElement> Bodies => _bodies ??= new HtmlCollection<IHtmlTableSectionElement>(this, deep: false, predicate: m => m.LocalName.Is(TagNames.Tbody));
 
-        public IHtmlTableSectionElement Foot
+        public IHtmlTableSectionElement? Foot
         {
             get => ChildNodes.OfType<IHtmlTableSectionElement>().FirstOrDefault(m => m.LocalName.Is(TagNames.Tfoot));
-            set { DeleteFoot(); AppendChild(value); }
+            set
+            {
+                DeleteFoot();
+                if (value != null) AppendChild(value);
+            }
         }
 
         public IEnumerable<IHtmlTableRowElement> AllRows

--- a/src/AngleSharp/Html/Forms/FileDataSetEntry.cs
+++ b/src/AngleSharp/Html/Forms/FileDataSetEntry.cs
@@ -36,7 +36,7 @@ namespace AngleSharp.Html.Forms
                     {
                         var line = sr.ReadLine();
 
-                        if (line.Contains(boundary))
+                        if (line != null && line.Contains(boundary))
                         {
                             result = true;
                             break;

--- a/src/AngleSharp/Html/Forms/Submitters/Json/JsonArray.cs
+++ b/src/AngleSharp/Html/Forms/Submitters/Json/JsonArray.cs
@@ -6,20 +6,20 @@ namespace AngleSharp.Html.Forms.Submitters.Json
     using System.Collections.Generic;
     using System.Linq;
 
-    sealed class JsonArray : JsonElement, IEnumerable<JsonElement>
+    sealed class JsonArray : JsonElement, IEnumerable<JsonElement?>
     {
-        private readonly List<JsonElement> _elements;
+        private readonly List<JsonElement?> _elements;
 
         public Int32 Length => _elements.Count;
 
         public JsonArray()
         {
-            _elements = new List<JsonElement>(); 
+            _elements = new List<JsonElement?>(); 
         }
 
         public JsonArray(int capacity)
         {
-            _elements = new List<JsonElement>(capacity);
+            _elements = new List<JsonElement?>(capacity);
         }
 
         public void Push(JsonElement element)
@@ -32,7 +32,7 @@ namespace AngleSharp.Html.Forms.Submitters.Json
             _elements.Add(element);
         }
 
-        public JsonElement this[Int32 key]
+        public JsonElement? this[Int32 key]
         {
             get => _elements.ElementAtOrDefault(key);
             set

--- a/src/AngleSharp/Html/Forms/Submitters/Json/JsonElement.cs
+++ b/src/AngleSharp/Html/Forms/Submitters/Json/JsonElement.cs
@@ -1,10 +1,10 @@
-﻿namespace AngleSharp.Html.Forms.Submitters.Json
+namespace AngleSharp.Html.Forms.Submitters.Json
 {
     using System;
 
     abstract class JsonElement
     {
-        public virtual JsonElement this[String key]
+        public virtual JsonElement? this[String key]
         {
             get => throw new InvalidOperationException();
             set => throw new InvalidOperationException();

--- a/src/AngleSharp/Html/Forms/Submitters/Json/JsonObject.cs
+++ b/src/AngleSharp/Html/Forms/Submitters/Json/JsonObject.cs
@@ -6,9 +6,9 @@ namespace AngleSharp.Html.Forms.Submitters.Json
 
     sealed class JsonObject : JsonElement
     {
-        private readonly Dictionary<String, JsonElement> _properties = new Dictionary<String, JsonElement>();
+        private readonly Dictionary<String, JsonElement?> _properties = new Dictionary<String, JsonElement?>();
 
-        public override JsonElement this[String key]
+        public override JsonElement? this[String key]
         {
             get
             {
@@ -31,7 +31,7 @@ namespace AngleSharp.Html.Forms.Submitters.Json
                 }
 
                 sb.Append(Symbols.DoubleQuote).Append(property.Key).Append(Symbols.DoubleQuote);
-                sb.Append(Symbols.Colon).Append(property.Value.ToString());
+                sb.Append(Symbols.Colon).Append(property.Value!.ToString());
                 needsComma = true;
             }
 

--- a/src/AngleSharp/Io/BaseRequester.cs
+++ b/src/AngleSharp/Io/BaseRequester.cs
@@ -1,4 +1,4 @@
-﻿namespace AngleSharp.Io
+namespace AngleSharp.Io
 {
     using AngleSharp.Dom;
     using AngleSharp.Dom.Events;
@@ -37,7 +37,7 @@
         /// <returns>
         /// The task that will eventually give the response data.
         /// </returns>
-        public async Task<IResponse> RequestAsync(Request request, CancellationToken cancel)
+        public async Task<IResponse?> RequestAsync(Request request, CancellationToken cancel)
         {
             var ev = new RequestEvent(request, null);
             InvokeEventListener(ev);
@@ -64,6 +64,6 @@
         /// <param name="request">The options to consider.</param>
         /// <param name="cancel">The token for cancelling the task.</param>
         /// <returns>The task resulting in the response.</returns>
-        protected abstract Task<IResponse> PerformRequestAsync(Request request, CancellationToken cancel);
+        protected abstract Task<IResponse?> PerformRequestAsync(Request request, CancellationToken cancel);
     }
 }

--- a/src/AngleSharp/Io/DefaultHttpRequester.cs
+++ b/src/AngleSharp/Io/DefaultHttpRequester.cs
@@ -23,7 +23,7 @@ namespace AngleSharp.Io
 
         private const Int32 BufferSize = 4096;
 
-        private static readonly String Version = typeof(DefaultHttpRequester).Assembly.GetCustomAttribute<AssemblyFileVersionAttribute>().Version;
+        private static readonly String? Version = typeof(DefaultHttpRequester).Assembly.GetCustomAttribute<AssemblyFileVersionAttribute>()?.Version;
         private static readonly String AgentName = "AngleSharp/" + Version;
 
         #endregion
@@ -99,7 +99,7 @@ namespace AngleSharp.Io
         /// <returns>
         /// The task that will eventually give the response data.
         /// </returns>
-        protected override async Task<IResponse> PerformRequestAsync(Request request, CancellationToken cancellationToken)
+        protected override async Task<IResponse?> PerformRequestAsync(Request request, CancellationToken cancellationToken)
         {
             var cts = new CancellationTokenSource(_timeOut);
             var cache = new RequestState(request, _headers, _setup);
@@ -139,7 +139,7 @@ namespace AngleSharp.Io
                 setup.Invoke(_http);
             }
 
-            public async Task<IResponse> RequestAsync(CancellationToken cancellationToken)
+            public async Task<IResponse?> RequestAsync(CancellationToken cancellationToken)
             {
                 cancellationToken.Register(_http.Abort);
 
@@ -149,7 +149,7 @@ namespace AngleSharp.Io
                     SendRequest(target);
                 }
 
-                var response = default(WebResponse);
+                WebResponse? response;
 
                 try
                 {
@@ -161,7 +161,7 @@ namespace AngleSharp.Io
                 }
 
                 RaiseConnectionLimit(_http);
-                return GetResponse((HttpWebResponse)response);
+                return GetResponse(response as HttpWebResponse);
             }
 
             private void SendRequest(Stream target)
@@ -182,7 +182,7 @@ namespace AngleSharp.Io
             }
 
             [return: NotNullIfNotNull("response")]
-            private DefaultResponse? GetResponse(HttpWebResponse response)
+            private DefaultResponse? GetResponse(HttpWebResponse? response)
             {
                 if (response != null)
                 {
@@ -225,10 +225,10 @@ namespace AngleSharp.Io
                 {
                     var methods = typeof(Cookie).GetMethods();
                     var func = methods.FirstOrDefault(m => m.Name is "ToServerString");
-                    _serverString = func ?? methods.FirstOrDefault(m => m.Name is "ToString");
+                    _serverString = func ?? methods.First(m => m.Name is "ToString");
                 }
 
-                return _serverString.Invoke(cookie, null).ToString();
+                return _serverString.Invoke(cookie, null)!.ToString()!;
             }
 
             /// <summary>

--- a/src/AngleSharp/Io/DocumentRequest.cs
+++ b/src/AngleSharp/Io/DocumentRequest.cs
@@ -180,7 +180,7 @@ namespace AngleSharp.Io
 
         private void SetHeader(String name, String value) => Headers[name] = value;
 
-        private String GetHeader(String name)
+        private String? GetHeader(String name)
         {
             Headers.TryGetValue(name, out var value);
             return value;

--- a/src/AngleSharp/Io/IRequester.cs
+++ b/src/AngleSharp/Io/IRequester.cs
@@ -1,4 +1,4 @@
-﻿namespace AngleSharp.Io
+namespace AngleSharp.Io
 {
     using AngleSharp.Dom;
     using System;
@@ -29,7 +29,7 @@
         /// <returns>
         /// The task that will eventually give the response data.
         /// </returns>
-        Task<IResponse> RequestAsync(Request request, CancellationToken cancel);
+        Task<IResponse?> RequestAsync(Request request, CancellationToken cancel);
 
         /// <summary>
         /// Fired when a request is starting.

--- a/src/AngleSharp/Io/MimeType.cs
+++ b/src/AngleSharp/Io/MimeType.cs
@@ -158,15 +158,32 @@ namespace AngleSharp.Io
         /// </summary>
         /// <param name="other">The type to compare to.</param>
         /// <returns>True if both types are equal, otherwise false.</returns>
+#if NET5_0_OR_GREATER
+        public Boolean Equals(MimeType? other) => _general.Isi(other?._general) &&
+                                                  _media.Isi(other?._media) &&
+                                                  _suffix.Isi(other?._suffix);
+#else
         public Boolean Equals(MimeType other) => _general.Isi(other._general) &&
-            _media.Isi(other._media) &&
-            _suffix.Isi(other._suffix);
+                                                 _media.Isi(other._media) &&
+                                                 _suffix.Isi(other._suffix);
+#endif
 
         /// <summary>
         /// Compares to the other object. It has to be a MIME type.
         /// </summary>
         /// <param name="obj">The object to compare to.</param>
         /// <returns>True if both objects are equal, otherwise false.</returns>
+#if NET5_0_OR_GREATER
+        public override Boolean Equals(Object? obj)
+        {
+            if (!Object.ReferenceEquals(this, obj))
+            {
+                return obj is MimeType other && Equals(other);
+            }
+
+            return true;
+        }
+#else
         public override Boolean Equals(Object obj)
         {
             if (!Object.ReferenceEquals(this, obj))
@@ -176,6 +193,7 @@ namespace AngleSharp.Io
 
             return true;
         }
+#endif
 
         /// <summary>
         /// Computes the hash code for the MIME type.

--- a/src/AngleSharp/Io/PortNumbers.cs
+++ b/src/AngleSharp/Io/PortNumbers.cs
@@ -30,7 +30,7 @@ namespace AngleSharp.Io
         /// The string representing the default port, or null, if the protocol
         /// is not known.
         /// </returns>
-        public static String GetDefaultPort(String protocol)
+        public static String? GetDefaultPort(String protocol)
         {
             Ports.TryGetValue(protocol, out var value);
             return value;

--- a/src/AngleSharp/Text/StringExtensions.cs
+++ b/src/AngleSharp/Text/StringExtensions.cs
@@ -42,10 +42,23 @@ namespace AngleSharp.Text
         /// <returns>The compatibility string.</returns>
         internal static String GetCompatiblity(this QuirksMode mode)
         {
+            var description = "CSS1Compat";
 
-            var field = typeof(QuirksMode).GetField(mode.ToString());
-            var description = field.GetCustomAttribute<DomDescriptionAttribute>()?.Description;
-            return description ?? "CSS1Compat";
+            var fieldName = mode.ToString();
+
+            if (fieldName != null)
+            {
+                var field = typeof(QuirksMode).GetField(fieldName);
+
+                if (field != null)
+                {
+                    var domDescriptionAttribute = field.GetCustomAttribute<DomDescriptionAttribute>();
+
+                    if (domDescriptionAttribute != null) description = domDescriptionAttribute.Description;
+                }
+            }
+
+            return description;
         }
 
         /// <summary>

--- a/src/AngleSharp/Text/TextPosition.cs
+++ b/src/AngleSharp/Text/TextPosition.cs
@@ -147,7 +147,11 @@ namespace AngleSharp.Text
         /// True if the given object is a text position with the same values,
         /// otherwise false.
         /// </returns>
-        public override Boolean Equals(Object obj) => obj is TextPosition other ? Equals(other) : false;
+#if NET5_0_OR_GREATER
+        public override Boolean Equals(Object? obj) => obj is TextPosition other && Equals(other);
+#else
+        public override Boolean Equals(Object obj) => obj is TextPosition other && Equals(other);
+#endif
 
         /// <summary>
         /// Indicates whether the current position is equal to the given

--- a/src/AngleSharp/Text/TextRange.cs
+++ b/src/AngleSharp/Text/TextRange.cs
@@ -79,10 +79,17 @@ namespace AngleSharp.Text
         /// True if the given object is a text position with the same values,
         /// otherwise false.
         /// </returns>
-        public override Boolean Equals(Object obj)
+#if NET5_0_OR_GREATER
+        public override Boolean Equals(Object? obj)
         {
             return obj is TextRange other && Equals(other);
         }
+#else
+           public override Boolean Equals(Object obj)
+        {
+            return obj is TextRange other && Equals(other);
+        }
+#endif
 
         /// <summary>
         /// Indicates whether the current range is equal to the given range.

--- a/src/AngleSharp/Text/TextSource.cs
+++ b/src/AngleSharp/Text/TextSource.cs
@@ -70,7 +70,6 @@ namespace AngleSharp.Text
         /// <param name="encoding">
         /// The initial encoding. Otherwise UTF-8.
         /// </param>
-        [MemberNotNull("_content")]
         public TextSource(Stream baseStream, Encoding encoding = null)
             : this(encoding, allocateBuffers: baseStream != null)
         {
@@ -86,6 +85,7 @@ namespace AngleSharp.Text
         /// <summary>
         /// Gets the full text buffer.
         /// </summary>
+        [MemberNotNull("_content")]
         public String Text => _content.ToString();
 
         /// <summary>


### PR DESCRIPTION
# Types of Changes

## Prerequisites

Please make sure you can check the following two boxes:

- [x] I have read the **CONTRIBUTING** document
- [x] My code follows the code style of this project

## Contribution Type

What types of changes does your code introduce? Put an `x` in all the boxes that apply:

- [ ] Bug fix (non-breaking change which fixes an issue, please reference the issue id)
- [x] New feature (non-breaking change which adds functionality, make sure to open an associated issue first)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] My change requires a change to the documentation
- [ ] I have updated the documentation accordingly
- [ ] I have added tests to cover my changes
- [x] All new and existing tests passed

## Description

I believe that as a modern library, AngleSharp should target the current and latest LTS release of .NET. This PR adds **.NET 6.0** as as a target framework in addition to the currently existing ones.
Some adjustments have been made in order to fix any resulting nullable reference errors.
