### PR TITLE
Fix Url.Hash and Url.Search

### DIFF
--- a/src/AngleSharp.Core.Tests/Urls/UrlApi.cs
+++ b/src/AngleSharp.Core.Tests/Urls/UrlApi.cs
@@ -41,6 +41,39 @@ namespace AngleSharp.Core.Tests.Urls
         }
 
         [Test]
+        public void UrlHashAssigningStringWithHash()
+        {
+            var url = new Url("https://florian-rappl.de/foo/bar#baz");
+            Assert.AreEqual("#baz", url.Hash);
+            Assert.AreEqual("baz", url.Fragment);
+            url.Hash = "#foobar";
+            Assert.AreEqual("#foobar", url.Hash);
+            Assert.AreEqual("foobar", url.Fragment);
+        }
+
+        [Test]
+        public void UrlHashAssigningStringWithoutHash()
+        {
+            var url = new Url("https://florian-rappl.de/foo/bar#baz");
+            Assert.AreEqual("#baz", url.Hash);
+            Assert.AreEqual("baz", url.Fragment);
+            url.Hash = "foobar";
+            Assert.AreEqual("#foobar", url.Hash);
+            Assert.AreEqual("foobar", url.Fragment);
+        }
+
+        [Test]
+        public void UrlHashAssigningEmpty()
+        {
+            var url = new Url("https://florian-rappl.de/foo/bar#baz");
+            Assert.AreEqual("#baz", url.Hash);
+            Assert.AreEqual("baz", url.Fragment);
+            url.Hash = "";
+            Assert.AreEqual("", url.Hash);
+            Assert.AreEqual(null, url.Fragment);
+        }
+
+        [Test]
         public void UrlPathnameIncludesSlash()
         {
             var url = new Url("https://florian-rappl.de/foo/bar");
@@ -112,6 +145,48 @@ namespace AngleSharp.Core.Tests.Urls
             Assert.AreEqual(false, url.SearchParams.Has("qxz"));
             Assert.AreEqual("bar", url.SearchParams.Get("foo"));
             Assert.AreEqual("foo=bar", url.Query);
+        }
+
+        [Test]
+        public void UrlSearchAssigningStringWithoutQuestion()
+        {
+            var url = new Url("https://florian-rappl.de?qxz=bar");
+            Assert.AreEqual("bar", url.SearchParams.Get("qxz"));
+            Assert.AreEqual(true, url.SearchParams.Has("qxz"));
+            Assert.AreEqual(null, url.SearchParams.Get("foo"));
+            url.Search = "foo=bar";
+            Assert.AreEqual(null, url.SearchParams.Get("qxz"));
+            Assert.AreEqual(false, url.SearchParams.Has("qxz"));
+            Assert.AreEqual("bar", url.SearchParams.Get("foo"));
+            Assert.AreEqual("foo=bar", url.Query);
+        }
+
+        [Test]
+        public void UrlSearchAssigningStringWithQuestion()
+        {
+            var url = new Url("https://florian-rappl.de?qxz=bar");
+            Assert.AreEqual("bar", url.SearchParams.Get("qxz"));
+            Assert.AreEqual(true, url.SearchParams.Has("qxz"));
+            Assert.AreEqual(null, url.SearchParams.Get("foo"));
+            url.Search = "?foo=bar";
+            Assert.AreEqual(null, url.SearchParams.Get("qxz"));
+            Assert.AreEqual(false, url.SearchParams.Has("qxz"));
+            Assert.AreEqual("bar", url.SearchParams.Get("foo"));
+            Assert.AreEqual("foo=bar", url.Query);
+        }
+
+        [Test]
+        public void UrlSearchAssigningEmpty()
+        {
+            var url = new Url("https://florian-rappl.de?qxz=bar");
+            Assert.AreEqual("bar", url.SearchParams.Get("qxz"));
+            Assert.AreEqual(true, url.SearchParams.Has("qxz"));
+            Assert.AreEqual(null, url.SearchParams.Get("foo"));
+            url.Search = "";
+            Assert.AreEqual(null, url.SearchParams.Get("qxz"));
+            Assert.AreEqual(false, url.SearchParams.Has("qxz"));
+            Assert.AreEqual(null, url.SearchParams.Get("foo"));
+            Assert.AreEqual(null, url.Query);
         }
 
         [Test]

