### PR TITLE
ISelector.Text escape values

### DIFF
--- a/src/AngleSharp.Core.Tests/Css/CssSelector.cs
+++ b/src/AngleSharp.Core.Tests/Css/CssSelector.cs
@@ -5,6 +5,7 @@ namespace AngleSharp.Core.Tests.Css
     using System;
     using System.Linq;
     using AngleSharp.Css;
+    using AngleSharp.Css.Dom;
     using AngleSharp.Css.Parser;
 
     [TestFixture]
@@ -1197,13 +1198,92 @@ nav h1, nav h2, nav h3, nav h4, nav h5, nav h6";
         }
 
         [Test]
-        public void EscapeCssSpecialCharacters_IssueCss119()
+        public void SelectorText_EscapeCssSpecialCharacters_ClassSelector()
         {
             var selectorText = @".\@\$\!\.\%";
             var parser = new CssSelectorParser();
 
             var selector = parser.ParseSelector(selectorText);
 
+            Assert.IsInstanceOf<ClassSelector>(selector);
+            Assert.NotNull(selector);
+            Assert.AreEqual(selectorText, selector.Text);
+        }
+
+        [Test]
+        public void SelectorText_EscapeCssSpecialCharacters_IdSelector()
+        {
+            var selectorText = @"#\@\$\!\.\%";
+            var parser = new CssSelectorParser();
+
+            var selector = parser.ParseSelector(selectorText);
+
+            Assert.IsInstanceOf<IdSelector>(selector);
+            Assert.NotNull(selector);
+            Assert.AreEqual(selectorText, selector.Text);
+        }
+
+        [Test]
+        public void SelectorText_EscapeCssSpecialCharacters_AttrAvailableSelector()
+        {
+            var selectorText = @"[\@\$\!\.\%]";
+            var parser = new CssSelectorParser();
+
+            var selector = parser.ParseSelector(selectorText);
+
+            Assert.IsInstanceOf<AttrAvailableSelector>(selector);
+            Assert.NotNull(selector);
+            Assert.AreEqual(selectorText, selector.Text);
+        }
+
+        [Test]
+        public void SelectorText_EscapeCssSpecialCharacters_AttrMatchSelector()
+        {
+            var selectorText = @"[\@\$\!\.\%=""some text""]";
+            var parser = new CssSelectorParser();
+
+            var selector = parser.ParseSelector(selectorText);
+
+            Assert.IsInstanceOf<AttrMatchSelector>(selector);
+            Assert.NotNull(selector);
+            Assert.AreEqual(selectorText, selector.Text);
+        }
+
+        [Test]
+        public void SelectorText_EscapeCssSpecialCharacters_AttrContainsSelector()
+        {
+            var selectorText = @"[\@\$\!\.\%*=""some text""]";
+            var parser = new CssSelectorParser();
+
+            var selector = parser.ParseSelector(selectorText);
+
+            Assert.IsInstanceOf<AttrContainsSelector>(selector);
+            Assert.NotNull(selector);
+            Assert.AreEqual(selectorText, selector.Text);
+        }
+
+        [Test]
+        public void SelectorText_EscapeCssSpecialCharacters_AttrInListSelector()
+        {
+            var selectorText = @"[\@\$\!\.\%~=""some text""]";
+            var parser = new CssSelectorParser();
+
+            var selector = parser.ParseSelector(selectorText);
+
+            Assert.IsInstanceOf<AttrInListSelector>(selector);
+            Assert.NotNull(selector);
+            Assert.AreEqual(selectorText, selector.Text);
+        }
+
+        [Test]
+        public void SelectorText_EscapeCssSpecialCharacters_NamespaceSelector()
+        {
+            var selectorText = @"\@\$\!\.\%|node";
+            var parser = new CssSelectorParser();
+
+            var selector = parser.ParseSelector(selectorText);
+
+            Assert.IsInstanceOf<ComplexSelector>(selector);
             Assert.NotNull(selector);
             Assert.AreEqual(selectorText, selector.Text);
         }

--- a/src/AngleSharp.Core.Tests/Css/CssSelector.cs
+++ b/src/AngleSharp.Core.Tests/Css/CssSelector.cs
@@ -4,6 +4,8 @@ namespace AngleSharp.Core.Tests.Css
     using NUnit.Framework;
     using System;
     using System.Linq;
+    using AngleSharp.Css;
+    using AngleSharp.Css.Parser;
 
     [TestFixture]
     public class CssSelectorTests
@@ -1192,6 +1194,18 @@ nav h1, nav h2, nav h3, nav h4, nav h5, nav h6";
             var selector = div?.GetSelector();
 
             Assert.AreEqual("#-\\31 ", selector);
