### PR TITLE
Fix typo in DomNoInterfaceObjectAttribute docs.

### DIFF
--- a/src/AngleSharp/Attributes/DomNoInterfaceObjectAttribute.cs
+++ b/src/AngleSharp/Attributes/DomNoInterfaceObjectAttribute.cs
@@ -3,7 +3,7 @@
     using System;
 
     /// <summary>
-    /// This attribute appears on an interfaces, which must not be available 
+    /// This attribute appears on interfaces, which must not be available 
     /// in the ECMAScript binding.
     /// </summary>
     [AttributeUsage(


### PR DESCRIPTION
# Types of Changes

## Prerequisites

Please make sure you can check the following two boxes:

- [x] I have read the **CONTRIBUTING** document
- [x] My code follows the code style of this project

## Contribution Type

What types of changes does your code introduce? Put an `x` in all the boxes that apply:

- [x] Bug fix (non-breaking change which fixes an issue, please reference the issue id)
- [ ] New feature (non-breaking change which adds functionality, make sure to open an associated issue first)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] My change requires a change to the documentation
- [ ] I have updated the documentation accordingly
- [ ] I have added tests to cover my changes
- [ ] All new and existing tests passed

## Description

The follow sentence in the XML docs for the `DomNoInterfaceObjectAttribute` class:

> This attribute appears on **an** interfaces, ...

Doesn't need the word "an" and should probably read:

> This attribute appears on interfaces, ...

**PS:** I just found this typo while going through every single class in every single namespace of AngleSharp to learn how it works and it's a truly amazing piece of engineering! :rocket: 