### PR TITLE
Fixed behavior of Url with empty query 

### DIFF
--- a/src/AngleSharp.Core.Tests/Urls/UrlApi.cs
+++ b/src/AngleSharp.Core.Tests/Urls/UrlApi.cs
@@ -12,6 +12,7 @@ namespace AngleSharp.Core.Tests.Urls
             var url = new Url("https://florian-rappl.de/foo/bar");
             Assert.AreEqual("", url.Search);
             Assert.AreEqual(null, url.Query);
+            Assert.AreEqual("", url.SearchParams.ToString());
         }
 
         [Test]
@@ -20,6 +21,7 @@ namespace AngleSharp.Core.Tests.Urls
             var url = new Url("https://florian-rappl.de/foo/bar?qxz=baz");
             Assert.AreEqual("?qxz=baz", url.Search);
             Assert.AreEqual("qxz=baz", url.Query);
+            Assert.AreEqual("qxz=baz", url.SearchParams.ToString());
         }
 
         [Test]
@@ -60,6 +62,42 @@ namespace AngleSharp.Core.Tests.Urls
             var url = new Url("https://florian-rappl.de/foo/bar");
             Assert.AreEqual("", url.UserName);
             Assert.AreEqual("", url.Password);
+        }
+
+        [Test]
+        public void UrlQueryIsClearedWithNull()
+        {
+            var url = new Url("https://florian-rappl.de?qxz=bar");
+            Assert.AreEqual("bar", url.SearchParams.Get("qxz"));
+            Assert.AreEqual(true, url.SearchParams.Has("qxz"));
+            Assert.AreEqual(null, url.SearchParams.Get("foo"));
+            Assert.AreEqual("qxz=bar", url.SearchParams.ToString());
+            Assert.AreEqual("qxz=bar", url.Query);
+            Assert.AreEqual("?qxz=bar", url.Search);
+            url.Query = null;
+            Assert.AreEqual(null, url.SearchParams.Get("qxz"));
+            Assert.AreEqual(false, url.SearchParams.Has("qxz"));
+            Assert.AreEqual("", url.SearchParams.ToString());
+            Assert.AreEqual(null, url.Query);
+            Assert.AreEqual("", url.Search);
+        }
+
+        [Test]
+        public void UrlQueryIsClearedWithEmpty()
+        {
+            var url = new Url("https://florian-rappl.de?qxz=bar");
+            Assert.AreEqual("bar", url.SearchParams.Get("qxz"));
+            Assert.AreEqual(true, url.SearchParams.Has("qxz"));
+            Assert.AreEqual(null, url.SearchParams.Get("foo"));
+            Assert.AreEqual("qxz=bar", url.SearchParams.ToString());
+            Assert.AreEqual("qxz=bar", url.Query);
+            Assert.AreEqual("?qxz=bar", url.Search);
+            url.Query = "";
+            Assert.AreEqual(null, url.SearchParams.Get("qxz"));
+            Assert.AreEqual(false, url.SearchParams.Has("qxz"));
+            Assert.AreEqual("", url.SearchParams.ToString());
+            Assert.AreEqual("", url.Query);
+            Assert.AreEqual("", url.Search);
         }
 
         [Test]

--- a/src/AngleSharp/Dom/Url.cs
+++ b/src/AngleSharp/Dom/Url.cs
@@ -372,8 +372,15 @@ namespace AngleSharp.Dom
             get => _query;
             set
             {
-                var input = value ?? String.Empty;
-                ParseQuery(input, 0, input.Length, true);
+                if(value == null)
+                {
+                    _query = null;
+                    _params?.Reset();
+                }
+                else
+                {
+                    ParseQuery(value, 0, value.Length, true);
+                }
             }
         }
 

--- a/src/AngleSharp/Dom/UrlSearchParams.cs
+++ b/src/AngleSharp/Dom/UrlSearchParams.cs
@@ -60,6 +60,11 @@ namespace AngleSharp.Dom
             {
                 Reset();
 
+                if (query is "")
+                {
+                    return;
+                }
+
                 foreach (var pair in query.Split('&'))
                 {
                     var kvp = pair.Split('=');


### PR DESCRIPTION
# Types of Changes

## Prerequisites

Please make sure you can check the following two boxes:

- [x] I have read the **CONTRIBUTING** document
- [x] My code follows the code style of this project

## Contribution Type

What types of changes does your code introduce? Put an `x` in all the boxes that apply:

- [ ] Bug fix (non-breaking change which fixes an issue, please reference the issue id)
- [ ] New feature (non-breaking change which adds functionality, make sure to open an associated issue first)
- [x] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] My change requires a change to the documentation
- [ ] I have updated the documentation accordingly
- [x] I have added tests to cover my changes
- [x] All new and existing tests passed

## Description

Fix #1015

### Fixed behavior of `Url.SearchParams` with empty query

**old behavior**

```cs
var url = new AngleSharp.Dom.Url("http://example.com/foo/bar");
Console.WriteLine(url.SearchParams.ToString()); // "="
```

**new behavior**

```cs
var url = new AngleSharp.Dom.Url("http://example.com/foo/bar");
Console.WriteLine(url.SearchParams.ToString()); // ""
```

### Assigning null to `Url.Query`

**old behavior**

```cs
var url = new AngleSharp.Dom.Url("http://example.com/foo/bar");
Console.WriteLine(url.ToString());      // "http://example.com/foo/bar"
Console.WriteLine(url.Query ?? "null"); // null
url.Query = null;
Console.WriteLine(url.ToString());      // "http://example.com/foo/bar?"
Console.WriteLine(url.Query ?? "null"); // ""
```

**new behavior**

```cs
var url = new AngleSharp.Dom.Url("http://example.com/foo/bar");
Console.WriteLine(url.ToString());      // "http://example.com/foo/bar"
Console.WriteLine(url.Query ?? "null"); // null
url.Query = null;
Console.WriteLine(url.ToString());      // "http://example.com/foo/bar"
Console.WriteLine(url.Query ?? "null"); // null
```