+        }
+
+        [Test]
+        public void EscapeCssSpecialCharacters_IssueCss119()
+        {
+            var selectorText = @".\@\$\!\.\%";
+            var parser = new CssSelectorParser();
+
+            var selector = parser.ParseSelector(selectorText);
+
+            Assert.NotNull(selector);
+            Assert.AreEqual(selectorText, selector.Text);
         }
     }
 }

--- a/src/AngleSharp/Css/CssStyleFormatter.cs
+++ b/src/AngleSharp/Css/CssStyleFormatter.cs
@@ -4,6 +4,7 @@ namespace AngleSharp.Css
     using System;
     using System.Collections.Generic;
     using System.IO;
+    using System.Text;
 
     /// <summary>
     /// Represents the standard CSS3 style formatter.
@@ -39,7 +40,7 @@ namespace AngleSharp.Css
                     sb.Remove(sb.Length - sep.Length, sep.Length);
                 }
             }
-            
+
             return sb.ToPool();
         }
 
@@ -85,7 +86,7 @@ namespace AngleSharp.Css
 
         String IStyleFormatter.Rule(String name, String value) => String.Concat(name, " ", value, ";");
 
-        String IStyleFormatter.Rule(String name, String prelude, String rules) => String.Concat(name, " ", String.IsNullOrEmpty(prelude) ? String.Empty : prelude + " ", rules);
+        String IStyleFormatter.Rule(String name, String prelude, String rules) => String.Concat(name.Length > 2 ? String.Concat(name.Substring(0, 2), CssUtilities.Escape(name.Substring(2))) : name, " ", String.IsNullOrEmpty(prelude) ? String.Empty : prelude + " ", rules);
 
         String IStyleFormatter.Comment(String data) => String.Join("/*", data, "*/");
 

--- a/src/AngleSharp/Css/CssStyleFormatter.cs
+++ b/src/AngleSharp/Css/CssStyleFormatter.cs
@@ -4,7 +4,6 @@ namespace AngleSharp.Css
     using System;
     using System.Collections.Generic;
     using System.IO;
-    using System.Text;
 
     /// <summary>
     /// Represents the standard CSS3 style formatter.
@@ -40,7 +39,7 @@ namespace AngleSharp.Css
                     sb.Remove(sb.Length - sep.Length, sep.Length);
                 }
             }
-
+            
             return sb.ToPool();
         }
 
@@ -86,7 +85,7 @@ namespace AngleSharp.Css
 
         String IStyleFormatter.Rule(String name, String value) => String.Concat(name, " ", value, ";");
 
-        String IStyleFormatter.Rule(String name, String prelude, String rules) => String.Concat(name.Length > 2 ? String.Concat(name.Substring(0, 2), CssUtilities.Escape(name.Substring(2))) : name, " ", String.IsNullOrEmpty(prelude) ? String.Empty : prelude + " ", rules);
+        String IStyleFormatter.Rule(String name, String prelude, String rules) => String.Concat(name, " ", String.IsNullOrEmpty(prelude) ? String.Empty : prelude + " ", rules);
 
         String IStyleFormatter.Comment(String data) => String.Join("/*", data, "*/");
 

--- a/src/AngleSharp/Css/Dom/Internal/BaseAttrSelector.cs
+++ b/src/AngleSharp/Css/Dom/Internal/BaseAttrSelector.cs
@@ -26,7 +26,7 @@ namespace AngleSharp.Css.Dom
 
         public Priority Specificity => Priority.OneClass;
 
-        protected String Attribute => !String.IsNullOrEmpty(_prefix) ? String.Concat(_prefix, "|", _name) : _name;
+        protected String Attribute => !String.IsNullOrEmpty(_prefix) ? String.Concat(CssUtilities.Escape(_prefix!), "|", CssUtilities.Escape(_name)) : CssUtilities.Escape(_name);
 
         protected String Name => _attr;
     }

--- a/src/AngleSharp/Css/Dom/Internal/ClassSelector.cs
+++ b/src/AngleSharp/Css/Dom/Internal/ClassSelector.cs
@@ -14,7 +14,7 @@ namespace AngleSharp.Css.Dom
 
         public Priority Specificity => Priority.OneClass;
 
-        public String Text => "." + _cls;
+        public String Text => "." + CssUtilities.Escape(_cls);
 
         public void Accept(ISelectorVisitor visitor) => visitor.Class(_cls);
 

--- a/src/AngleSharp/Css/Dom/Internal/IdSelector.cs
+++ b/src/AngleSharp/Css/Dom/Internal/IdSelector.cs
@@ -15,7 +15,7 @@ namespace AngleSharp.Css.Dom
 
         public Priority Specificity => Priority.OneId;
 
