### PR TITLE
Add .NET 6.0 target framework

### DIFF
--- a/src/AngleSharp.Core.Tests/AngleSharp.Core.Tests.csproj
+++ b/src/AngleSharp.Core.Tests/AngleSharp.Core.Tests.csproj
@@ -1,6 +1,6 @@
 <Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
-    <TargetFrameworks>netcoreapp3.1</TargetFrameworks>
+    <TargetFrameworks>net6.0</TargetFrameworks>
     <SignAssembly>true</SignAssembly>
     <AssemblyOriginatorKeyFile>Key.snk</AssemblyOriginatorKeyFile>
     <IsPackable>false</IsPackable>
@@ -19,8 +19,8 @@
     <PackageReference Include="GitHubActionsTestLogger" Version="1.2.0" />
     <PackageReference Include="Newtonsoft.Json" Version="13.0.1" />
     <PackageReference Include="NUnit" Version="3.13.2" />
-    <PackageReference Include="NUnit3TestAdapter" Version="3.17.0" />
-    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="16.10.0" />
+    <PackageReference Include="NUnit3TestAdapter" Version="4.1.0" />
+    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.0.0" />
   </ItemGroup>
 
   <ItemGroup>

--- a/src/AngleSharp.Core.Tests/Assets.cs
+++ b/src/AngleSharp.Core.Tests/Assets.cs
@@ -60,7 +60,11 @@ namespace AngleSharp.Core.Tests
             var fullName = typeof(Assets).Namespace + "." + name;
             using (var stream = typeof(Assets).Assembly.GetManifestResourceStream(fullName))
             {
-                if (stream == null) throw new ArgumentException($"Unable to load Resource {fullName}. Check test project", nameof(name));
+                if (stream == null)
+                {
+                    throw new ArgumentException($"Unable to load Resource {fullName}. Check test project", nameof(name));
+                }
+
                 using (var reader = new StreamReader(stream, encoding))
                 {
                     return reader.ReadToEnd();
@@ -73,7 +77,11 @@ namespace AngleSharp.Core.Tests
             var fullName = typeof(Assets).Namespace + "." + name;
             using (var stream = typeof(Assets).Assembly.GetManifestResourceStream(fullName))
             {
-                if (stream == null) throw new ArgumentException($"Unable to load Resource {fullName}. Check test project", nameof(name));
+                if (stream == null)
+                {
+                    throw new ArgumentException($"Unable to load Resource {fullName}. Check test project", nameof(name));
+                }
+
                 using (var memStream = new MemoryStream())
                 {
                     stream.CopyTo(memStream);

--- a/src/AngleSharp.Core.Tests/Css/CssSelector.cs
+++ b/src/AngleSharp.Core.Tests/Css/CssSelector.cs
@@ -704,7 +704,9 @@ nav h1, nav h2, nav h3, nav h4, nav h5, nav h6";
             Assert.AreEqual(expected.Length, actual.Length);
 
             for (int i = 0; i < 6; i++)
+            {
                 Assert.AreSame(expected[i], actual[i]);
+            }
         }
 
         [Test]

--- a/src/AngleSharp.Core.Tests/Helper.cs
+++ b/src/AngleSharp.Core.Tests/Helper.cs
@@ -48,21 +48,29 @@ namespace AngleSharp.Core.Tests
                         if ((ni.OperationalStatus != OperationalStatus.Up) ||
                             (ni.NetworkInterfaceType == NetworkInterfaceType.Loopback) ||
                             (ni.NetworkInterfaceType == NetworkInterfaceType.Tunnel))
+                        {
                             continue;
+                        }
 
                         // this allow to filter modems, serial, etc.
                         // I use 10000000 as a minimum speed for most cases
                         if (ni.Speed < minimumSpeed)
+                        {
                             continue;
+                        }
 
                         // discard virtual cards (virtual box, virtual pc, etc.)
                         if ((ni.Description.IndexOf("virtual", StringComparison.OrdinalIgnoreCase) >= 0) ||
                             (ni.Name.IndexOf("virtual", StringComparison.OrdinalIgnoreCase) >= 0))
+                        {
                             continue;
+                        }
 
                         // discard "Microsoft Loopback Adapter", it will not show as NetworkInterfaceType.Loopback but as Ethernet Card.
                         if (ni.Description.Equals("Microsoft Loopback Adapter", StringComparison.OrdinalIgnoreCase))
+                        {
                             continue;
+                        }
 
                         return true;
                     }

--- a/src/AngleSharp.Core.Tests/Html/DOM.cs
+++ b/src/AngleSharp.Core.Tests/Html/DOM.cs
@@ -76,7 +76,9 @@ namespace AngleSharp.Core.Tests.Html
             Assert.AreEqual(18, attributes.Length);
 
             for (int i = 0; i < attributes.Length; i++)
+            {
                 Assert.AreEqual(expected[i], attributes[i].Name);
+            }
         }
 
         [Test]

--- a/src/AngleSharp.Core.Tests/Html/HtmlTokenization.cs
+++ b/src/AngleSharp.Core.Tests/Html/HtmlTokenization.cs
@@ -234,7 +234,9 @@ namespace AngleSharp.Core.Tests.Html
                 token = t.Get();
 
                 if (token.Type == HtmlTokenType.Character)
+                {
                     str += token.Data;
+                }
             }
             while (token.Type != HtmlTokenType.EndOfFile);
 
@@ -255,7 +257,9 @@ namespace AngleSharp.Core.Tests.Html
                 token = t.Get();
 
                 if (token.Type == HtmlTokenType.Character)
+                {
                     str += token.Data;
+                }
             }
             while (token.Type != HtmlTokenType.EndOfFile);
 
@@ -304,7 +308,9 @@ namespace AngleSharp.Core.Tests.Html
                 token = t.Get();
 
                 if (token.Type == HtmlTokenType.Character)
+                {
                     sb.Append(token.Data);
+                }
             }
             while (token.Type != HtmlTokenType.EndOfFile);
 

--- a/src/AngleSharp.Core.Tests/Html/Quirksmode.cs
+++ b/src/AngleSharp.Core.Tests/Html/Quirksmode.cs
@@ -36,7 +36,9 @@
             var testEl = document.GetElementById("test");
 
             for (var i = testEl.ChildNodes.Length - 1; i >= 0; i--)
+            {
                 testEl.RemoveChild(testEl.ChildNodes[i]);
+            }
 
             Assert.AreEqual(0, testEl.Children.Length);
             testEl.AppendChild(test as TextNode);

--- a/src/AngleSharp.Core.Tests/Library/CookieHandling.cs
+++ b/src/AngleSharp.Core.Tests/Library/CookieHandling.cs
@@ -431,7 +431,7 @@ namespace AngleSharp.Core.Tests.Library
             var mcp = new MemoryCookieProvider();
             var config = Configuration.Default.With(mcp).With(requester).WithDefaultLoader();
             var context = BrowsingContext.New(config);
-            var receivedCookieHeader = "THECOOKIE=value1";
+            var receivedCookieHeader = "THECOOKIE=value1; Path=/path1";
             var url = new Url("http://example.com/path1");
             //request 1: /path1, set a cookie THECOOKIE=value1
             requester.BuildResponse(req => VirtualResponse.Create(r => r
@@ -441,11 +441,13 @@ namespace AngleSharp.Core.Tests.Library
             context.OpenAsync("http://example.com/path1");
             //request 2: /path1/somefile.jsp redirects to /path2/file2.jsp
             requester.BuildResponses(new Func<Request, IResponse>[] {
-                req => VirtualResponse.Create(r => r
+                req => {
+                    return VirtualResponse.Create(r => r
                     .Address("http://example.com/path1/somefile.jsp")
                     .Content("")
                     .Status(System.Net.HttpStatusCode.Redirect)
-                    .Header(HeaderNames.Location, "http://example.com/path2/file2.jsp")),
+                    .Header(HeaderNames.Location, "http://example.com/path2/file2.jsp"));
+                },
                 req => {
                     receivedCookieHeader = req.Headers.GetOrDefault(HeaderNames.Cookie, String.Empty);
                     return VirtualResponse.Create(r => r

--- a/src/AngleSharp.Core.Tests/Library/DOMTable.cs
+++ b/src/AngleSharp.Core.Tests/Library/DOMTable.cs
@@ -195,13 +195,19 @@
             };
 
             foreach (var id in ids)
+            {
                 Assert.AreEqual(id, rows[id].Id);
+            }
 
             while (table.FirstChild != null)
+            {
                 table.RemoveChild(table.FirstChild);
+            }
 
             foreach (var id in ids)
+            {
                 Assert.IsNull(rows[id]);
+            }
         }
 
         [Test]

--- a/src/AngleSharp.Core.Tests/Library/FormSubmit.cs
+++ b/src/AngleSharp.Core.Tests/Library/FormSubmit.cs
@@ -29,7 +29,9 @@
             return PostDocumentAsync((document, form) =>
             {
                 if (encType != null)
+                {
                     form.Enctype = encType;
+                }
 
                 foreach (var field in fields)
                 {
@@ -45,7 +47,9 @@
             return PostDocumentAsync((document, form) =>
             {
                 if (encType != null)
+                {
                     form.Enctype = encType;
+                }
 
                 form.InnerHtml = content;
             }, fromButton);
@@ -269,7 +273,9 @@
                 isactive.IsChecked = true;
 
                 for (int i = 0; i < 5; i++)
+                {
                     (files.Files as FileList).Add(GenerateFile(i));
+                }
 
                 var response = await form.SubmitAsync();
                 Assert.IsNotNull(response);
@@ -363,10 +369,14 @@
                 var valueLines = new[] { 4, 8, 12 };
 
                 foreach (var emptyLine in emptyLines)
+                {
                     Assert.AreEqual(String.Empty, lines[emptyLine]);
+                }
 
                 for (int i = 1; i < sameLines.Length; i++)
+                {
                     Assert.AreEqual(lines[sameLines[0]], lines[sameLines[i]]);
+                }
 
                 Assert.AreEqual(lines[sameLines[0]] + "--", lines[lines.Length - 2]);
 
@@ -593,7 +603,9 @@
                 var emptyLines = new[] { 0, 4, 5, 7 };
 
                 foreach (var emptyLine in emptyLines)
+                {
                     Assert.AreEqual(String.Empty, lines[emptyLine]);
+                }
 
                 Assert.AreEqual(lines[1] + "--", lines[lines.Length - 2]);
                 Assert.AreEqual("Content-Disposition: form-data; name=\"image\"; filename=\"\"", lines[2]);
@@ -627,7 +639,9 @@
                 var emptyLines = new[] { 0, 4, 7 };
 
                 foreach (var emptyLine in emptyLines)
+                {
                     Assert.AreEqual(String.Empty, lines[emptyLine]);
+                }
 
                 Assert.AreEqual(lines[1] + "--", lines[lines.Length - 2]);
                 Assert.AreEqual("Content-Disposition: form-data; name=\"image\"; filename=\"test.txt\"", lines[2]);
@@ -661,7 +675,9 @@
                 var emptyLines = new[] { 0, 2 };
 
                 foreach (var emptyLine in emptyLines)
+                {
                     Assert.AreEqual(String.Empty, lines[emptyLine]);
+                }
             }
         }
 

--- a/src/AngleSharp.Core.Tests/Library/MutationObserver.cs
+++ b/src/AngleSharp.Core.Tests/Library/MutationObserver.cs
@@ -1384,10 +1384,14 @@ namespace AngleSharp.Core.Tests.Library
             foreach (var record in records)
             {
                 if (record.Added != null)
+                {
                     added.AddRange((NodeList)record.Added);
+                }
 
                 if (record.Removed != null)
+                {
                     removed.AddRange((NodeList)record.Removed);
+                }
             }
 
             return Tuple.Create(added, removed);
@@ -1398,7 +1402,9 @@ namespace AngleSharp.Core.Tests.Library
             Assert.AreEqual(expected.Length, actual.Length);
 
             for (int i = 0; i < expected.Length; i++)
+            {
                 Assert.AreSame(expected[i], actual[i]);
+            }
         }
 
         private static void AssertAll(IMutationRecord[] actualRecords, TestMutationRecord expected)
@@ -1426,7 +1432,9 @@ namespace AngleSharp.Core.Tests.Library
             var list = new NodeList();
 
             foreach (var node in nodes)
+            {
                 list.Add((Node)node);
+            }
 
             return list;
         }

--- a/src/AngleSharp.Core.Tests/Library/NodeIterator.cs
+++ b/src/AngleSharp.Core.Tests/Library/NodeIterator.cs
@@ -90,7 +90,9 @@
             {
 
                 if (node is IHtmlListItemElement element && element.ClassList.Contains("item"))
+                {
                     return FilterResult.Accept;
+                }
 
                 return FilterResult.Reject;
             });
@@ -101,7 +103,9 @@
             var results = new List<INode>();
 
             while (iterator.Next() != null)
+            {
                 results.Add(iterator.Reference);
+            }
 
             Assert.AreEqual(7, rootnode.ChildNodes.Length);
             Assert.AreEqual(3, rootnode.Children.Length);

--- a/src/AngleSharp.Core.Tests/Library/StringMap.cs
+++ b/src/AngleSharp.Core.Tests/Library/StringMap.cs
@@ -38,7 +38,9 @@
         public void GetEnumeratorTest()
         {
             foreach (var str in stringMap)
+            {
                 Assert.AreEqual(a.GetAttribute("data-" + str.Key), str.Value);
+            }
         }
     }
 }