--- a/src/AngleSharp/Dom/Url.cs
+++ b/src/AngleSharp/Dom/Url.cs
@@ -263,7 +263,21 @@ namespace AngleSharp.Dom
         public String Hash
         {
             get => String.IsNullOrEmpty(_fragment) ? String.Empty : $"#{_fragment}";
-            set => Fragment = value;
+            set
+            {
+                if (String.IsNullOrEmpty(value))
+                {
+                    Fragment = null;
+                }
+                else if (value[0] is Symbols.Num)
+                {
+                    Fragment = value.Substring(1);
+                }
+                else
+                {
+                    Fragment = value;
+                }
+            }
         }
 
         /// <summary>
@@ -391,7 +405,21 @@ namespace AngleSharp.Dom
         public String Search
         {
             get => String.IsNullOrEmpty(_query) ? String.Empty : $"?{_query}";
-            set => Query = value;
+            set
+            {
+                if (String.IsNullOrEmpty(value))
+                {
+                    Query = null;
+                }
+                else if (value[0] is Symbols.QuestionMark)
+                {
+                    Query = value.Substring(1);
+                }
+                else
+                {
+                    Query = value;
+                }
+            }
         }
 
         /// <summary>


### PR DESCRIPTION
# Types of Changes

## Prerequisites

Please make sure you can check the following two boxes:

- [x] I have read the **CONTRIBUTING** document
- [x] My code follows the code style of this project

## Contribution Type

What types of changes does your code introduce? Put an `x` in all the boxes that apply:

- [ ] Bug fix (non-breaking change which fixes an issue, please reference the issue id)
- [ ] New feature (non-breaking change which adds functionality, make sure to open an associated issue first)
- [x] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] My change requires a change to the documentation
- [ ] I have updated the documentation accordingly
- [x] I have added tests to cover my changes
- [x] All new and existing tests passed

## Description

Fix #1019

This PR change behavior of `Url.Hash` and `Url.Search` setter.

- `Url.Hash`
  - if `value` is null or empty, setter assign `Fragment` to `null`.
  - if `value` starts with '#', setter assign `Fragment` to `value.Substring(1)`.
  - else, setter assign `Fragment` to `value`.
- `Url.Search`
  - if `value` is null or empty, setter assign `Query` to `null`.
  - if `value` starts with '?', setter assign `Query` to `value.Substring(1)`.
  - else, setter assign `Query` to `value`.

### Browser's JavaScript behavior

I verified it on https://kzrnm.github.io/work/location.html

**Chrome**

- `Url.Hash`
  - if `value` is null or empty, setter assign `Fragment` to `""`.
  - if `value` starts with '#', setter assign `Fragment` to `value.Substring(1)`.
  - else, setter assign `Fragment` to `value`.
- `Url.Search`
  - if `value` is null or empty, setter assign `Query` to `""`.
  - if `value` starts with '?', setter assign `Query` to `value.Substring(1)`.
  - else, setter assign `Query` to `value`.

**Firefox**

- `Url.Hash`
  - if `value` is null or empty, setter assign `Fragment` to `""`.
  - if `value` starts with '#', setter assign `Fragment` to `value.Substring(1)`.
  - else, setter assign `Fragment` to `value`.
- `Url.Search`
  - if `value` is null or empty, setter assign `Query` to `null`.
  - if `value` starts with '?', setter assign `Query` to `value.Substring(1)`.
  - else, setter assign `Query` to `value`.

https://user-images.githubusercontent.com/32071278/145015921-e1a8a639-85f3-4a80-b410-5b4050134569.mp4