-        public String Text => "#" + _id;
+        public String Text => "#" + CssUtilities.Escape(_id);
 
         public void Accept(ISelectorVisitor visitor) => visitor.Id(_id);
 

--- a/src/AngleSharp/Css/Dom/Internal/NamespaceSelector.cs
+++ b/src/AngleSharp/Css/Dom/Internal/NamespaceSelector.cs
@@ -7,6 +7,9 @@ namespace AngleSharp.Css.Dom
     {
         private readonly String _prefix;
 
+        /// <summary>
+        /// </summary>
+        /// <param name="prefix">The escaped prefix text</param>
         public NamespaceSelector(String prefix)
         {
             _prefix = prefix;
@@ -14,7 +17,7 @@ namespace AngleSharp.Css.Dom
 
         public Priority Specificity => Priority.Zero;
 
-        public String Text => CssUtilities.Escape(_prefix);
+        public String Text => _prefix;
 
         public Boolean Match(IElement element, IElement? scope) => element.MatchesCssNamespace(_prefix);
 

--- a/src/AngleSharp/Css/Dom/Internal/NamespaceSelector.cs
+++ b/src/AngleSharp/Css/Dom/Internal/NamespaceSelector.cs
@@ -14,7 +14,7 @@ namespace AngleSharp.Css.Dom
 
         public Priority Specificity => Priority.Zero;
 
-        public String Text => _prefix;
+        public String Text => CssUtilities.Escape(_prefix);
 
         public Boolean Match(IElement element, IElement? scope) => element.MatchesCssNamespace(_prefix);
 

--- a/src/AngleSharp/Css/Dom/Internal/NamespaceSelector.cs
+++ b/src/AngleSharp/Css/Dom/Internal/NamespaceSelector.cs
@@ -17,7 +17,7 @@ namespace AngleSharp.Css.Dom
 
         public Priority Specificity => Priority.Zero;
 
-        public String Text => _prefix;
+        public String Text => CssUtilities.Escape(_prefix);
 
         public Boolean Match(IElement element, IElement? scope) => element.MatchesCssNamespace(_prefix);
 

--- a/src/AngleSharp/Css/Dom/Internal/PseudoClassSelector.cs
+++ b/src/AngleSharp/Css/Dom/Internal/PseudoClassSelector.cs
@@ -16,7 +16,7 @@ namespace AngleSharp.Css.Dom
 
         public Priority Specificity => Priority.OneClass;
 
-        public String Text => PseudoClassNames.Separator + _pseudoClass;
+        public String Text => PseudoClassNames.Separator + CssUtilities.Escape(_pseudoClass);
 
         public void Accept(ISelectorVisitor visitor) => visitor.PseudoClass(_pseudoClass);
 

--- a/src/AngleSharp/Css/Dom/Internal/PseudoElementSelector.cs
+++ b/src/AngleSharp/Css/Dom/Internal/PseudoElementSelector.cs
@@ -16,7 +16,7 @@ namespace AngleSharp.Css.Dom
 
         public Priority Specificity => Priority.OneTag;
 
-        public String Text => PseudoElementNames.Separator + _pseudoElement;
+        public String Text => PseudoElementNames.Separator + CssUtilities.Escape(_pseudoElement);
 
         public void Accept(ISelectorVisitor visitor) => visitor.PseudoElement(_pseudoElement);
 

--- a/src/AngleSharp/Css/Dom/Internal/TypeSelector.cs
+++ b/src/AngleSharp/Css/Dom/Internal/TypeSelector.cs
@@ -13,6 +13,11 @@ namespace AngleSharp.Css.Dom
             _type = type;
         }
 
+        /// <summary>
+        /// Gets the raw type name value
+        /// </summary>
+        internal String TypeName => _type;
+
         public Priority Specificity => Priority.OneTag;
 
         public String Text => CssUtilities.Escape(_type);

--- a/src/AngleSharp/Css/Dom/Internal/TypeSelector.cs
+++ b/src/AngleSharp/Css/Dom/Internal/TypeSelector.cs
@@ -15,7 +15,7 @@ namespace AngleSharp.Css.Dom
 
         public Priority Specificity => Priority.OneTag;
 
-        public String Text => _type;
+        public String Text => CssUtilities.Escape(_type);
 
         public void Accept(ISelectorVisitor visitor) => visitor.Type(_type);
 

--- a/src/AngleSharp/Css/Parser/CssCombinator.cs
+++ b/src/AngleSharp/Css/Parser/CssCombinator.cs
@@ -187,7 +187,16 @@ namespace AngleSharp.Css.Parser
                 Transform = el => Single(el);
             }
 
