### PR TITLE
Count specificity properly for various pseudo classes with exceptional rules

### DIFF
--- a/src/AngleSharp/Css/Dom/Internal/ChildSelector.cs
+++ b/src/AngleSharp/Css/Dom/Internal/ChildSelector.cs
@@ -1,6 +1,7 @@
 ﻿namespace AngleSharp.Css.Dom
 {
     using System;
+    using System.Linq;
 
     /// <summary>
     /// Base class for all nth-child (or related) selectors.
@@ -30,7 +31,24 @@
 
         #region Properties
 
-        public Priority Specificity => Priority.OneClass;
+        public Priority Specificity
+        {
+            get
+            {
+                var specificity = Priority.OneClass;
+
+                if (IncludeParameterInSpecificity)
+                {
+                    specificity += Kind is ListSelector list
+                        ? list.Max(x => x.Specificity)
+                        : Kind.Specificity;
+                }
+
+                return specificity;
+            }
+        }
+
+        protected virtual Boolean IncludeParameterInSpecificity => false;
 
         public String Text
         {

--- a/src/AngleSharp/Css/Dom/Internal/FirstChildSelector.cs
+++ b/src/AngleSharp/Css/Dom/Internal/FirstChildSelector.cs
@@ -13,6 +13,8 @@ namespace AngleSharp.Css.Dom
         {
         }
 
+        protected override Boolean IncludeParameterInSpecificity => true;
+
         public Boolean Match(IElement element, IElement? scope)
         {
             var parent = element.ParentElement;

--- a/src/AngleSharp/Css/Dom/Internal/LastChildSelector.cs
+++ b/src/AngleSharp/Css/Dom/Internal/LastChildSelector.cs
@@ -13,6 +13,8 @@ namespace AngleSharp.Css.Dom
         {
         }
 
+        protected override Boolean IncludeParameterInSpecificity => true;
+
         public Boolean Match(IElement element, IElement? scope)
         {
             var parent = element.ParentElement;

--- a/src/AngleSharp/Css/Dom/Internal/PseudoClassSelector.cs
+++ b/src/AngleSharp/Css/Dom/Internal/PseudoClassSelector.cs
@@ -12,9 +12,17 @@ namespace AngleSharp.Css.Dom
         {
             _action = action;
             _pseudoClass = pseudoClass;
+            Specificity = Priority.OneClass;
         }
 
-        public Priority Specificity => Priority.OneClass;
+        public PseudoClassSelector(Predicate<IElement> action, String pseudoClass, Priority specificity)
+        {
+            _action = action;
+            _pseudoClass = pseudoClass;
+            Specificity = specificity;
+        }
+
+        public Priority Specificity { get; }
 
         public String Text => PseudoClassNames.Separator + CssUtilities.Escape(_pseudoClass);
 

--- a/src/AngleSharp/Css/PseudoClassNames.cs
+++ b/src/AngleSharp/Css/PseudoClassNames.cs
@@ -1,4 +1,4 @@
-﻿namespace AngleSharp.Css
+namespace AngleSharp.Css
 {
     using System;
 
@@ -180,6 +180,11 @@
         /// <summary>
         /// The matches pseudo function.
         /// </summary>
+        public static readonly String Is = "is";
+
+        /// <summary>
+        /// The matches pseudo function.
+        /// </summary>
         public static readonly String Matches = "matches";
 
         /// <summary>
@@ -226,6 +231,11 @@
         /// The contains pseudo function.
         /// </summary>
         public static readonly String Contains = "contains";
+
+        /// <summary>
+        /// The contains pseudo function.
+        /// </summary>
+        public static readonly String Where = "where";
 
         /// <summary>
         /// The host-context pseudo function.


### PR DESCRIPTION
# Types of Changes

## Prerequisites

Please make sure you can check the following two boxes:

- [x] I have read the **CONTRIBUTING** document
- [x] My code follows the code style of this project

## Contribution Type

What types of changes does your code introduce? Put an `x` in all the boxes that apply:

- [x] Bug fix (non-breaking change which fixes an issue, please reference the issue id)
- [ ] New feature (non-breaking change which adds functionality, make sure to open an associated issue first)
- [x] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] My change requires a change to the documentation
- [ ] I have updated the documentation accordingly
- [x] I have added tests to cover my changes
- [x] All new and existing tests passed

NOTE: It's breaking in the sense that selector priorities change to fit the spec. If that's not considered breaking, then please consider it a bug fix.

## Description

Specificity calculations are incomplete when using certain pseudo classes.
- `:has()`
- `:matches()`
- `:not()`
- `:nth-child()`
- `:nth-last-child()`

They all incorrectly count as 1 CLASS in weight when they should actually contribute the weight of their most specific inner selector to the total specificity. Additionally, while the `nth-child` classes should count themselves as 1 CLASS in addition to the contained selector, the others should only count their contained selector.

Example: `foo:matches(.bar, #bar)`
Expected: `1 0 1` (one ID, one TAG)
AngleSharp: `0 1 1` (one CLASS, one TAG)

See the spec about specificity here: [[spec]](https://w3c.github.io/csswg-drafts/selectors/#specificity-rules)

Related to this, the following were missing entirely. I was unsure if it was okay to add them in the same PR, but it's easy enough to just cut them out if desired:
- `:is()` (same as `:matches()` [[spec]](https://w3c.github.io/csswg-drafts/selectors/#matches-pseudo) )
- `:where()` (same as `:matches()` but with 0 contributed specificity)
