### PR TITLE
Fix StackOverflowException in StyleExtensions.GetStyleSheets()

### DIFF
--- a/src/AngleSharp.Core.Tests/Css/StyleExtensions.cs
+++ b/src/AngleSharp.Core.Tests/Css/StyleExtensions.cs
@@ -1,0 +1,90 @@
+namespace AngleSharp.Core.Tests.Css
+{
+    using System;
+    using System.IO;
+    using System.Linq;
+    using System.Threading;
+    using System.Threading.Tasks;
+    using AngleSharp.Css;
+    using AngleSharp.Css.Dom;
+    using AngleSharp.Html.Parser;
+    using AngleSharp.Io;
+    using Dom;
+    using Mocks;
+    using NUnit.Framework;
+    using Text;
+
+    public class StylesheetExtensions
+    {
+        [Test]
+        public void TestStyleSheetsDoesNotThrowStackOverflowException()
+        {
+            var thread = new Thread( () =>
+            {
+                var beginTags = String.Join("", Enumerable.Repeat("<div>", 1000));
+                var endTags = String.Join("", Enumerable.Repeat("</div>", 1000));
+                var html = $"<html><head><style></style></head><body>{beginTags}<span><style></style></span>{endTags}</body></html>";
+
+                var stylingService = new MockStylingService();
+                var context = BrowsingContext.New(Configuration.Default.WithOnly<IStylingService>(stylingService));
+                var document = context.GetService<IHtmlParser>()!.ParseDocument(html);
+
+                var sheets = document.StyleSheets;
+                Assert.AreEqual(sheets.Length, 2);
+                Assert.AreEqual("HEAD", sheets[0]!.OwnerNode.ParentElement?.TagName);
+                Assert.AreEqual("SPAN", sheets[1]!.OwnerNode.ParentElement?.TagName);
+
+            }, 64 * 1024);
+
+            thread.Start();
+            thread.Join();
+        }
+    }
+
+    internal class MockStylingService : IStylingService
+    {
+        public Boolean SupportsType(String mimeType) => "text/css" == mimeType;
+
+        public Task<IStyleSheet> ParseStylesheetAsync(IResponse response, StyleOptions options, CancellationToken cancel)
+        {
+            return Task.FromResult<IStyleSheet>(new MockStyleSheet(options));
+        }
+    }
+
+
+    internal class MockStyleSheet : IStyleSheet
+    {
+        private readonly StyleOptions _options;
+
+        public MockStyleSheet(StyleOptions options)
+        {
+            _options = options;
+        }
+
+        public void ToCss(TextWriter writer, IStyleFormatter formatter)
+        {
+        }
+
+        public String Type { get; } = "text/css";
+
+        public String Href { get; } = null;
+
+        public IElement OwnerNode => _options.Element;
+
+        public String Title { get; } = "";
+
+        public IMediaList Media { get; } = null;
+
+        public Boolean IsDisabled { get => _options.IsDisabled; set { } }
+
+        public IBrowsingContext Context => _options.Document.Context;
+
+        public TextSource Source { get; } = null;
+
+        public void SetOwner(IElement element)
+        {
+        }
+
+        public String LocateNamespace(String prefix) => null;
+    }
+}

--- a/src/AngleSharp/Css/Dom/StyleExtensions.cs
+++ b/src/AngleSharp/Css/Dom/StyleExtensions.cs
@@ -107,8 +107,21 @@ namespace AngleSharp.Css.Dom
         /// <returns>The enumeration over all stylesheets.</returns>
         public static IEnumerable<IStyleSheet> GetStyleSheets(this INode parent)
         {
-            foreach (var child in parent.ChildNodes)
+            if (parent.ChildNodes.Length == 0)
             {
+                yield break;
+            }
+
+            var st = new Stack<INode>();
+            for (var i = parent.ChildNodes.Length - 1; i >= 0; i--)
+            {
+                st.Push(parent.ChildNodes[i]);
+            }
+
+            while (st.Count > 0)
+            {
+                var child = st.Pop();
+
                 if (child.NodeType == NodeType.Element)
                 {
                     if (child is ILinkStyle linkStyle)
@@ -120,13 +133,11 @@ namespace AngleSharp.Css.Dom
                             yield return sheet;
                         }
                     }
-                    else
-                    {
-                        foreach (var sheet in child.GetStyleSheets())
-                        {
-                            yield return sheet;
-                        }
-                    }
+                }
+
+                for (var i = child.ChildNodes.Length - 1; i >= 0; i--)
+                {
+                    st.Push(child.ChildNodes[i]);
                 }
             }
         }


### PR DESCRIPTION
## Contribution Type

What types of changes does your code introduce? Put an `x` in all the boxes that apply:

- [x] Bug fix (non-breaking change which fixes an issue, please reference the issue id)
- [ ] New feature (non-breaking change which adds functionality, make sure to open an associated issue first)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] My change requires a change to the documentation
- [ ] I have updated the documentation accordingly
- [x] I have added tests to cover my changes
- [x] All new and existing tests passed

## Description

Refer to issue https://github.com/AngleSharp/AngleSharp/issues/1084. Reimplemented `StyleExtensions.GetStyleSheets()` to use a stack on the heap instead of the program stack to avoid stack overflow exceptions. I have kept the original depth-first ordering of the return value.

I did make a unit test, but because AngleSharp.Css is not available here I believe I need to mock the styling service and return a dummy object to be able to assert something. To keep the execution time low I created a thread with a small stack size. Using the main thread gave an execution time of 3 seconds or so on "my machine" because we need a very deep DOM. Using a 64KB stack made the unit test run in just 85ms (also on "my machine").