-            public override ISelector Change(ISelector selector) => new NamespaceSelector(selector.Text);
+            public override ISelector Change(ISelector selector)
+            {
+                var prefix = selector switch
+                {
+                    TypeSelector typeSelector => typeSelector.TypeName,
+                    _ => selector.Text
+                };
+
+                return new NamespaceSelector(prefix);
+            }
         }
 
         private sealed class ColumnCombinator : CssCombinator

--- a/src/AngleSharp/Html/HtmlEntityProvider.cs
+++ b/src/AngleSharp/Html/HtmlEntityProvider.cs
@@ -2589,7 +2589,7 @@ namespace AngleSharp.Html
         /// <param name="code">The code to examine.</param>
         /// <returns>True if the code is in the table, else false.</returns>
         public static Boolean IsInCharacterTable(Int32 code) =>
-            /* 
+            /*
              * If that number is one of the numbers in the first column of the
              * following table, then this is a parse error. Find the row with that
              * number in the first column, and return a character token for the
@@ -2613,7 +2613,7 @@ namespace AngleSharp.Html
         public static String? GetSymbolFromTable(Int32 code)
         {
             switch (code)
-            { 
+            {
                 case 0x00:
                     return Convert(0xfffd);
                 case 0x0D:
@@ -2621,18 +2621,18 @@ namespace AngleSharp.Html
                 case 0x80:
                     return Convert(0x20ac);
                 case 0x81:
-                    return Convert(0x81);;
+                    return Convert(0x81);
                 case 0x82:
                     return Convert(0x201a);
-                case 0x83: 	
+                case 0x83:
                     return Convert(0x192);
-                case 0x84:  
+                case 0x84:
                     return Convert(0x201e);
                 case 0x85:
                     return Convert(0x2026);
-                case 0x86: 	
+                case 0x86:
                     return Convert(0x2020);
-                case 0x87: 
+                case 0x87:
                     return Convert(0x2021);
                 case 0x88:
                     return Convert(0x02C6);
@@ -2648,39 +2648,39 @@ namespace AngleSharp.Html
                     return Convert(0x008D);
                 case 0x8E:
                     return Convert(0x017D);
-                case 0x8F: 	
+                case 0x8F:
                     return Convert(0x008F);
                 case 0x90:
                     return Convert(0x0090);
-                case 0x91: 	
+                case 0x91:
                     return Convert(0x2018);
-                case 0x92: 	
+                case 0x92:
                     return Convert(0x2019);
-                case 0x93: 	
+                case 0x93:
                     return Convert(0x201C);
-                case 0x94: 	
+                case 0x94:
                     return Convert(0x201D);
-                case 0x95: 	
+                case 0x95:
                     return Convert(0x2022);
-                case 0x96: 	
+                case 0x96:
                     return Convert(0x2013);
-                case 0x97: 	
+                case 0x97:
                     return Convert(0x2014);
-                case 0x98: 	
+                case 0x98:
                     return Convert(0x02DC);
-                case 0x99: 	
+                case 0x99:
                     return Convert(0x2122);
-                case 0x9A: 	
+                case 0x9A:
                     return Convert(0x0161);
-                case 0x9B: 	
+                case 0x9B:
                     return Convert(0x203A);
-                case 0x9C: 	
+                case 0x9C:
                     return Convert(0x0153);
                 case 0x9D:
                     return Convert(0x009D);
-                case 0x9E: 	
+                case 0x9E:
                     return Convert(0x017E);
-                case 0x9F: 
+                case 0x9F:
                     return Convert(0x0178);
                 default:
                     return null;


### PR DESCRIPTION
# Types of Changes

## Prerequisites

Please make sure you can check the following two boxes:

- [x] I have read the **CONTRIBUTING** document
- [x] My code follows the code style of this project

## Contribution Type

What types of changes does your code introduce? Put an `x` in all the boxes that apply:

- [x] Bug fix (non-breaking change which fixes an issue, please reference the issue id)
- [ ] New feature (non-breaking change which adds functionality, make sure to open an associated issue first)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] My change requires a change to the documentation
- [ ] I have updated the documentation accordingly
- [x] I have added tests to cover my changes
- [x] All new ~and existing tests~ passed

## Description

Fixes #1068 and https://github.com/AngleSharp/AngleSharp.Css/issues/119

Each `ISelector.Text` implementation escapes its actual value using `CssUtilities.Escape`.

Small problem: `NamespaceSelector` would **not** hold the actual (non-escaped) value in Field `_prefix` which may cause incorrect results of its `Match`-method. This is because `NamespaceSelector` is constructed using the return value of another selectors' `Text` property which is escaped. The value would need to get un-escaped again. Since in reality only `TypeSelector.Text` is feasible to be used to construct `NamespaceSelector`, a type check and a property providing the raw value is all that is necessary.
