### PR TITLE
Feature/#1029 add emptyTagsToSelfClosing option to xhtml formatter

### DIFF
--- a/src/AngleSharp.Core.Tests/Library/XhtmlFormatter.cs
+++ b/src/AngleSharp.Core.Tests/Library/XhtmlFormatter.cs
@@ -1,0 +1,55 @@
+using AngleSharp.Xhtml;
+using NUnit.Framework;
+
+namespace AngleSharp.Core.Tests.Library
+{
+    [TestFixture]
+    public class XhtmlFormatter
+    {
+        [Test]
+        public void XhtmlMarkupFormatter_DoesNotFormatEmptyElementsToSelfClosing_WhenEmptyTagsToSelfClosingIsFalse()
+        {
+            var formatter = new XhtmlMarkupFormatter(false);
+            var input = "<html>" +
+                            "<head></head>" +
+                            "<body>" +
+                                "<div>test</div>" +
+                                "<div></div>" +
+                                "<div class=\"test\"></div>" +
+                            "</body>" +
+                        "</html>";
+            var doc = input.ToHtmlDocument();
+
+            var res = doc.ToHtml(formatter);
+
+            Assert.AreEqual(input, res);
+        }
+
+        [Test]
+        public void XhtmlMarkupFormatter_FormatsEmptyElementsToSelfClosing_WhenEmptyTagsToSelfClosingIsTrue()
+        {
+            var formatter = new XhtmlMarkupFormatter(true);
+            var input = "<html>" +
+                                "<head></head>" +
+                                "<body>" +
+                                    "<div>test</div>" +
+                                    "<div></div>" +
+                                    "<div class=\"test\"></div>" +
+                                "</body>" +
+                            "</html>";
+            var expected = "<html>" +
+                                   "<head />" +
+                                   "<body>" +
+                                       "<div>test</div>" +
+                                       "<div />" +
+                                       "<div class=\"test\" />" +
+                                   "</body>" +
+                               "</html>";
+            var doc = input.ToHtmlDocument();
+
+            var res = doc.ToHtml(formatter);
+
+            Assert.AreEqual(expected, res);
+        }
+    }
+}

--- a/src/AngleSharp/Xhtml/XhtmlMarkupFormatter.cs
+++ b/src/AngleSharp/Xhtml/XhtmlMarkupFormatter.cs
@@ -18,6 +18,34 @@ namespace AngleSharp.Xhtml
 
         #endregion
 
+        #region Constructors
+
+        /// <summary>
+        /// Default constructor for <see cref="XhtmlMarkupFormatter"/>
+        /// </summary>
+        public XhtmlMarkupFormatter() : this(true)
+        {
+
+        }
+
+        /// <summary>
+        /// Constructor for <see cref="XhtmlMarkupFormatter"/>
+        /// </summary>
+        /// <param name="emptyTagsToSelfClosing">Specify if empty elements like &lt;div&gt;&lt;/div&gt;
+        /// should be converted to self-closing ones like &lt;div/&gt;</param>
+        public XhtmlMarkupFormatter(Boolean emptyTagsToSelfClosing)
+        {
+            _emptyTagsToSelfClosing = emptyTagsToSelfClosing;
+        }
+
+        #endregion
+
+        #region Private fields
+
+        private readonly Boolean _emptyTagsToSelfClosing;
+
+        #endregion
+
         #region Methods
 
         /// <inheritdoc />
@@ -26,7 +54,7 @@ namespace AngleSharp.Xhtml
             var prefix = element.Prefix;
             var name = element.LocalName;
             var tag = !String.IsNullOrEmpty(prefix) ? prefix + ":" + name : name;
-            return (selfClosing || !element.HasChildNodes) ? String.Empty : String.Concat("</", tag, ">");
+            return (selfClosing || _emptyTagsToSelfClosing && !element.HasChildNodes) ? String.Empty : String.Concat("</", tag, ">");
         }
 
         /// <inheritdoc />
@@ -64,7 +92,7 @@ namespace AngleSharp.Xhtml
                 temp.Append(' ').Append(Attribute(attribute));
             }
 
-            if (selfClosing || !element.HasChildNodes)
+            if (selfClosing || _emptyTagsToSelfClosing && !element.HasChildNodes)
             {
                 temp.Append(" /");
             }


### PR DESCRIPTION
# Types of Changes

## Prerequisites

Please make sure you can check the following two boxes:

- [x] I have read the **CONTRIBUTING** document
- [x] My code follows the code style of this project

## Contribution Type

What types of changes does your code introduce? Put an `x` in all the boxes that apply:

- [ ] Bug fix (non-breaking change which fixes an issue, please reference the issue id)
- [x] New feature (non-breaking change which adds functionality, make sure to open an associated issue first)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] My change requires a change to the documentation
- [ ] I have updated the documentation accordingly
- [x] I have added tests to cover my changes
- [x] All new and existing tests passed

## Description

Add `emptyTagsToSelfClosing` option to `XhtmlMarkupFormatter`
Resolve #1029 