### PR TITLE
Issue #1115

### DIFF
--- a/src/AngleSharp.Core.Tests/Library/XhtmlFormatter.cs
+++ b/src/AngleSharp.Core.Tests/Library/XhtmlFormatter.cs
@@ -3,6 +3,9 @@ using NUnit.Framework;
 
 namespace AngleSharp.Core.Tests.Library
 {
+    using System;
+    using Dom;
+
     [TestFixture]
     public class XhtmlFormatter
     {
@@ -49,6 +52,54 @@ namespace AngleSharp.Core.Tests.Library
 
             var res = doc.ToHtml(formatter);
 
+            Assert.AreEqual(expected, res);
+        }
+
+        [Test]
+        public void XhtmlMarkupFormatter_KeepsEntireNameOfXmlNamespacedAttributes()
+        {
+            var formatter = new XhtmlMarkupFormatter();
+            var attributeName = String.Concat(NamespaceNames.XmlNsPrefix, ":", "pfx");
+            var inputOnWhichToSetAttribute = "<html>" +
+                                "<head></head>" +
+                                 "<body>" +
+                                    "<div>test</div>" +
+                                "</body>" +
+                            "</html>";
+            var expected = "<html>" +
+                                    "<head />" +
+                                    "<body>" +
+                                       "<div xmlns:pfx=\"http://www.foo.com\">test</div>" +
+                                    "</body>" +
+                                "</html>";
+            var doc = inputOnWhichToSetAttribute.ToHtmlDocument();
+            doc.Body.FirstElementChild.SetAttribute(NamespaceNames.XmlNsUri, attributeName, "http://www.foo.com");
+            var res = doc.ToHtml(formatter);
+            Assert.AreEqual(expected, res);
+        }
+
+
+        [Test]
+        public void XhtmlMarkupFormatter_DoesNotDuplicatePrefixIfUnnecessary()
+        {
+            var formatter = new XhtmlMarkupFormatter();
+            var attributeName = NamespaceNames.XmlNsPrefix;
+            var inputOnWhichToSetAttribute = "<html>" +
+                        "<head></head>" +
+                        "<body>" +
+                        "<div>test</div>" +
+                        "</body>" +
+                        "</html>";
+            var expected = "<html>" +
+                           "<head />" +
+                           "<body>" +
+                           "<div xmlns=\"http://www.foo.com\">test</div>" +
+                           "</body>" +
+                           "</html>";
+            var doc = inputOnWhichToSetAttribute.ToHtmlDocument();
+
+            doc.Body.FirstElementChild.SetAttribute(NamespaceNames.XmlNsUri, attributeName, "http://www.foo.com");
+            var res = doc.ToHtml(formatter);
             Assert.AreEqual(expected, res);
         }
     }

--- a/src/AngleSharp/Xhtml/XhtmlMarkupFormatter.cs
+++ b/src/AngleSharp/Xhtml/XhtmlMarkupFormatter.cs
@@ -202,9 +202,9 @@ namespace AngleSharp.Xhtml
         /// <summary>
         /// Gets the local name using the XML namespace prefix if required.
         /// </summary>
-        /// <param name="name">The name to be properly represented.</param>
+        /// <param name="localName">The name to be properly represented.</param>
         /// <returns>The string representation.</returns>
-        public static String XmlNamespaceLocalName(String name) => !name.Is(NamespaceNames.XmlNsPrefix) ? String.Concat(NamespaceNames.XmlNsPrefix, ":") : name;
+        public static String XmlNamespaceLocalName(String localName) => !localName.Is(NamespaceNames.XmlNsPrefix) ? String.Concat(NamespaceNames.XmlNsPrefix, Symbols.Colon, localName) : localName;
 
         #endregion
     }


### PR DESCRIPTION
Changed the local variable name to `localName` as that is what is being acted upon.
Prevented the method from stripping off the localName when prefixing with the xmlns prefix.

# Types of Changes

## Prerequisites

Please make sure you can check the following two boxes:

- [/] I have read the **CONTRIBUTING** document
- [/] My code follows the code style of this project

## Contribution Type

What types of changes does your code introduce? Put an `x` in all the boxes that apply:

- [/] Bug fix (non-breaking change which fixes an issue, please reference the issue id) 
Issue 1115
- [/] I have added tests to cover my changes
- [/] All new and existing tests passed

## Description

Formerly, when an attribute was in the xmlns namespace, the code that attempted to appropriately prefix the attribute name with the `xmlns` prefix would drop the local name, and simply output `xmlns:` as the name of the attribute, which is invalid XML and XHTML.