--- a/src/AngleSharp.Core.Tests/Library/TreeWalker.cs
+++ b/src/AngleSharp.Core.Tests/Library/TreeWalker.cs
@@ -34,7 +34,9 @@
             var results = new List<INode>();
 
             while (walker.ToNext() != null)
+            {
                 results.Add(walker.Current);
+            }
 
             Assert.AreEqual(3, results.Count);
             Assert.IsInstanceOf<HtmlParagraphElement>(results[0]);
@@ -64,7 +66,9 @@
             var paratext = walker.Current.TextContent;
 
             while (walker.ToNextSibling() != null)
+            {
                 paratext += walker.Current.TextContent;
+            }
 
             Assert.AreEqual("George loves JavaScript!", paratext);
         }
@@ -87,7 +91,9 @@
             {
 
                 if (node is IHtmlListItemElement element && element.ClassList.Contains("item"))
+                {
                     return FilterResult.Accept;
+                }
 
                 return FilterResult.Reject;
             });
@@ -98,7 +104,9 @@
             var results = new List<INode>();
 
             while (walker.ToNext() != null)
+            {
                 results.Add(walker.Current);
+            }
 
             Assert.AreEqual(7, rootnode.ChildNodes.Length);
             Assert.AreEqual(3, rootnode.Children.Length);

--- a/src/AngleSharp.Core.Tests/Mocks/DtdRequester.cs
+++ b/src/AngleSharp.Core.Tests/Mocks/DtdRequester.cs
@@ -18,7 +18,9 @@
             var stream = Assembly.GetExecutingAssembly().GetManifestResourceStream("AngleSharp.Core.Tests.Resources." + name);
 
             if (stream == null)
+            {
                 throw new ArgumentException("The DTD " + name + " could not be found! Check the name and the availability of this DTD.");
+            }
 
             return new DefaultResponse { Content = stream };
         }

--- a/src/AngleSharp/AngleSharp.Core.csproj
+++ b/src/AngleSharp/AngleSharp.Core.csproj
@@ -3,7 +3,7 @@
     <AssemblyName>AngleSharp</AssemblyName>
     <RootNamespace>AngleSharp</RootNamespace>
     <TargetFrameworks Condition=" '$(OS)' != 'Windows_NT' ">netstandard2.0</TargetFrameworks>
-    <TargetFrameworks Condition=" '$(OS)' == 'Windows_NT' ">netstandard2.0;net46;net461;net472</TargetFrameworks>
+    <TargetFrameworks Condition=" '$(OS)' == 'Windows_NT' ">netstandard2.0;net46;net461;net472;net6.0</TargetFrameworks>
     <SignAssembly>true</SignAssembly>
     <AssemblyOriginatorKeyFile>Key.snk</AssemblyOriginatorKeyFile>
     <GenerateDocumentationFile>true</GenerateDocumentationFile>
@@ -16,15 +16,23 @@
     <IncludeSymbols>true</IncludeSymbols>
     <SymbolPackageFormat>snupkg</SymbolPackageFormat>
     <TreatWarningsAsErrors>true</TreatWarningsAsErrors>
+    <NoWarn>$(NoWarn);SYSLIB0014</NoWarn>
   </PropertyGroup>
 
   <ItemGroup>
     <PackageReference Include="ConfigureAwaitChecker.Analyzer" Version="5.0.0" PrivateAssets="All" />
-    <PackageReference Include="Microsoft.SourceLink.GitHub" Version="1.0.0" PrivateAssets="All" />
+    <PackageReference Include="Microsoft.SourceLink.GitHub" Version="1.1.1" PrivateAssets="All" />
   </ItemGroup>
 
-  <ItemGroup>
+  <ItemGroup Condition=" '$(TargetFramework)' == 'netstandard2.0' or '$(TargetFramework)' == 'net461' or '$(TargetFramework)' == 'net472' or '$(TargetFramework)' == 'net6.0' ">
+    <PackageReference Include="System.Text.Encoding.CodePages" Version="6.0.0" />
+  </ItemGroup>
+
+  <ItemGroup Condition=" '$(TargetFramework)' == 'net46' ">
     <PackageReference Include="System.Text.Encoding.CodePages" Version="5.0.0" />
+  </ItemGroup>
+
+  <ItemGroup Condition=" '$(TargetFramework)' == 'netstandard2.0' or '$(TargetFramework)' == 'net46' or '$(TargetFramework)' == 'net461' or '$(TargetFramework)' == 'net472' ">
     <PackageReference Include="System.Buffers" Version="4.5.1" />
   </ItemGroup>
 

--- a/src/AngleSharp/Annotations/NullableAnnotations.cs
+++ b/src/AngleSharp/Annotations/NullableAnnotations.cs
@@ -1,6 +1,5 @@
 #if !NET5_0_OR_GREATER
 
-// ReSharper disable once CheckNamespace
 namespace System.Diagnostics.CodeAnalysis
 {
     internal sealed class AllowNullAttribute : Attribute { }

--- a/src/AngleSharp/Annotations/NullableAnnotations.cs
+++ b/src/AngleSharp/Annotations/NullableAnnotations.cs
@@ -1,3 +1,6 @@
+#if !NET5_0_OR_GREATER
+
+// ReSharper disable once CheckNamespace
 namespace System.Diagnostics.CodeAnalysis
 {
     internal sealed class AllowNullAttribute : Attribute { }
@@ -44,3 +47,5 @@ namespace System.Diagnostics.CodeAnalysis
         public string ParameterName { get; }
     }
 }
+
+#endif

--- a/src/AngleSharp/BrowsingContextExtensions.cs
+++ b/src/AngleSharp/BrowsingContextExtensions.cs
@@ -226,7 +226,7 @@ namespace AngleSharp
         /// <typeparam name="TProvider">The type of the provider service.</typeparam>
         /// <param name="context">The current context.</param>
         /// <returns>The provider instance or null.</returns>
-        public static TProvider GetProvider<TProvider>(this IBrowsingContext context)
+        public static TProvider? GetProvider<TProvider>(this IBrowsingContext context)
             where TProvider : class => context.GetServices<TProvider>().SingleOrDefault();
 
         /// <summary>

--- a/src/AngleSharp/Common/ObjectExtensions.cs
+++ b/src/AngleSharp/Common/ObjectExtensions.cs
@@ -27,7 +27,7 @@ namespace AngleSharp.Common
                 foreach (var property in properties)
                 {
                     var value = property.GetValue(values, null) ?? String.Empty;
-                    symbols.Add(property.Name, value.ToString());
+                    symbols.Add(property.Name, value.ToString() ?? String.Empty);
                 }
             }
 
@@ -121,7 +121,7 @@ namespace AngleSharp.Common
         /// <param name="values">The dictionary for the lookup.</param>
         /// <param name="key">The key to look for.</param>
         /// <returns>An object instance or null.</returns>
-        public static Object TryGet(this IDictionary<String, Object> values, String key)
+        public static Object? TryGet(this IDictionary<String, Object> values, String key)
         {
             values.TryGetValue(key, out var value);
             return value;
@@ -165,9 +165,23 @@ namespace AngleSharp.Common
         public static String GetMessage<T>(this T code)
             where T : struct
         {
-            var field = typeof(T).GetField(code.ToString());
-            var description = field.GetCustomAttribute<DomDescriptionAttribute>()?.Description;
-            return description ?? "An unknown error occurred.";
+            var description = "An unknown error occurred.";
+
+            var fieldName = code.ToString();
+
+            if (fieldName != null)
+            {
+                var field = typeof(T).GetField(fieldName);
+
+                if (field != null)
+                {
+                    var domDescriptionAttribute = field.GetCustomAttribute<DomDescriptionAttribute>();
+
+                    if (domDescriptionAttribute != null) description = domDescriptionAttribute.Description;
+                }
+            }
+
+            return description;
         }
     }
 }

--- a/src/AngleSharp/Common/ObjectExtensions.cs
+++ b/src/AngleSharp/Common/ObjectExtensions.cs
@@ -177,7 +177,10 @@ namespace AngleSharp.Common
                 {
                     var domDescriptionAttribute = field.GetCustomAttribute<DomDescriptionAttribute>();
 
-                    if (domDescriptionAttribute != null) description = domDescriptionAttribute.Description;
+                    if (domDescriptionAttribute != null)
+                    {
+                        description = domDescriptionAttribute.Description;
+                    }
                 }
             }
 

--- a/src/AngleSharp/Common/ObjectExtensions.cs
+++ b/src/AngleSharp/Common/ObjectExtensions.cs
@@ -163,28 +163,13 @@ namespace AngleSharp.Common
         /// <param name="code">A specific error code.</param>
         /// <returns>The description of the error.</returns>
         public static String GetMessage<T>(this T code)
-            where T : struct
+            where T : Enum
         {
-            var description = "An unknown error occurred.";
+            var field = typeof(T).GetField(code.ToString());
 
-            var fieldName = code.ToString();
+            var description = field?.GetCustomAttribute<DomDescriptionAttribute>()?.Description;
 
-            if (fieldName != null)
-            {
-                var field = typeof(T).GetField(fieldName);
-
-                if (field != null)
-                {
-                    var domDescriptionAttribute = field.GetCustomAttribute<DomDescriptionAttribute>();
-
-                    if (domDescriptionAttribute != null)
-                    {
-                        description = domDescriptionAttribute.Description;
-                    }
-                }
-            }
-
-            return description;
+            return description ?? "An unknown error occurred.";
         }
     }
 }

--- a/src/AngleSharp/Css/DefaultAttributeSelectorFactory.cs
+++ b/src/AngleSharp/Css/DefaultAttributeSelectorFactory.cs
@@ -96,7 +96,7 @@ namespace AngleSharp.Css
         /// </summary>
         /// <param name="combinator">The used CSS combinator.</param>
         /// <returns>The registered creator, if any.</returns>
