### PR TITLE
Use InvariantCulture in DateTime.ToString

### DIFF
--- a/src/AngleSharp.Core.Tests/Library/CookieHandling.cs
+++ b/src/AngleSharp.Core.Tests/Library/CookieHandling.cs
@@ -466,7 +466,7 @@ namespace AngleSharp.Core.Tests.Library
             var url = Url.Create("http://www.example.com");
             var cookie = "A=A";
             mcp.SetCookie(url,
-                $"{cookie}; expires={DateTime.UtcNow.AddHours(1).ToString("ddd, dd MMM yyyy HH:mm:ss")} GMT");
+                $"{cookie}; expires={DateTime.UtcNow.AddHours(1).ToString("ddd, dd MMM yyyy HH:mm:ss", CultureInfo.InvariantCulture)} GMT");
             Assert.AreEqual(mcp.GetCookie(url), cookie);
         }
 


### PR DESCRIPTION
# Types of Changes

## Prerequisites

Please make sure you can check the following two boxes:

- [x] I have read the **CONTRIBUTING** document
- [x] My code follows the code style of this project

## Contribution Type

What types of changes does your code introduce? Put an `x` in all the boxes that apply:

- [x] Bug fix (non-breaking change which fixes an issue, please reference the issue id)
- [ ] New feature (non-breaking change which adds functionality, make sure to open an associated issue first)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] My change requires a change to the documentation
- [ ] I have updated the documentation accordingly
- [ ] I have added tests to cover my changes
- [x] All new and existing tests passed

## Description

`CookieHandlingTests.MissingCookie_Issue768` depend on culture "en-US" because `DateTime.ToString` is culture aware.

```cs
CultureInfo.CurrentCulture = CultureInfo.GetCultureInfo("ja");

// 月, 06 12月 2021 12:11:19
Console.WriteLine(DateTime.UtcNow.AddHours(1).ToString("ddd, dd MMM yyyy HH:mm:ss"));

// Mon, 06 Dec 2021 12:11:19
Console.WriteLine(DateTime.UtcNow.AddHours(1).ToString("ddd, dd MMM yyyy HH:mm:ss", CultureInfo.InvariantCulture));
```