### PR TITLE
remove System.Text.Encoding.CodePages in net7

### DIFF
--- a/src/AngleSharp.nuspec
+++ b/src/AngleSharp.nuspec
@@ -27,9 +27,6 @@
       <group targetFramework="net60">
         <dependency id="System.Text.Encoding.CodePages" version="6.0.0" />
       </group>
-      <group targetFramework="net70">
-        <dependency id="System.Text.Encoding.CodePages" version="7.0.0" />
-      </group>
     </dependencies>
   </metadata>
 </package>


### PR DESCRIPTION
doesnt seem to be required based on this
```
  <ItemGroup Condition=" '$(TargetFramework)' == 'netstandard2.0' or '$(TargetFramework)' == 'net461' or '$(TargetFramework)' == 'net472' or '$(TargetFramework)' == 'net6.0' ">
    <PackageReference Include="System.Text.Encoding.CodePages" Version="6.0.0" />
  </ItemGroup>
```