-        public Creator Unregister(String combinator)
+        public Creator? Unregister(String combinator)
         {
             if (_creators.TryGetValue(combinator, out var creator))
             {

--- a/src/AngleSharp/Css/DefaultPseudoClassSelectorFactory.cs
+++ b/src/AngleSharp/Css/DefaultPseudoClassSelectorFactory.cs
@@ -65,7 +65,7 @@ namespace AngleSharp.Css
         /// </summary>
         /// <param name="name">The name of the CSS pseudo class.</param>
         /// <returns>The registered selector, if any.</returns>
-        public ISelector Unregister(String name)
+        public ISelector? Unregister(String name)
         {
             if (_selectors.TryGetValue(name, out var selector))
             {

--- a/src/AngleSharp/Css/DefaultPseudoElementSelectorFactory.cs
+++ b/src/AngleSharp/Css/DefaultPseudoElementSelectorFactory.cs
@@ -39,7 +39,7 @@ namespace AngleSharp.Css
         /// </summary>
         /// <param name="name">The name of the CSS pseudo element.</param>
         /// <returns>The registered selector, if any.</returns>
-        public ISelector Unregister(String name)
+        public ISelector? Unregister(String name)
         {
             if (_selectors.TryGetValue(name, out var selector))
             {

--- a/src/AngleSharp/Css/Dom/StyleExtensions.cs
+++ b/src/AngleSharp/Css/Dom/StyleExtensions.cs
@@ -143,7 +143,7 @@ namespace AngleSharp.Css.Dom
 
             for (var i = 0; i < length && uri is null; i++)
             {
-                uri = sheets[i].LocateNamespace(prefix);
+                uri = sheets[i]?.LocateNamespace(prefix);
             }
 
             return uri;

--- a/src/AngleSharp/Css/Priority.cs
+++ b/src/AngleSharp/Css/Priority.cs
@@ -181,11 +181,7 @@ namespace AngleSharp.Css
         /// </summary>
         /// <param name="obj">The object to test with.</param>
         /// <returns>True if the two objects are equal, otherwise false.</returns>
-#if NET5_0_OR_GREATER
         public override Boolean Equals(Object? obj) => obj is Priority other && Equals(other);
-#else
-        public override Boolean Equals(Object obj) => obj is Priority other && Equals(other);
-#endif
 
         /// <summary>
         /// Returns a hash code that defines the current priority.

--- a/src/AngleSharp/Css/Priority.cs
+++ b/src/AngleSharp/Css/Priority.cs
@@ -181,7 +181,11 @@ namespace AngleSharp.Css
         /// </summary>
         /// <param name="obj">The object to test with.</param>
         /// <returns>True if the two objects are equal, otherwise false.</returns>
-        public override Boolean Equals(Object obj) => (obj is Priority other) ? Equals(other) : false;
+#if NET5_0_OR_GREATER
+        public override Boolean Equals(Object? obj) => obj is Priority other && Equals(other);
+#else
+        public override Boolean Equals(Object obj) => obj is Priority other && Equals(other);
+#endif
 
         /// <summary>
         /// Returns a hash code that defines the current priority.

--- a/src/AngleSharp/Dom/AttrExtensions.cs
+++ b/src/AngleSharp/Dom/AttrExtensions.cs
@@ -26,7 +26,9 @@ namespace AngleSharp.Dom
                         found = elA.GetHashCode() == elB.GetHashCode();
 
                         if (found)
+                        {
                             break;
+                        }
                     }
 
                     if (!found)
@@ -49,7 +51,9 @@ namespace AngleSharp.Dom
         public static INamedNodeMap Clear(this INamedNodeMap attributes)
         {
             if (attributes is null)
+            {
                 throw new ArgumentNullException(nameof(attributes));
+            }
 
             while (attributes.Length > 0)
             {

--- a/src/AngleSharp/Dom/DefaultDocumentFactory.cs
+++ b/src/AngleSharp/Dom/DefaultDocumentFactory.cs
@@ -46,7 +46,7 @@ namespace AngleSharp.Dom
         /// </summary>
         /// <param name="contentType">The content-type value.</param>
         /// <returns>The registered creator, if any.</returns>
-        public virtual Creator Unregister(String contentType)
+        public virtual Creator? Unregister(String contentType)
         {
             if (_creators.TryGetValue(contentType, out var creator))
             {

--- a/src/AngleSharp/Dom/DocumentExtensions.cs
+++ b/src/AngleSharp/Dom/DocumentExtensions.cs
@@ -39,7 +39,7 @@ namespace AngleSharp.Dom
                 foreach (var ctor in ctors)
                 {
                     var parameters = ctor.GetParameters();
-                    var arguments = new Object[parameters.Length];
+                    var arguments = new Object?[parameters.Length];
 
                     for (var i = 0; i < parameters.Length; i++)
                     {

--- a/src/AngleSharp/Dom/DocumentExtensions.cs
+++ b/src/AngleSharp/Dom/DocumentExtensions.cs
@@ -25,7 +25,9 @@ namespace AngleSharp.Dom
             where TElement : IElement
         {
             if (document is null)
+            {
                 throw new ArgumentNullException(nameof(document));
+            }
 
             var type = typeof(BrowsingContext).Assembly.GetTypes()
                 .Where(m => !m.IsAbstract && m.GetInterfaces().Contains(typeof(TElement)))
@@ -282,7 +284,9 @@ namespace AngleSharp.Dom
         public static IEnumerable<IDownload> GetDownloads(this IDocument document)
         {
             if (document is null)
+            {
                 throw new ArgumentNullException(nameof(document));
+            }
 
             foreach (var element in document.All)
             {

--- a/src/AngleSharp/Dom/EventTarget.cs
+++ b/src/AngleSharp/Dom/EventTarget.cs
@@ -151,7 +151,9 @@ namespace AngleSharp.Dom
         public Boolean Dispatch(Event ev)
         {
             if (ev is null || ((ev.Flags & EventFlags.Dispatch) == EventFlags.Dispatch) || ((ev.Flags & EventFlags.Initialized) != EventFlags.Initialized))
+            {
                 throw new DomException(DomError.InvalidState);
+            }
 
             ev.IsTrusted = false;
             return ev.Dispatch(this);

--- a/src/AngleSharp/Dom/EventTargetExtensions.cs
+++ b/src/AngleSharp/Dom/EventTargetExtensions.cs
@@ -75,10 +75,14 @@ namespace AngleSharp.Dom
             where TEventTarget : IEventTarget
         {
             if (node is null)
+            {
                 throw new ArgumentNullException(nameof(node));
+            }
 
             if (eventName is null)
+            {
                 throw new ArgumentNullException(nameof(eventName));
+            }
 
             var completion = new TaskCompletionSource<Event>();
             void handler(Object s, Event ev) => completion.TrySetResult(ev);

--- a/src/AngleSharp/Dom/Events/DefaultEventFactory.cs
+++ b/src/AngleSharp/Dom/Events/DefaultEventFactory.cs
@@ -56,7 +56,7 @@ namespace AngleSharp.Dom.Events
         /// </summary>
         /// <param name="name">The name of the event.</param>
         /// <returns>The registered creator, if any.</returns>
-        public Creator Unregister(String name)
+        public Creator? Unregister(String name)
         {
             if (_creators.TryGetValue(name, out var creator))
             {

--- a/src/AngleSharp/Dom/IStyleSheetList.cs
+++ b/src/AngleSharp/Dom/IStyleSheetList.cs
@@ -1,4 +1,4 @@
-﻿namespace AngleSharp.Dom
+namespace AngleSharp.Dom
 {
     using AngleSharp.Attributes;
     using System;
@@ -19,7 +19,7 @@
         /// <returns>The stylesheet.</returns>
         [DomName("item")]
         [DomAccessor(Accessors.Getter)]
-        IStyleSheet this[Int32 index] { get; }
+        IStyleSheet? this[Int32 index] { get; }
         
         /// <summary>
         /// Gets the number of elements in the list of stylesheets.

--- a/src/AngleSharp/Dom/Internal/Attr.cs
+++ b/src/AngleSharp/Dom/Internal/Attr.cs
@@ -173,11 +173,7 @@ namespace AngleSharp.Dom
         /// </summary>
         /// <param name="other">The other attribute.</param>
         /// <returns>True if both are equivalent, otherwise false.</returns>
-#if NET5_0_OR_GREATER
         public Boolean Equals(IAttr? other) =>  Prefix.Is(other?.Prefix) && NamespaceUri.Is(other?.NamespaceUri) && Value.Is(other?.Value);
-#else
-        public Boolean Equals(IAttr other) => Prefix.Is(other.Prefix) && NamespaceUri.Is(other.NamespaceUri) && Value.Is(other.Value);
-#endif
 
         /// <summary>
         /// Computes the hash code of the attribute.

--- a/src/AngleSharp/Dom/Internal/Attr.cs
+++ b/src/AngleSharp/Dom/Internal/Attr.cs
@@ -173,7 +173,11 @@ namespace AngleSharp.Dom
         /// </summary>
         /// <param name="other">The other attribute.</param>
         /// <returns>True if both are equivalent, otherwise false.</returns>
+#if NET5_0_OR_GREATER
+        public Boolean Equals(IAttr? other) =>  Prefix.Is(other?.Prefix) && NamespaceUri.Is(other?.NamespaceUri) && Value.Is(other?.Value);
+#else
         public Boolean Equals(IAttr other) => Prefix.Is(other.Prefix) && NamespaceUri.Is(other.NamespaceUri) && Value.Is(other.Value);
+#endif
 
         /// <summary>
         /// Computes the hash code of the attribute.

--- a/src/AngleSharp/Dom/Internal/CharacterData.cs
+++ b/src/AngleSharp/Dom/Internal/CharacterData.cs
@@ -135,7 +135,9 @@ namespace AngleSharp.Dom
             var length = _content.Length;
 
             if (offset > length)
+            {
                 throw new DomException(DomError.IndexSizeError);
+            }
 
             if (offset + count > length)
             {
@@ -157,7 +159,9 @@ namespace AngleSharp.Dom
             var length = _content.Length;
 
             if (offset > length)
+            {
                 throw new DomException(DomError.IndexSizeError);
+            }
 
             if (offset + count > length)
             {

--- a/src/AngleSharp/Dom/Internal/Document.cs
+++ b/src/AngleSharp/Dom/Internal/Document.cs
@@ -1476,8 +1476,11 @@ namespace AngleSharp.Dom
             await _context.InteractAsync(EventNames.Print, new { Document = this }).ConfigureAwait(false);
             await this.QueueTaskAsync(_ => this.FireSimpleEvent(EventNames.AfterPrint)).ConfigureAwait(false);
         }
-
+#if NET5_0_OR_GREATER
+        private async void LocationChanged(Object? sender, Location.ChangedEventArgs e)
+#else
         private async void LocationChanged(Object sender, Location.ChangedEventArgs e)
+#endif
         {
             if (e.IsHashChanged)
             {
@@ -1564,6 +1567,6 @@ namespace AngleSharp.Dom
         {
             return _importedUris?.Contains(uri) ?? false;
         }
-        #endregion
+#endregion
     }
 }

--- a/src/AngleSharp/Dom/Internal/Document.cs
+++ b/src/AngleSharp/Dom/Internal/Document.cs
@@ -1492,11 +1492,8 @@ namespace AngleSharp.Dom
             await _context.InteractAsync(EventNames.Print, new { Document = this }).ConfigureAwait(false);
             await this.QueueTaskAsync(_ => this.FireSimpleEvent(EventNames.AfterPrint)).ConfigureAwait(false);
         }
-#if NET5_0_OR_GREATER
+
         private async void LocationChanged(Object? sender, Location.ChangedEventArgs e)
-#else
-        private async void LocationChanged(Object sender, Location.ChangedEventArgs e)
-#endif
         {
             if (e.IsHashChanged)
             {

--- a/src/AngleSharp/Dom/Internal/Document.cs
+++ b/src/AngleSharp/Dom/Internal/Document.cs
@@ -742,7 +742,9 @@ namespace AngleSharp.Dom
             set
             {
                 if (value is IHtmlBodyElement == false && value is HtmlFrameSetElement == false)
+                {
                     throw new DomException(DomError.HierarchyRequest);
+                }
 
                 var body = Body;
 
@@ -753,7 +755,9 @@ namespace AngleSharp.Dom
                         var root = DocumentElement;
 
                         if (root is null)
+                        {
                             throw new DomException(DomError.HierarchyRequest);
+                        }
 
                         root.AppendChild(value);
                     }
@@ -786,7 +790,7 @@ namespace AngleSharp.Dom
         public String Domain
         {
             get => String.IsNullOrEmpty(DocumentUri) ? String.Empty : new Uri(DocumentUri).Host;
-            set { if (_location is null) return; _location.Host = value; }
+            set { if (_location is null) { return; } _location.Host = value; }
         }
 
         /// <inheritdoc />
@@ -900,14 +904,18 @@ namespace AngleSharp.Dom
         public IDocument Open(String type = "text/html", String? replace = null)
         {
             if (!ContentType.Is(MimeTypeNames.Html))
+            {
                 throw new DomException(DomError.InvalidState);
+            }
 
             if (!IsInBrowsingContext || Object.ReferenceEquals(_context.Active, this))
             {
                 var responsibleDocument = _context?.Parent!.Active;
 
                 if (responsibleDocument != null && !responsibleDocument.Origin.Is(Origin))
+                {
                     throw new DomException(DomError.Security);
+                }
 
                 if (!_firedUnload && _loadingScripts.Count == 0)
                 {
@@ -1013,7 +1021,9 @@ namespace AngleSharp.Dom
         public INode Import(INode externalNode, Boolean deep = true)
         {
             if (externalNode.NodeType == NodeType.Document)
+            {
                 throw new DomException(DomError.NotSupported);
+            }
 
             return externalNode.Clone(deep);
         }
@@ -1022,7 +1032,9 @@ namespace AngleSharp.Dom
         public INode Adopt(INode externalNode)
         {
             if (externalNode.NodeType == NodeType.Document)
+            {
                 throw new DomException(DomError.NotSupported);
+            }
 
             this.AdoptNode(externalNode);
             return externalNode;
@@ -1114,7 +1126,9 @@ namespace AngleSharp.Dom
         public IProcessingInstruction CreateProcessingInstruction(String target, String data)
         {
             if (!target.IsXmlName() || data.Contains("?>"))
+            {
                 throw new DomException(DomError.InvalidCharacter);
+            }
 
             return new ProcessingInstruction(this, target) { Data = data };
         }
@@ -1147,7 +1161,9 @@ namespace AngleSharp.Dom
         public IAttr CreateAttribute(String localName)
         {
             if (!localName.IsXmlName())
+            {
                 throw new DomException(DomError.InvalidCharacter);
+            }
 
             return new Attr(localName);
         }
@@ -1538,7 +1554,9 @@ namespace AngleSharp.Dom
         public bool AddImportUrl(Uri uri)
         {
             if (uri is null)
+            {
                 return false;
+            }
 
             IDocument? ancestor = this;
 
@@ -1554,10 +1572,12 @@ namespace AngleSharp.Dom
             }
 
             if (_importedUris is null)
-                lock(_importedUrisLock)
+            {
+                lock (_importedUrisLock)
                 {
                     _importedUris = _importedUris ?? new HashSet<Uri>();
                 }
+            }
 
             return _importedUris.Add(uri);
         }

--- a/src/AngleSharp/Dom/Internal/DomImplementation.cs
+++ b/src/AngleSharp/Dom/Internal/DomImplementation.cs
@@ -52,13 +52,19 @@ namespace AngleSharp.Dom
         public IDocumentType CreateDocumentType(String qualifiedName, String publicId, String systemId)
         {
             if (qualifiedName is null)
+            {
                 throw new ArgumentNullException(nameof(qualifiedName));
+            }
 
             if (!qualifiedName.IsXmlName())
+            {
                 throw new DomException(DomError.InvalidCharacter);
+            }
 
             if (!qualifiedName.IsQualifiedName())
+            {
                 throw new DomException(DomError.Namespace);
+            }
 
             return new DocumentType(_owner, qualifiedName) 
             { 
@@ -89,7 +95,9 @@ namespace AngleSharp.Dom
         public Boolean HasFeature(String feature, String? version = null)
         {
             if (feature is null)
+            {
                 throw new ArgumentNullException(nameof(feature));
+            }
 
             if (features.TryGetValue(feature, out var versions))
             {

--- a/src/AngleSharp/Dom/Internal/Element.cs
+++ b/src/AngleSharp/Dom/Internal/Element.cs
@@ -505,6 +505,19 @@ namespace AngleSharp.Dom
         }
 
         /// <inheritdoc />
+#if NET5_0_OR_GREATER
+        public override Boolean Equals(INode? otherNode)
+        {
+            if (otherNode is IElement otherElement)
+            {
+                return NamespaceUri.Is(otherElement.NamespaceUri) &&
+                    _attributes.SameAs(otherElement.Attributes) &&
+                    base.Equals(otherNode);
+            }
+
+            return false;
+        }
+#else
         public override Boolean Equals(INode otherNode)
         {
             if (otherNode is IElement otherElement)
@@ -516,6 +529,7 @@ namespace AngleSharp.Dom
 
             return false;
         }
+#endif
 
         /// <inheritdoc />
         public void Before(params INode[] nodes) => this.InsertBefore(nodes);

--- a/src/AngleSharp/Dom/Internal/Element.cs
+++ b/src/AngleSharp/Dom/Internal/Element.cs
@@ -327,10 +327,14 @@ namespace AngleSharp.Dom
         public IShadowRoot AttachShadow(ShadowRootMode mode = ShadowRootMode.Open)
         {
             if (TagNames.AllNoShadowRoot.Contains(_localName))
+            {
                 throw new DomException(DomError.NotSupported);
+            }
 
             if (ShadowRoot != null)
+            {
                 throw new DomException(DomError.InvalidState);
+            }
 
             _shadowRoot = new ShadowRoot(this, mode);
             return _shadowRoot;
@@ -431,7 +435,9 @@ namespace AngleSharp.Dom
             if (value != null)
             {
                 if (!name.IsXmlName())
+                {
                     throw new DomException(DomError.InvalidCharacter);
+                }
 
                 if (_namespace.Is(NamespaceNames.HtmlUri))
                 {

--- a/src/AngleSharp/Dom/Internal/Element.cs
+++ b/src/AngleSharp/Dom/Internal/Element.cs
@@ -511,7 +511,6 @@ namespace AngleSharp.Dom
         }
 
         /// <inheritdoc />
-#if NET5_0_OR_GREATER
         public override Boolean Equals(INode? otherNode)
         {
             if (otherNode is IElement otherElement)
@@ -523,19 +522,6 @@ namespace AngleSharp.Dom
 
             return false;
         }
-#else
-        public override Boolean Equals(INode otherNode)
-        {
-            if (otherNode is IElement otherElement)
-            {
-                return NamespaceUri.Is(otherElement.NamespaceUri) &&
-                    _attributes.SameAs(otherElement.Attributes) &&
-                    base.Equals(otherNode);
-            }
-
-            return false;
-        }
-#endif
 
         /// <inheritdoc />
         public void Before(params INode[] nodes) => this.InsertBefore(nodes);

--- a/src/AngleSharp/Dom/Internal/NamedNodeMap.cs
+++ b/src/AngleSharp/Dom/Internal/NamedNodeMap.cs
@@ -225,7 +225,9 @@ namespace AngleSharp.Dom
             var result = RemoveNamedItemOrDefault(name);
 
             if (result is null)
+            {
                 throw new DomException(DomError.NotFound);
+            }
 
             return result;
         }
@@ -236,7 +238,9 @@ namespace AngleSharp.Dom
             var result = RemoveNamedItemOrDefault(namespaceUri, localName);
 
             if (result is null)
+            {
                 throw new DomException(DomError.NotFound);
+            }
 
             return result;
         }
@@ -268,7 +272,9 @@ namespace AngleSharp.Dom
                 }
 
                 if (attr.Container != null)
+                {
                     throw new DomException(DomError.InUse);
+                }
 
                 attr.Container = this;
             }

--- a/src/AngleSharp/Dom/Internal/Node.cs
+++ b/src/AngleSharp/Dom/Internal/Node.cs
@@ -284,7 +284,9 @@ namespace AngleSharp.Dom
             }
 
             if (newElement.NodeType == NodeType.Document || newElement.Contains(this))
+            {
                 throw new DomException(DomError.HierarchyRequest);
+            }
 
             var addedNodes = new NodeList();
             var n = _children.Index(referenceElement!);
@@ -384,10 +386,14 @@ namespace AngleSharp.Dom
         internal Node ReplaceChild(Node node, Node child, Boolean suppressObservers)
         {
             if (this.IsEndPoint() || node.IsHostIncludingInclusiveAncestor(this))
+            {
                 throw new DomException(DomError.HierarchyRequest);
+            }
 
             if (child.Parent != this)
+            {
                 throw new DomException(DomError.NotFound);
+            }
 
             if (node.IsInsertable())
             {
@@ -397,7 +403,9 @@ namespace AngleSharp.Dom
                 var removedNodes = new NodeList();
 
                 if (this is IDocument parent && IsChangeForbidden(node, parent, child))
+                {
                     throw new DomException(DomError.HierarchyRequest);
+                }
 
                 if (Object.ReferenceEquals(referenceChild, node))
                 {
@@ -781,10 +789,14 @@ namespace AngleSharp.Dom
         protected static void GetPrefixAndLocalName(String qualifiedName, ref String? namespaceUri, out String? prefix, out String localName)
         {
             if (!qualifiedName.IsXmlName())
+            {
                 throw new DomException(DomError.InvalidCharacter);
+            }
 
             if (!qualifiedName.IsQualifiedName())
+            {
                 throw new DomException(DomError.Namespace);
+            }
 
             if (String.IsNullOrEmpty(namespaceUri))
             {
@@ -805,7 +817,9 @@ namespace AngleSharp.Dom
             }
 
             if (IsNamespaceError(prefix, namespaceUri, qualifiedName))
+            {
                 throw new DomException(DomError.Namespace);
+            }
         }
 
         /// <inheritdoc />

--- a/src/AngleSharp/Dom/Internal/Node.cs
+++ b/src/AngleSharp/Dom/Internal/Node.cs
@@ -712,7 +712,26 @@ namespace AngleSharp.Dom
             return namespaceUri.Is(defaultNamespace);
         }
 
-        /// <inheritdoc />
+        /// <inheritdoc cref="IEquatable{T}.Equals(T)" />
+#if NET5_0_OR_GREATER
+        public virtual Boolean Equals(INode? otherNode)
+        {
+            if (BaseUri.Is(otherNode?.BaseUri) && NodeName.Is(otherNode?.NodeName) && ChildNodes.Length == otherNode?.ChildNodes.Length)
+            {
+                for (var i = 0; i < _children.Length; i++)
+                {
+                    if (!_children[i].Equals(otherNode.ChildNodes[i]))
+                    {
+                        return false;
+                    }
+                }
+
+                return true;
+            }
+
+            return false;
+        }
+#else
         public virtual Boolean Equals(INode otherNode)
         {
             if (BaseUri.Is(otherNode.BaseUri) && NodeName.Is(otherNode.NodeName) && ChildNodes.Length == otherNode.ChildNodes.Length)
@@ -730,6 +749,7 @@ namespace AngleSharp.Dom
 
             return false;
         }
+#endif
 
         #endregion
 

--- a/src/AngleSharp/Dom/Internal/Node.cs
+++ b/src/AngleSharp/Dom/Internal/Node.cs
@@ -721,7 +721,6 @@ namespace AngleSharp.Dom
         }
 
         /// <inheritdoc cref="IEquatable{T}.Equals(T)" />
-#if NET5_0_OR_GREATER
         public virtual Boolean Equals(INode? otherNode)
         {
             if (BaseUri.Is(otherNode?.BaseUri) && NodeName.Is(otherNode?.NodeName) && ChildNodes.Length == otherNode?.ChildNodes.Length)
@@ -739,25 +738,6 @@ namespace AngleSharp.Dom
 
             return false;
         }
-#else
-        public virtual Boolean Equals(INode otherNode)
-        {
-            if (BaseUri.Is(otherNode.BaseUri) && NodeName.Is(otherNode.NodeName) && ChildNodes.Length == otherNode.ChildNodes.Length)
-            {
-                for (var i = 0; i < _children.Length; i++)
-                {
-                    if (!_children[i].Equals(otherNode.ChildNodes[i]))
-                    {
-                        return false;
-                    }
-                }
-
-                return true;
-            }
-
-            return false;
-        }
-#endif
 
         #endregion
 

--- a/src/AngleSharp/Dom/Internal/Range.cs
+++ b/src/AngleSharp/Dom/Internal/Range.cs
@@ -72,13 +72,19 @@ namespace AngleSharp.Dom
         public void StartWith(INode refNode, Int32 offset)
         {
             if (refNode is null)
+            {
                 throw new ArgumentNullException(nameof(refNode));
+            }
 
             if (refNode.NodeType == NodeType.DocumentType)
+            {
                 throw new DomException(DomError.InvalidNodeType);
+            }
 
             if (offset > refNode.ChildNodes.Length)
+            {
                 throw new DomException(DomError.IndexSizeError);
+            }
 
             var bp = new Boundary(refNode, offset);
 
@@ -91,13 +97,19 @@ namespace AngleSharp.Dom
         public void EndWith(INode refNode, Int32 offset)
         {
             if (refNode is null)
+            {
                 throw new ArgumentNullException(nameof(refNode));
+            }
 
             if (refNode.NodeType == NodeType.DocumentType)
+            {
                 throw new DomException(DomError.InvalidNodeType);
+            }
 
             if (offset > refNode.ChildNodes.Length)
+            {
                 throw new DomException(DomError.IndexSizeError);
+            }
 
             var bp = new Boundary(refNode, offset);
 
@@ -110,12 +122,16 @@ namespace AngleSharp.Dom
         public void StartBefore(INode refNode)
         {
             if (refNode is null)
+            {
                 throw new ArgumentNullException(nameof(refNode));
+            }
 
             var parent = refNode.Parent;
 
             if (parent is null)
+            {
                 throw new DomException(DomError.InvalidNodeType);
+            }
 
             _start = new Boundary(parent, parent.ChildNodes.Index(refNode));
         }
@@ -123,12 +139,16 @@ namespace AngleSharp.Dom
         public void EndBefore(INode refNode)
         {
             if (refNode is null)
+            {
                 throw new ArgumentNullException(nameof(refNode));
+            }
 
             var parent = refNode.Parent;
 
             if (parent is null)
+            {
                 throw new DomException(DomError.InvalidNodeType);
+            }
 
             _end = new Boundary(parent, parent.ChildNodes.Index(refNode));
         }
@@ -136,12 +156,16 @@ namespace AngleSharp.Dom
         public void StartAfter(INode refNode)
         {
             if (refNode is null)
+            {
                 throw new ArgumentNullException(nameof(refNode));
+            }
 
             var parent = refNode.Parent;
 
             if (parent is null)
+            {
                 throw new DomException(DomError.InvalidNodeType);
+            }
 
             _start = new Boundary(parent, parent.ChildNodes.Index(refNode) + 1);
         }
@@ -149,12 +173,16 @@ namespace AngleSharp.Dom
         public void EndAfter(INode refNode)
         {
             if (refNode is null)
+            {
                 throw new ArgumentNullException(nameof(refNode));
+            }
 
             var parent = refNode.Parent;
 
             if (parent is null)
+            {
                 throw new DomException(DomError.InvalidNodeType);
+            }
 
             _end = new Boundary(parent, parent.ChildNodes.Index(refNode) + 1);
         }
@@ -174,12 +202,16 @@ namespace AngleSharp.Dom
         public void Select(INode refNode)
         {
             if (refNode is null)
+            {
                 throw new ArgumentNullException(nameof(refNode));
+            }
 
             var parent = refNode.Parent;
 
             if (parent is null)
+            {
                 throw new DomException(DomError.InvalidNodeType);
+            }
 
             var index = parent.ChildNodes.Index(refNode);
             _start = new Boundary(parent, index);
@@ -189,10 +221,14 @@ namespace AngleSharp.Dom
         public void SelectContent(INode refNode)
         {
             if (refNode is null)
+            {
                 throw new ArgumentNullException(nameof(refNode));
+            }
 
             if (refNode.NodeType == NodeType.DocumentType)
+            {
                 throw new DomException(DomError.InvalidNodeType);
+            }
 
             var length = refNode.ChildNodes.Length;
             _start = new Boundary(refNode, 0);
@@ -297,7 +333,9 @@ namespace AngleSharp.Dom
                     var containedChildren = commonAncestor.GetNodes<INode>(predicate: Intersects).ToList();
 
                     if (containedChildren.OfType<IDocumentType>().Any())
+                    {
                         throw new DomException(DomError.HierarchyRequest);
+                    }
 
                     if (!originalStart.Node.IsInclusiveAncestorOf(originalEnd.Node))
                     {
@@ -395,7 +433,9 @@ namespace AngleSharp.Dom
                     var containedChildren = commonAncestor.GetNodes<INode>(predicate: Intersects).ToList();
 
                     if (containedChildren.OfType<IDocumentType>().Any())
+                    {
                         throw new DomException(DomError.HierarchyRequest);
+                    }
 
                     if (firstPartiallyContainedChild is ICharacterData)
                     {
@@ -444,14 +484,18 @@ namespace AngleSharp.Dom
         public void Insert(INode node)
         {
             if (node is null)
+            {
                 throw new ArgumentNullException(nameof(node));
+            }
 
             var snode = _start.Node;
             var type = snode.NodeType;
             var istext = type == NodeType.Text;
 
             if (type == NodeType.ProcessingInstruction || type == NodeType.Comment || (istext && snode.Parent is null))
+            {
                 throw new DomException(DomError.HierarchyRequest);
+            }
 
             var referenceNode = istext ? snode : _start.ChildAtOffset;
             var parent = referenceNode is null ? snode : referenceNode.Parent;
@@ -482,15 +526,21 @@ namespace AngleSharp.Dom
         public void Surround(INode newParent)
         {
             if (newParent is null)
+            {
                 throw new ArgumentNullException(nameof(newParent));
+            }
 
             if (Nodes.Any(m => m.NodeType != NodeType.Text && IsPartiallyContained(m)))
+            {
                 throw new DomException(DomError.InvalidState);
+            }
 
             var type = newParent.NodeType;
 
             if (type == NodeType.Document || type == NodeType.DocumentType || type == NodeType.DocumentFragment)
+            {
                 throw new DomException(DomError.InvalidNodeType);
+            }
 
             var fragment = ExtractContent();
 
@@ -517,15 +567,21 @@ namespace AngleSharp.Dom
         public Boolean Contains(INode node, Int32 offset)
         {
             if (node is null)
+            {
                 throw new ArgumentNullException(nameof(node));
+            }
 
             if (node.GetRoot() == Root)
             {
                 if (node.NodeType == NodeType.DocumentType)
+                {
                     throw new DomException(DomError.InvalidNodeType);
+                }
 
                 if (offset > node.ChildNodes.Length)
+                {
                     throw new DomException(DomError.IndexSizeError);
+                }
 
                 return !IsStartAfter(node, offset) && !IsEndBefore(node, offset);
             }
@@ -536,10 +592,14 @@ namespace AngleSharp.Dom
         public RangePosition CompareBoundaryTo(RangeType how, IRange sourceRange)
         {
             if (sourceRange is null)
+            {
                 throw new ArgumentNullException(nameof(sourceRange));
+            }
 
             if (Root != sourceRange.Head.GetRoot())
+            {
                 throw new DomException(DomError.WrongDocument);
+            }
 
             var thisPoint = default(Boundary);
             var otherPoint = default(Boundary);
@@ -576,16 +636,24 @@ namespace AngleSharp.Dom
         public RangePosition CompareTo(INode node, Int32 offset)
         {
             if (node is null)
+            {
                 throw new ArgumentNullException(nameof(node));
+            }
 
             if (Root != _start.Node.GetRoot())
+            {
                 throw new DomException(DomError.WrongDocument);
+            }
 
             if (node.NodeType == NodeType.DocumentType)
+            {
                 throw new DomException(DomError.InvalidNodeType);
+            }
 
             if (offset > node.ChildNodes.Length)
+            {
                 throw new DomException(DomError.IndexSizeError);
+            }
 
             if (IsStartAfter(node, offset))
             {
@@ -602,7 +670,9 @@ namespace AngleSharp.Dom
         public Boolean Intersects(INode node)
         {
             if (node is null)
+            {
                 throw new ArgumentNullException(nameof(node));
+            }
 
             if (Root == node.GetRoot())
             {

--- a/src/AngleSharp/Dom/Internal/StringMap.cs
+++ b/src/AngleSharp/Dom/Internal/StringMap.cs
@@ -59,15 +59,21 @@ namespace AngleSharp.Dom
         private static String Check(String name)
         {
             if (name.StartsWith(TagNames.Xml, StringComparison.OrdinalIgnoreCase))
+            {
                 throw new DomException(DomError.Syntax);
+            }
 
             if (name.IndexOf(Symbols.Semicolon) >= 0)
+            {
                 throw new DomException(DomError.Syntax);
+            }
 
             for (var i = 0; i < name.Length; i++)
             {
                 if (name[i].IsUppercaseAscii())
+                {
                     throw new DomException(DomError.Syntax);
+                }
             }
 
             return name;

--- a/src/AngleSharp/Dom/Internal/StyleSheetList.cs
+++ b/src/AngleSharp/Dom/Internal/StyleSheetList.cs
@@ -1,4 +1,4 @@
-﻿namespace AngleSharp.Dom
+namespace AngleSharp.Dom
 {
     using System;
     using System.Collections;
@@ -38,7 +38,7 @@
         /// </summary>
         /// <param name="index">The index of the element.</param>
         /// <returns>The stylesheet.</returns>
-        public IStyleSheet this[Int32 index] => _sheets.Skip(index).FirstOrDefault();
+        public IStyleSheet? this[Int32 index] => _sheets.Skip(index).FirstOrDefault();
 
         #endregion
 

--- a/src/AngleSharp/Dom/Internal/TextNode.cs
+++ b/src/AngleSharp/Dom/Internal/TextNode.cs
@@ -90,7 +90,9 @@ namespace AngleSharp.Dom
             var length = Length;
 
             if (offset > length)
+            {
                 throw new DomException(DomError.IndexSizeError);
+            }
 
             var count = length - offset;
             var newData = Substring(offset, count);

--- a/src/AngleSharp/Dom/MutationObserver.cs
+++ b/src/AngleSharp/Dom/MutationObserver.cs
@@ -207,16 +207,24 @@ namespace AngleSharp.Dom
                 };
 
                 if (options.IsExaminingOldAttributeValue && !options.IsObservingAttributes)
+                {
                     throw new DomException(DomError.TypeMismatch);
+                }
 
                 if (options.AttributeFilters != null && !options.IsObservingAttributes)
+                {
                     throw new DomException(DomError.TypeMismatch);
+                }
 
                 if (options.IsExaminingOldCharacterData && !options.IsObservingCharacterData)
+                {
                     throw new DomException(DomError.TypeMismatch);
+                }
 
                 if (options.IsInvalid)
+                {
                     throw new DomException(DomError.Syntax);
+                }
 
                 if (node is Document document && document.DocumentElement is Node documentElement) {
                     node = documentElement;
@@ -224,7 +232,9 @@ namespace AngleSharp.Dom
                 }
 
                 if (node.Owner is null)
+                {
                     throw new DomException(DomError.HierarchyRequest);
+                }
 
                 node.Owner.Mutations.Register(this);
 

--- a/src/AngleSharp/Dom/ParentNodeExtensions.cs
+++ b/src/AngleSharp/Dom/ParentNodeExtensions.cs
@@ -138,7 +138,9 @@ namespace AngleSharp.Dom
             where TElement : class, IElement
         {
             if (parent is null)
+            {
                 throw new ArgumentNullException(nameof(parent));
+            }
 
             return (TElement)parent.AppendChild(element);
         }
@@ -157,7 +159,9 @@ namespace AngleSharp.Dom
             where TElement : class, IElement
         {
             if (parent is null)
+            {
                 throw new ArgumentNullException(nameof(parent));
+            }
 
             return (TElement)parent.InsertBefore(newElement, referenceElement);
         }
@@ -174,7 +178,9 @@ namespace AngleSharp.Dom
             where TElement : class, IElement
         {
             if (parent is null)
+            {
                 throw new ArgumentNullException(nameof(parent));
+            }
 
             return (TElement)parent.RemoveChild(element);
         }
@@ -191,10 +197,14 @@ namespace AngleSharp.Dom
             where TElement : class, IElement
         {
             if (parent is null)
+            {
                 throw new ArgumentNullException(nameof(parent));
+            }
 
             if (selectors is null)
+            {
                 throw new ArgumentNullException(nameof(selectors));
+            }
 
             return parent.QuerySelector(selectors) as TElement;
         }
@@ -211,10 +221,14 @@ namespace AngleSharp.Dom
             where TElement : IElement
         {
             if (parent is null)
+            {
                 throw new ArgumentNullException(nameof(parent));
+            }
 
             if (selectors is null)
+            {
                 throw new ArgumentNullException(nameof(selectors));
+            }
 
             return parent.QuerySelectorAll(selectors).OfType<TElement>();
         }
@@ -238,7 +252,9 @@ namespace AngleSharp.Dom
         public static IEnumerable<INode> Descendents(this INode parent)
         {
             if (parent is null)
+            {
                 throw new ArgumentNullException(nameof(parent));
+            }
 
             return parent.GetDescendants();
         }
@@ -262,7 +278,9 @@ namespace AngleSharp.Dom
         public static IEnumerable<INode> DescendentsAndSelf(this INode parent)
         {
             if (parent is null)
+            {
                 throw new ArgumentNullException(nameof(parent));
+            }
 
             return parent.GetDescendantsAndSelf();
         }
@@ -286,7 +304,9 @@ namespace AngleSharp.Dom
         public static IEnumerable<INode> Ancestors(this INode child)
         {
             if (child is null)
+            {
                 throw new ArgumentNullException(nameof(child));
+            }
 
             return child.GetAncestors();
         }

--- a/src/AngleSharp/Dom/SelectorExtensions.cs
+++ b/src/AngleSharp/Dom/SelectorExtensions.cs
@@ -24,7 +24,9 @@ namespace AngleSharp.Dom
             where T : notnull, IElement
         {
             if (elements is null)
+            {
                 throw new ArgumentNullException(nameof(elements));
+            }
 
             return elements.Skip(index).FirstOrDefault();
         }
@@ -40,7 +42,9 @@ namespace AngleSharp.Dom
             where T : IElement
         {
             if (elements is null)
+            {
                 throw new ArgumentNullException(nameof(elements));
+            }
 
             return elements.Skip(index + 1);
         }
@@ -56,7 +60,9 @@ namespace AngleSharp.Dom
             where T : IElement
         {
             if (elements is null)
+            {
                 throw new ArgumentNullException(nameof(elements));
+            }
 
             return elements.Take(index);
         }
@@ -71,7 +77,9 @@ namespace AngleSharp.Dom
             where T : IElement
         {
             if (elements is null)
+            {
                 throw new ArgumentNullException(nameof(elements));
+            }
 
             var even = true;
 
@@ -96,7 +104,9 @@ namespace AngleSharp.Dom
             where T : IElement
         {
             if (elements is null)
+            {
                 throw new ArgumentNullException(nameof(elements));
+            }
 
             var odd = false;
 

--- a/src/AngleSharp/Dom/Url.cs
+++ b/src/AngleSharp/Dom/Url.cs
@@ -873,7 +873,9 @@ namespace AngleSharp.Dom
 
                     case Symbols.Colon:
                         if (inBracket)
+                        {
                             break;
+                        }
 
                         if (!TrySanatizeHost(input, start, index - start, out _host))
                         {

--- a/src/AngleSharp/Dom/Url.cs
+++ b/src/AngleSharp/Dom/Url.cs
@@ -428,7 +428,11 @@ namespace AngleSharp.Dom
         /// <returns>
         /// True if the object is equal to the current object, otherwise false.
         /// </returns>
+#if NET5_0_OR_GREATER
+        public override Boolean Equals(Object? obj)
+#else
         public override Boolean Equals(Object obj)
+#endif
         {
             return ReferenceEquals(this, obj) || obj is Url other && Equals(other);
         }
@@ -443,6 +447,16 @@ namespace AngleSharp.Dom
         /// <returns>
         /// True if the given url is equal to the current url, otherwise false.
         /// </returns>
+#if NET5_0_OR_GREATER
+        public Boolean Equals(Url? other)
+        {
+            return other != null && _fragment.Is(other._fragment) && _query.Is(other._query) &&
+                   _path.Is(other._path) && _scheme.Isi(other._scheme) &&
+                   _port.Is(other._port) && _host.Isi(other._host) &&
+                   _username.Is(other._username) && _password.Is(other._password) &&
+                   _schemeData.Is(other._schemeData);
+        }
+#else
         public Boolean Equals(Url other)
         {
             return other != null && _fragment.Is(other._fragment) && _query.Is(other._query) &&
@@ -451,6 +465,7 @@ namespace AngleSharp.Dom
                 _username.Is(other._username) && _password.Is(other._password) &&
                 _schemeData.Is(other._schemeData);
         }
+#endif
 
         #endregion
 

--- a/src/AngleSharp/Dom/Url.cs
+++ b/src/AngleSharp/Dom/Url.cs
@@ -428,11 +428,7 @@ namespace AngleSharp.Dom
         /// <returns>
         /// True if the object is equal to the current object, otherwise false.
         /// </returns>
-#if NET5_0_OR_GREATER
         public override Boolean Equals(Object? obj)
-#else
-        public override Boolean Equals(Object obj)
-#endif
         {
             return ReferenceEquals(this, obj) || obj is Url other && Equals(other);
         }
@@ -447,7 +443,6 @@ namespace AngleSharp.Dom
         /// <returns>
         /// True if the given url is equal to the current url, otherwise false.
         /// </returns>
-#if NET5_0_OR_GREATER
         public Boolean Equals(Url? other)
         {
             return other != null && _fragment.Is(other._fragment) && _query.Is(other._query) &&
@@ -456,16 +451,6 @@ namespace AngleSharp.Dom
                    _username.Is(other._username) && _password.Is(other._password) &&
                    _schemeData.Is(other._schemeData);
         }
-#else
-        public Boolean Equals(Url other)
-        {
-            return other != null && _fragment.Is(other._fragment) && _query.Is(other._query) &&
-                _path.Is(other._path) && _scheme.Isi(other._scheme) &&
-                _port.Is(other._port) && _host.Isi(other._host) &&
-                _username.Is(other._username) && _password.Is(other._password) &&
-                _schemeData.Is(other._schemeData);
-        }
-#endif
 
         #endregion
 

--- a/src/AngleSharp/Html/DefaultInputTypeFactory.cs
+++ b/src/AngleSharp/Html/DefaultInputTypeFactory.cs
@@ -61,7 +61,7 @@ namespace AngleSharp.Html
         /// </summary>
         /// <param name="type">The input type value.</param>
         /// <returns>The registered creator, if any.</returns>
-        public Creator Unregister(String type)
+        public Creator? Unregister(String type)
         {
             if (_creators.TryGetValue(type, out var creator))
             {

--- a/src/AngleSharp/Html/DefaultLinkRelationFactory.cs
+++ b/src/AngleSharp/Html/DefaultLinkRelationFactory.cs
@@ -40,7 +40,7 @@ namespace AngleSharp.Html
         /// </summary>
         /// <param name="rel">The relation value.</param>
         /// <returns>The registered creator, if any.</returns>
-        public Creator Unregister(String rel)
+        public Creator? Unregister(String rel)
         {
             if (_creators.TryGetValue(rel, out var creator))
             {

--- a/src/AngleSharp/Html/Dom/FormExtensions.cs
+++ b/src/AngleSharp/Html/Dom/FormExtensions.cs
@@ -29,10 +29,14 @@ namespace AngleSharp.Html.Dom
         public static IHtmlFormElement SetValues(this IHtmlFormElement form, IDictionary<String, String> fields, Boolean createMissing = false)
         {
             if (form is null)
+            {
                 throw new ArgumentNullException(nameof(form));
+            }
 
             if (fields is null)
+            {
                 throw new ArgumentNullException(nameof(fields));
+            }
 
             var inputs = form.Elements.OfType<HtmlFormControlElement>();
 

--- a/src/AngleSharp/Html/Dom/IHtmlTableElement.cs
+++ b/src/AngleSharp/Html/Dom/IHtmlTableElement.cs
@@ -1,4 +1,4 @@
-﻿namespace AngleSharp.Html.Dom
+namespace AngleSharp.Html.Dom
 {
     using AngleSharp.Attributes;
     using AngleSharp.Dom;
@@ -14,7 +14,7 @@
         /// Gets or sets the assigned caption element.
         /// </summary>
         [DomName("caption")]
-        IHtmlTableCaptionElement Caption { get; set; }
+        IHtmlTableCaptionElement? Caption { get; set; }
 
         /// <summary>
         /// Creates a new table caption object or returns the existing one.
@@ -33,7 +33,7 @@
         /// Gets or sets the assigned head section.
         /// </summary>
         [DomName("tHead")]
-        IHtmlTableSectionElement Head { get; set; }
+        IHtmlTableSectionElement? Head { get; set; }
 
         /// <summary>
         /// Creates a new table header section or returns the existing one.
@@ -52,7 +52,7 @@
         /// Gets or sets the assigned foot section.
         /// </summary>
         [DomName("tFoot")]
-        IHtmlTableSectionElement Foot { get; set; }
+        IHtmlTableSectionElement? Foot { get; set; }
 
         /// <summary>
         /// Creates a table footer section or returns an existing one.

--- a/src/AngleSharp/Html/Dom/Internal/HtmlAnchorElement.cs
+++ b/src/AngleSharp/Html/Dom/Internal/HtmlAnchorElement.cs
@@ -56,7 +56,9 @@ namespace AngleSharp.Html.Dom
         public override void DoFocus()
         {
             if (this.HasOwnAttribute(AttributeNames.Href))
+            {
                 IsFocused = true;
+            }
         }
 
         #endregion

--- a/src/AngleSharp/Html/Dom/Internal/HtmlCanvasElement.cs
+++ b/src/AngleSharp/Html/Dom/Internal/HtmlCanvasElement.cs
@@ -119,13 +119,19 @@ namespace AngleSharp.Html.Dom
         public void SetContext(IRenderingContext context)
         {
             if (_mode != ContextMode.None && _mode != ContextMode.Indirect)
+            {
                 throw new DomException(DomError.InvalidState);
+            }
 
             if (context.IsFixed)
+            {
                 throw new DomException(DomError.InvalidState);
+            }
 
             if (context.Host != this)
+            {
                 throw new DomException(DomError.InUse);
+            }
 
             _current = context;
             _mode = ContextMode.Indirect;

--- a/src/AngleSharp/Html/Dom/Internal/HtmlFormControlElement.cs
+++ b/src/AngleSharp/Html/Dom/Internal/HtmlFormControlElement.cs
@@ -96,7 +96,7 @@ namespace AngleSharp.Html.Dom
                 if (fieldSet.IsDisabled)
                 {
                     var firstLegend = fieldSet.ChildNodes.FirstOrDefault(m => m is IHtmlLegendElement);
-                    return !this.IsDescendantOf(firstLegend);
+                    return firstLegend == null || !this.IsDescendantOf(firstLegend);
                 }
             }
 

--- a/src/AngleSharp/Html/Dom/Internal/HtmlInputElement.cs
+++ b/src/AngleSharp/Html/Dom/Internal/HtmlInputElement.cs
@@ -89,7 +89,9 @@ namespace AngleSharp.Html.Dom
             set
             {
                 if (Double.IsInfinity(value))
+                {
                     throw new DomException(DomError.TypeMismatch);
+                }
 
                 if (Double.IsNaN(value))
                 {

--- a/src/AngleSharp/Html/Dom/Internal/HtmlOptionElement.cs
+++ b/src/AngleSharp/Html/Dom/Internal/HtmlOptionElement.cs
@@ -60,7 +60,9 @@ namespace AngleSharp.Html.Dom
                     foreach (var child in group.ChildNodes)
                     {
                         if (Object.ReferenceEquals(child, this))
+                        {
                             return i;
+                        }
 
                         i++;
                     }

--- a/src/AngleSharp/Html/Dom/Internal/HtmlSelectElement.cs
+++ b/src/AngleSharp/Html/Dom/Internal/HtmlSelectElement.cs
@@ -158,7 +158,9 @@ namespace AngleSharp.Html.Dom
                 var option = options.GetOptionAt(i);
 
                 if (!option.IsDisabled)
+                {
                     return option;
+                }
             }
 
             return null;

--- a/src/AngleSharp/Html/Dom/Internal/HtmlTableElement.cs
+++ b/src/AngleSharp/Html/Dom/Internal/HtmlTableElement.cs
@@ -29,24 +29,38 @@ namespace AngleSharp.Html.Dom
 
         #region Properties
 
-        public IHtmlTableCaptionElement Caption
+        public IHtmlTableCaptionElement? Caption
         {
             get => ChildNodes.OfType<IHtmlTableCaptionElement>().FirstOrDefault(m => m.LocalName.Is(TagNames.Caption));
-            set { DeleteCaption(); InsertChild(0, value); }
+            set
+            {
+                DeleteCaption();
+
+                if (value != null) InsertChild(0, value);
+            }
         }
 
-        public IHtmlTableSectionElement Head
+        public IHtmlTableSectionElement? Head
         {
             get => ChildNodes.OfType<IHtmlTableSectionElement>().FirstOrDefault(m => m.LocalName.Is(TagNames.Thead));
-            set { DeleteHead(); AppendChild(value); }
+            set
+            {
+                DeleteHead();
+
+                if (value != null) AppendChild(value);
+            }
         }
 
         public IHtmlCollection<IHtmlTableSectionElement> Bodies => _bodies ??= new HtmlCollection<IHtmlTableSectionElement>(this, deep: false, predicate: m => m.LocalName.Is(TagNames.Tbody));
 
-        public IHtmlTableSectionElement Foot
+        public IHtmlTableSectionElement? Foot
         {
             get => ChildNodes.OfType<IHtmlTableSectionElement>().FirstOrDefault(m => m.LocalName.Is(TagNames.Tfoot));
-            set { DeleteFoot(); AppendChild(value); }
+            set
+            {
+                DeleteFoot();
+                if (value != null) AppendChild(value);
+            }
         }
 
         public IEnumerable<IHtmlTableRowElement> AllRows

--- a/src/AngleSharp/Html/Dom/Internal/HtmlTableElement.cs
+++ b/src/AngleSharp/Html/Dom/Internal/HtmlTableElement.cs
@@ -36,7 +36,10 @@ namespace AngleSharp.Html.Dom
             {
                 DeleteCaption();
 
-                if (value != null) InsertChild(0, value);
+                if (value != null)
+                {
+                    InsertChild(0, value);
+                }
             }
         }
 
@@ -47,7 +50,10 @@ namespace AngleSharp.Html.Dom
             {
                 DeleteHead();
 
-                if (value != null) AppendChild(value);
+                if (value != null)
+                {
+                    AppendChild(value);
+                }
             }
         }
 
@@ -59,7 +65,11 @@ namespace AngleSharp.Html.Dom
             set
             {
                 DeleteFoot();
-                if (value != null) AppendChild(value);
+
+                if (value != null)
+                {
+                    AppendChild(value);
+                }
             }
         }
 

--- a/src/AngleSharp/Html/Forms/FileDataSetEntry.cs
+++ b/src/AngleSharp/Html/Forms/FileDataSetEntry.cs
@@ -36,7 +36,7 @@ namespace AngleSharp.Html.Forms
                     {
                         var line = sr.ReadLine();
 
-                        if (line.Contains(boundary))
+                        if (line != null && line.Contains(boundary))
                         {
                             result = true;
                             break;

--- a/src/AngleSharp/Html/Forms/Submitters/Json/JsonArray.cs
+++ b/src/AngleSharp/Html/Forms/Submitters/Json/JsonArray.cs
@@ -6,20 +6,20 @@ namespace AngleSharp.Html.Forms.Submitters.Json
     using System.Collections.Generic;
     using System.Linq;
 
-    sealed class JsonArray : JsonElement, IEnumerable<JsonElement>
+    sealed class JsonArray : JsonElement, IEnumerable<JsonElement?>
     {
-        private readonly List<JsonElement> _elements;
+        private readonly List<JsonElement?> _elements;
 
         public Int32 Length => _elements.Count;
 
         public JsonArray()
         {
-            _elements = new List<JsonElement>(); 
+            _elements = new List<JsonElement?>(); 
         }
 
         public JsonArray(int capacity)
         {
-            _elements = new List<JsonElement>(capacity);
+            _elements = new List<JsonElement?>(capacity);
         }
 
         public void Push(JsonElement element)
@@ -32,7 +32,7 @@ namespace AngleSharp.Html.Forms.Submitters.Json
             _elements.Add(element);
         }
 
-        public JsonElement this[Int32 key]
+        public JsonElement? this[Int32 key]
         {
             get => _elements.ElementAtOrDefault(key);
             set

--- a/src/AngleSharp/Html/Forms/Submitters/Json/JsonArray.cs
+++ b/src/AngleSharp/Html/Forms/Submitters/Json/JsonArray.cs
@@ -54,7 +54,9 @@ namespace AngleSharp.Html.Forms.Submitters.Json
             foreach (var element in _elements)
             {
                 if (needsComma)
+                {
                     sb.Append(Symbols.Comma);
+                }
 
                 sb.Append(element?.ToString() ?? "null");
                 needsComma = true;

--- a/src/AngleSharp/Html/Forms/Submitters/Json/JsonElement.cs
+++ b/src/AngleSharp/Html/Forms/Submitters/Json/JsonElement.cs
@@ -1,10 +1,10 @@
-﻿namespace AngleSharp.Html.Forms.Submitters.Json
+namespace AngleSharp.Html.Forms.Submitters.Json
 {
     using System;
 
     abstract class JsonElement
     {
-        public virtual JsonElement this[String key]
+        public virtual JsonElement? this[String key]
         {
             get => throw new InvalidOperationException();
             set => throw new InvalidOperationException();

--- a/src/AngleSharp/Html/Forms/Submitters/Json/JsonObject.cs
+++ b/src/AngleSharp/Html/Forms/Submitters/Json/JsonObject.cs
@@ -6,9 +6,9 @@ namespace AngleSharp.Html.Forms.Submitters.Json
 
     sealed class JsonObject : JsonElement
     {
-        private readonly Dictionary<String, JsonElement> _properties = new Dictionary<String, JsonElement>();
+        private readonly Dictionary<String, JsonElement?> _properties = new Dictionary<String, JsonElement?>();
 
-        public override JsonElement this[String key]
+        public override JsonElement? this[String key]
         {
             get
             {
@@ -31,7 +31,7 @@ namespace AngleSharp.Html.Forms.Submitters.Json
                 }
 
                 sb.Append(Symbols.DoubleQuote).Append(property.Key).Append(Symbols.DoubleQuote);
-                sb.Append(Symbols.Colon).Append(property.Value.ToString());
+                sb.Append(Symbols.Colon).Append(property.Value!.ToString());
                 needsComma = true;
             }
 

--- a/src/AngleSharp/Html/Parser/HtmlDomBuilder.cs
+++ b/src/AngleSharp/Html/Parser/HtmlDomBuilder.cs
@@ -1005,7 +1005,9 @@ namespace AngleSharp.Html.Parser
                     AddElement(_currentFormElement, tag);
                 }
                 else
+                {
                     RaiseErrorOccurred(HtmlParseError.FormAlreadyOpen, tag);
+                }
             }
             else if (TagNames.AllBody.Contains(tagName))
             {
@@ -1809,7 +1811,9 @@ namespace AngleSharp.Html.Parser
                     AddCharacters(str);
 
                     if (token.IsEmpty)
+                    {
                         return;
+                    }
 
                     break;
                 }
@@ -1976,7 +1980,9 @@ namespace AngleSharp.Html.Parser
                     else if (tagName.Is(TagNames.Tr) || TagNames.AllTableGeneral.Contains(tagName))
                     {
                         if (InRowEndTagTablerow(token))
+                        {
                             InTableBody(token);
+                        }
                     }
                     else
                     {
@@ -2993,7 +2999,9 @@ namespace AngleSharp.Html.Parser
                 }
 
                 if (openIndex != _openElements.Count - 1)
+                {
                     RaiseErrorOccurred(HtmlParseError.TagClosedWrong, tag);
+                }
 
                 bookmark = index;
 
@@ -4118,13 +4126,17 @@ namespace AngleSharp.Html.Parser
         private void ReconstructFormatting()
         {
             if (_formattingElements.Count == 0)
+            {
                 return;
+            }
 
             var index = _formattingElements.Count - 1;
             var entry = _formattingElements[index];
 
             if (entry is null || _openElements.Contains(entry))
+            {
                 return;
+            }
 
             while (index > 0)
             {

--- a/src/AngleSharp/Html/Parser/HtmlTagNameLookup.cs
+++ b/src/AngleSharp/Html/Parser/HtmlTagNameLookup.cs
@@ -558,7 +558,9 @@ namespace AngleSharp.Html.Parser
             for ( int i = 0; i < tagName.Length; i++ )
             {
                 if ( tagName[ i ] != builder[ i ] )
+                {
                     return false;
+                }
             }
 
             return true;

--- a/src/AngleSharp/Html/Parser/HtmlTokenizer.cs
+++ b/src/AngleSharp/Html/Parser/HtmlTokenizer.cs
@@ -1110,7 +1110,9 @@ namespace AngleSharp.Html.Parser
         private HtmlToken DoctypeNameBefore(Char c)
         {
             while (c.IsSpaceCharacter())
+            {
                 c = GetNext();
+            }
 
             if (c.IsUppercaseAscii())
             {

--- a/src/AngleSharp/Io/BaseRequester.cs
+++ b/src/AngleSharp/Io/BaseRequester.cs
@@ -1,4 +1,4 @@
-﻿namespace AngleSharp.Io
+namespace AngleSharp.Io
 {
     using AngleSharp.Dom;
     using AngleSharp.Dom.Events;
@@ -37,7 +37,7 @@
         /// <returns>
         /// The task that will eventually give the response data.
         /// </returns>
-        public async Task<IResponse> RequestAsync(Request request, CancellationToken cancel)
+        public async Task<IResponse?> RequestAsync(Request request, CancellationToken cancel)
         {
             var ev = new RequestEvent(request, null);
             InvokeEventListener(ev);
@@ -64,6 +64,6 @@
         /// <param name="request">The options to consider.</param>
         /// <param name="cancel">The token for cancelling the task.</param>
         /// <returns>The task resulting in the response.</returns>
-        protected abstract Task<IResponse> PerformRequestAsync(Request request, CancellationToken cancel);
+        protected abstract Task<IResponse?> PerformRequestAsync(Request request, CancellationToken cancel);
     }
 }

--- a/src/AngleSharp/Io/DefaultHttpRequester.cs
+++ b/src/AngleSharp/Io/DefaultHttpRequester.cs
@@ -23,7 +23,7 @@ namespace AngleSharp.Io
 
         private const Int32 BufferSize = 4096;
 
-        private static readonly String Version = typeof(DefaultHttpRequester).Assembly.GetCustomAttribute<AssemblyFileVersionAttribute>().Version;
+        private static readonly String? Version = typeof(DefaultHttpRequester).Assembly.GetCustomAttribute<AssemblyFileVersionAttribute>()?.Version;
         private static readonly String AgentName = "AngleSharp/" + Version;
 
         #endregion
@@ -99,7 +99,7 @@ namespace AngleSharp.Io
         /// <returns>
         /// The task that will eventually give the response data.
         /// </returns>
-        protected override async Task<IResponse> PerformRequestAsync(Request request, CancellationToken cancellationToken)
+        protected override async Task<IResponse?> PerformRequestAsync(Request request, CancellationToken cancellationToken)
         {
             var cts = new CancellationTokenSource(_timeOut);
             var cache = new RequestState(request, _headers, _setup);
@@ -139,7 +139,7 @@ namespace AngleSharp.Io
                 setup.Invoke(_http);
             }
 
-            public async Task<IResponse> RequestAsync(CancellationToken cancellationToken)
+            public async Task<IResponse?> RequestAsync(CancellationToken cancellationToken)
             {
                 cancellationToken.Register(_http.Abort);
 
@@ -149,7 +149,7 @@ namespace AngleSharp.Io
                     SendRequest(target);
                 }
 
-                var response = default(WebResponse);
+                WebResponse? response;
 
                 try
                 {
@@ -161,7 +161,7 @@ namespace AngleSharp.Io
                 }
 
                 RaiseConnectionLimit(_http);
-                return GetResponse((HttpWebResponse)response);
+                return GetResponse(response as HttpWebResponse);
             }
 
             private void SendRequest(Stream target)
@@ -182,7 +182,7 @@ namespace AngleSharp.Io
             }
 
             [return: NotNullIfNotNull("response")]
-            private DefaultResponse? GetResponse(HttpWebResponse response)
+            private DefaultResponse? GetResponse(HttpWebResponse? response)
             {
                 if (response != null)
                 {
@@ -225,10 +225,10 @@ namespace AngleSharp.Io
                 {
                     var methods = typeof(Cookie).GetMethods();
                     var func = methods.FirstOrDefault(m => m.Name is "ToServerString");
-                    _serverString = func ?? methods.FirstOrDefault(m => m.Name is "ToString");
+                    _serverString = func ?? methods.First(m => m.Name is "ToString");
                 }
 
-                return _serverString.Invoke(cookie, null).ToString();
+                return _serverString.Invoke(cookie, null)!.ToString()!;
             }
 
             /// <summary>

--- a/src/AngleSharp/Io/DocumentRequest.cs
+++ b/src/AngleSharp/Io/DocumentRequest.cs
@@ -180,7 +180,7 @@ namespace AngleSharp.Io
 
         private void SetHeader(String name, String value) => Headers[name] = value;
 
-        private String GetHeader(String name)
+        private String? GetHeader(String name)
         {
             Headers.TryGetValue(name, out var value);
             return value;

--- a/src/AngleSharp/Io/IRequester.cs
+++ b/src/AngleSharp/Io/IRequester.cs
@@ -1,4 +1,4 @@
-﻿namespace AngleSharp.Io
+namespace AngleSharp.Io
 {
     using AngleSharp.Dom;
     using System;
@@ -29,7 +29,7 @@
         /// <returns>
         /// The task that will eventually give the response data.
         /// </returns>
-        Task<IResponse> RequestAsync(Request request, CancellationToken cancel);
+        Task<IResponse?> RequestAsync(Request request, CancellationToken cancel);
 
         /// <summary>
         /// Fired when a request is starting.

--- a/src/AngleSharp/Io/MimeType.cs
+++ b/src/AngleSharp/Io/MimeType.cs
@@ -161,22 +161,15 @@ namespace AngleSharp.Io
         /// </summary>
         /// <param name="other">The type to compare to.</param>
         /// <returns>True if both types are equal, otherwise false.</returns>
-#if NET5_0_OR_GREATER
         public Boolean Equals(MimeType? other) => _general.Isi(other?._general) &&
                                                   _media.Isi(other?._media) &&
                                                   _suffix.Isi(other?._suffix);
-#else
-        public Boolean Equals(MimeType other) => _general.Isi(other._general) &&
-                                                 _media.Isi(other._media) &&
-                                                 _suffix.Isi(other._suffix);
-#endif
 
         /// <summary>
         /// Compares to the other object. It has to be a MIME type.
         /// </summary>
         /// <param name="obj">The object to compare to.</param>
         /// <returns>True if both objects are equal, otherwise false.</returns>
-#if NET5_0_OR_GREATER
         public override Boolean Equals(Object? obj)
         {
             if (!Object.ReferenceEquals(this, obj))
@@ -186,17 +179,6 @@ namespace AngleSharp.Io
 
             return true;
         }
-#else
-        public override Boolean Equals(Object obj)
-        {
-            if (!Object.ReferenceEquals(this, obj))
-            {
-                return obj is MimeType other && Equals(other);
-            }
-
-            return true;
-        }
-#endif
 
         /// <summary>
         /// Computes the hash code for the MIME type.

--- a/src/AngleSharp/Io/MimeType.cs
+++ b/src/AngleSharp/Io/MimeType.cs
@@ -101,7 +101,10 @@ namespace AngleSharp.Io
             {
                 foreach (var p in _params.Split(s_semicolon))
                 {
-                    if (p.Length == 0) continue;
+                    if (p.Length == 0)
+                    {
+                        continue;
+                    }
 
                     int equalIndex = p.IndexOf('=');
 

--- a/src/AngleSharp/Io/MimeType.cs
+++ b/src/AngleSharp/Io/MimeType.cs
@@ -158,15 +158,32 @@ namespace AngleSharp.Io
         /// </summary>
         /// <param name="other">The type to compare to.</param>
         /// <returns>True if both types are equal, otherwise false.</returns>
+#if NET5_0_OR_GREATER
+        public Boolean Equals(MimeType? other) => _general.Isi(other?._general) &&
+                                                  _media.Isi(other?._media) &&
+                                                  _suffix.Isi(other?._suffix);
+#else
         public Boolean Equals(MimeType other) => _general.Isi(other._general) &&
-            _media.Isi(other._media) &&
-            _suffix.Isi(other._suffix);
+                                                 _media.Isi(other._media) &&
+                                                 _suffix.Isi(other._suffix);
+#endif
 
         /// <summary>
         /// Compares to the other object. It has to be a MIME type.
         /// </summary>
         /// <param name="obj">The object to compare to.</param>
         /// <returns>True if both objects are equal, otherwise false.</returns>
+#if NET5_0_OR_GREATER
+        public override Boolean Equals(Object? obj)
+        {
+            if (!Object.ReferenceEquals(this, obj))
+            {
+                return obj is MimeType other && Equals(other);
+            }
+
+            return true;
+        }
+#else
         public override Boolean Equals(Object obj)
         {
             if (!Object.ReferenceEquals(this, obj))
@@ -176,6 +193,7 @@ namespace AngleSharp.Io
 
             return true;
         }
+#endif
 
         /// <summary>
         /// Computes the hash code for the MIME type.

--- a/src/AngleSharp/Io/PortNumbers.cs
+++ b/src/AngleSharp/Io/PortNumbers.cs
@@ -30,7 +30,7 @@ namespace AngleSharp.Io
         /// The string representing the default port, or null, if the protocol
         /// is not known.
         /// </returns>
-        public static String GetDefaultPort(String protocol)
+        public static String? GetDefaultPort(String protocol)
         {
             Ports.TryGetValue(protocol, out var value);
             return value;

--- a/src/AngleSharp/Io/RequesterExtensions.cs
+++ b/src/AngleSharp/Io/RequesterExtensions.cs
@@ -109,7 +109,9 @@ namespace AngleSharp.Io
         private static IDownload FetchWithoutCorsAsync(this IResourceLoader loader, ResourceRequest request, OriginBehavior behavior)
         {
             if (behavior == OriginBehavior.Fail)
+            {
                 throw new DomException(DomError.Network);
+            }
 
             return loader.FetchAsync(request);
         }

--- a/src/AngleSharp/Text/Punycode.cs
+++ b/src/AngleSharp/Text/Punycode.cs
@@ -261,7 +261,9 @@ namespace AngleSharp.Text
 
                 // Make sure its not too big
                 if (output.Length - iOutputAfterLastDot > LabelLimit)
+                {
                     throw new ArgumentException();
+                }
 
                 // Done with this segment, add dot if necessary
                 if (iNextDot != text.Length)

--- a/src/AngleSharp/Text/StringExtensions.cs
+++ b/src/AngleSharp/Text/StringExtensions.cs
@@ -54,7 +54,10 @@ namespace AngleSharp.Text
                 {
                     var domDescriptionAttribute = field.GetCustomAttribute<DomDescriptionAttribute>();
 
-                    if (domDescriptionAttribute != null) description = domDescriptionAttribute.Description;
+                    if (domDescriptionAttribute != null)
+                    {
+                        description = domDescriptionAttribute.Description;
+                    }
                 }
             }
 
@@ -266,7 +269,10 @@ namespace AngleSharp.Text
         /// <returns>The modified string with collapsed and stripped spaces.</returns>
         public static String CollapseAndStrip(this String str)
         {
-            if (str.Length == 0) return str;
+            if (str.Length == 0)
+            {
+                return str;
+            }
 
             var buffer = ArrayPool<Char>.Shared.Rent(str.Length);
 
@@ -754,7 +760,9 @@ namespace AngleSharp.Text
                 else if (chr == Symbols.Percent)
                 {
                     if (i + 2 >= value.Length)
+                    {
                         throw new FormatException();
+                    }
 
                     var code = 16 * value[++i].FromHex() + value[++i].FromHex();
                     var b = (Byte)code;

--- a/src/AngleSharp/Text/StringExtensions.cs
+++ b/src/AngleSharp/Text/StringExtensions.cs
@@ -42,10 +42,23 @@ namespace AngleSharp.Text
         /// <returns>The compatibility string.</returns>
         internal static String GetCompatiblity(this QuirksMode mode)
         {
+            var description = "CSS1Compat";
 
-            var field = typeof(QuirksMode).GetField(mode.ToString());
-            var description = field.GetCustomAttribute<DomDescriptionAttribute>()?.Description;
-            return description ?? "CSS1Compat";
+            var fieldName = mode.ToString();
+
+            if (fieldName != null)
+            {
+                var field = typeof(QuirksMode).GetField(fieldName);
+
+                if (field != null)
+                {
+                    var domDescriptionAttribute = field.GetCustomAttribute<DomDescriptionAttribute>();
+
+                    if (domDescriptionAttribute != null) description = domDescriptionAttribute.Description;
+                }
+            }
+
+            return description;
         }
 
         /// <summary>

--- a/src/AngleSharp/Text/TextPosition.cs
+++ b/src/AngleSharp/Text/TextPosition.cs
@@ -147,11 +147,7 @@ namespace AngleSharp.Text
         /// True if the given object is a text position with the same values,
         /// otherwise false.
         /// </returns>
-#if NET5_0_OR_GREATER
         public override Boolean Equals(Object? obj) => obj is TextPosition other && Equals(other);
-#else
-        public override Boolean Equals(Object obj) => obj is TextPosition other && Equals(other);
-#endif
 
         /// <summary>
         /// Indicates whether the current position is equal to the given

--- a/src/AngleSharp/Text/TextPosition.cs
+++ b/src/AngleSharp/Text/TextPosition.cs
@@ -147,7 +147,11 @@ namespace AngleSharp.Text
         /// True if the given object is a text position with the same values,
         /// otherwise false.
         /// </returns>
-        public override Boolean Equals(Object obj) => obj is TextPosition other ? Equals(other) : false;
+#if NET5_0_OR_GREATER
+        public override Boolean Equals(Object? obj) => obj is TextPosition other && Equals(other);
+#else
+        public override Boolean Equals(Object obj) => obj is TextPosition other && Equals(other);
+#endif
 
         /// <summary>
         /// Indicates whether the current position is equal to the given

--- a/src/AngleSharp/Text/TextRange.cs
+++ b/src/AngleSharp/Text/TextRange.cs
@@ -79,10 +79,17 @@ namespace AngleSharp.Text
         /// True if the given object is a text position with the same values,
         /// otherwise false.
         /// </returns>
-        public override Boolean Equals(Object obj)
+#if NET5_0_OR_GREATER
+        public override Boolean Equals(Object? obj)
         {
             return obj is TextRange other && Equals(other);
         }
+#else
+           public override Boolean Equals(Object obj)
+        {
+            return obj is TextRange other && Equals(other);
+        }
+#endif
 
         /// <summary>
         /// Indicates whether the current range is equal to the given range.

--- a/src/AngleSharp/Text/TextRange.cs
+++ b/src/AngleSharp/Text/TextRange.cs
@@ -79,17 +79,10 @@ namespace AngleSharp.Text
         /// True if the given object is a text position with the same values,
         /// otherwise false.
         /// </returns>
-#if NET5_0_OR_GREATER
         public override Boolean Equals(Object? obj)
         {
             return obj is TextRange other && Equals(other);
         }
-#else
-           public override Boolean Equals(Object obj)
-        {
-            return obj is TextRange other && Equals(other);
-        }
-#endif
 
         /// <summary>
         /// Indicates whether the current range is equal to the given range.

--- a/src/AngleSharp/Text/TextSource.cs
+++ b/src/AngleSharp/Text/TextSource.cs
@@ -70,7 +70,6 @@ namespace AngleSharp.Text
         /// <param name="encoding">
         /// The initial encoding. Otherwise UTF-8.
         /// </param>
-        [MemberNotNull("_content")]
         public TextSource(Stream baseStream, Encoding encoding = null)
             : this(encoding, allocateBuffers: baseStream != null)
         {
@@ -86,6 +85,7 @@ namespace AngleSharp.Text
         /// <summary>
         /// Gets the full text buffer.
         /// </summary>
+        [MemberNotNull("_content")]
         public String Text => _content.ToString();
 
         /// <summary>

--- a/src/AngleSharp/Text/XmlExtensions.cs
+++ b/src/AngleSharp/Text/XmlExtensions.cs
@@ -83,7 +83,9 @@
             var colon = str.IndexOf(Symbols.Colon);
 
             if (colon == -1)
+            {
                 return str.IsXmlName();
+            }
 
             if (colon > 0 && str[0].IsXmlNameStart())
             {


### PR DESCRIPTION
# Types of Changes

## Prerequisites

Please make sure you can check the following two boxes:

- [x] I have read the **CONTRIBUTING** document
- [x] My code follows the code style of this project

## Contribution Type

What types of changes does your code introduce? Put an `x` in all the boxes that apply:

- [ ] Bug fix (non-breaking change which fixes an issue, please reference the issue id)
- [x] New feature (non-breaking change which adds functionality, make sure to open an associated issue first)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] My change requires a change to the documentation
- [ ] I have updated the documentation accordingly
- [ ] I have added tests to cover my changes
- [x] All new and existing tests passed

## Description

I believe that as a modern library, AngleSharp should target the current and latest LTS release of .NET.

This PR adds **.NET 6.0** as as a target framework in addition to the currently existing ones.
Some adjustments have been made in order to fix any resulting nullable reference errors.