### PR TITLE
Implemented self-closing tags html formatter I-1111

### DIFF
--- a/src/AngleSharp.Core.Tests/Library/MarkupFormatter.cs
+++ b/src/AngleSharp.Core.Tests/Library/MarkupFormatter.cs
@@ -117,5 +117,13 @@ div.WordSection1 { page: WordSection1 }</style>
             var h = dom.Body.ToHtml();
             Assert.AreEqual("<body><noscript>&lt;</noscript></body>", h);
         }
+
+        [Test]
+        public void SelfClosingElements_Issue1111()
+        {
+            var doc = (@"<input type=""text""/>").ToHtmlDocument();
+            var input = doc.QuerySelector("input");
+            Assert.That(input.ToHtml(), Is.EqualTo(@"<input type=""text""/>"));
+        }
     }
 }

--- a/src/AngleSharp/Html/HtmlMarkupFormatter.cs
+++ b/src/AngleSharp/Html/HtmlMarkupFormatter.cs
@@ -66,6 +66,9 @@ namespace AngleSharp.Html
                 temp.Append(' ').Append(Attribute(attribute));
             }
 
+            if (selfClosing)
+                temp.Append(Symbols.Solidus);
+
             temp.Append(Symbols.GreaterThan);
             return temp.ToPool();
         }


### PR DESCRIPTION
# Types of Changes

## Prerequisites

Please make sure you can check the following two boxes:

- [/] I have read the **CONTRIBUTING** document
- [/] My code follows the code style of this project

## Contribution Type

What types of changes does your code introduce? Put an `x` in all the boxes that apply:

- [/] Bug fix Issue 1111
- [ ] New feature (non-breaking change which adds functionality, make sure to open an associated issue first)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [X] My change requires a change to the documentation
- [ ] I have updated the documentation accordingly
- [/] I have added tests to cover my changes
- [/] All new and existing tests passed

## Description

This PR causes "self-closing" tags to properly close when generating html.
