### PR TITLE
Improve QuerySelectorAll performance

### DIFF
--- a/src/AngleSharp.Benchmarks/AngleSharp.Benchmarks.csproj
+++ b/src/AngleSharp.Benchmarks/AngleSharp.Benchmarks.csproj
@@ -1,7 +1,7 @@
 <Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
     <OutputType>Exe</OutputType>
-    <TargetFramework>net472</TargetFramework>
+    <TargetFrameworks>net472;net6.0</TargetFrameworks>
     <SignAssembly>false</SignAssembly>
   </PropertyGroup>
 
@@ -10,16 +10,14 @@
   </ItemGroup>
 
   <ItemGroup>
-    <PackageReference Include="BenchmarkDotNet" Version="0.13.5" />
-    <PackageReference Include="CsQuery" Version="1.3.5-beta5" />
+    <PackageReference Include="BenchmarkDotNet" Version="0.13.7" />
+    <PackageReference Include="CsQuery" Version="1.3.5-beta5" Condition=" '$(TargetFramework)' == 'net472' " />
     <PackageReference Include="HtmlAgilityPack" Version="1.11.46" />
     <PackageReference Include="System.Net.Http" Version="4.3.4" />
   </ItemGroup>
 
   <ItemGroup>
-    <None Update="page.html">
-      <CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
-    </None>
+    <None Update="page.html" CopyToOutputDirectory="PreserveNewest" />
   </ItemGroup>
 
 </Project>

--- a/src/AngleSharp.Benchmarks/ParserBenchmark.cs
+++ b/src/AngleSharp.Benchmarks/ParserBenchmark.cs
@@ -1,11 +1,14 @@
 using System.Collections.Generic;
-using System.Text;
 using AngleSharp.Html.Parser;
 using BenchmarkDotNet.Attributes;
 using BenchmarkDotNet.Configs;
+
+#if NETFRAMEWORK
 using CsQuery;
 using CsQuery.ExtensionMethods.Internal;
 using CsQuery.HtmlParser;
+#endif
+
 using HtmlAgilityPack;
 
 namespace AngleSharp.Benchmarks
@@ -20,7 +23,7 @@ namespace AngleSharp.Benchmarks
             var websites = new UrlTests(
                 ".html",
                 true);
-            
+
             websites.Include(
                 "http://www.amazon.com",
                 "http://www.blogspot.com",
@@ -78,14 +81,16 @@ namespace AngleSharp.Benchmarks
 
         [ParamsSource(nameof(GetSources))] public UrlTest UrlTest { get; set; }
 
+#if NETFRAMEWORK
         [Benchmark]
         public void CsQuery()
         {
             var factory = new ElementFactory(DomIndexProviders.Simple);
 
             using var stream = UrlTest.Source.ToStream();
-            factory.Parse(stream, Encoding.UTF8);
+            factory.Parse(stream, System.Text.Encoding.UTF8);
         }
+#endif
 
         [Benchmark]
         public void HTMLAgilityPack()

--- a/src/AngleSharp.Benchmarks/SelectorBenchmark.cs
+++ b/src/AngleSharp.Benchmarks/SelectorBenchmark.cs
@@ -5,7 +5,10 @@ using AngleSharp.Dom;
 using AngleSharp.Html.Parser;
 using BenchmarkDotNet.Attributes;
 using BenchmarkDotNet.Configs;
+
+#if NETFRAMEWORK
 using CsQuery;
+#endif
 
 namespace AngleSharp.Benchmarks
 {
@@ -14,14 +17,19 @@ namespace AngleSharp.Benchmarks
     {
         private static readonly HtmlParser angleSharpParser = new HtmlParser();
         private IDocument angleSharpDocument;
+
+#if NETFRAMEWORK
         private CQ cqDocument;
+#endif
 
         [GlobalSetup]
         public void GlobalSetup()
         {
             var pageContent = File.ReadAllText("page.html");
             angleSharpDocument = angleSharpParser.ParseDocument(pageContent);
+#if NETFRAMEWORK
             cqDocument = CQ.CreateDocument(pageContent);
+#endif
         }
 
         [ParamsSource(nameof(GetSelectors))]
@@ -73,11 +81,13 @@ namespace AngleSharp.Benchmarks
             "div > p > a"
         };
 
+#if NETFRAMEWORK
         [Benchmark]
         public void CsQuery()
         {
             cqDocument.Select(Selector);
         }
+#endif
 
         [Benchmark]
         public void AngleSharp()

--- a/src/AngleSharp/Css/Dom/Internal/ComplexSelector.cs
+++ b/src/AngleSharp/Css/Dom/Internal/ComplexSelector.cs
@@ -133,11 +133,12 @@ namespace AngleSharp.Css.Dom
 
         private Boolean MatchCascade(Int32 pos, IElement element, IElement? scope)
         {
-            var newElements = _combinators[pos].Transform!(element);
+            var combinatorSelector = _combinators[pos];
+            var newElements = combinatorSelector.Transform!(element);
 
             foreach (var newElement in newElements)
             {
-                if (_combinators[pos].Selector.Match(newElement, scope) && (pos == 0 || MatchCascade(pos - 1, newElement, scope)))
+                if (combinatorSelector.Selector.Match(newElement, scope) && (pos == 0 || MatchCascade(pos - 1, newElement, scope)))
                 {
                     return true;
                 }

--- a/src/AngleSharp/Css/Dom/SelectorExtensions.cs
+++ b/src/AngleSharp/Css/Dom/SelectorExtensions.cs
@@ -19,14 +19,19 @@ namespace AngleSharp.Css.Dom
         /// <returns>The resulting element or null.</returns>
         public static IElement? MatchAny(this ISelector selector, IEnumerable<IElement> elements, IElement? scope)
         {
+            var stack = new Stack<INode>();
             foreach (var element in elements)
             {
-                foreach (var descendentAndSelf in element.DescendentsAndSelf<IElement>())
+                stack.Clear();
+                var nodes = element.GetDescendantsAndSelf(
+                    stack,
+                    filter: static (node, state) => node is IElement e && state.Selector.Match(e, state.Scope),
+                    state: new SelectorState(selector, scope));
+
+                var enumerator = nodes.GetEnumerator();
+                if (enumerator.MoveNext())
                 {
-                    if (selector.Match(descendentAndSelf, scope))
-                    {
-                        return descendentAndSelf;
-                    }
+                    return (IElement?) enumerator.Current;
                 }
             }
 
@@ -59,15 +64,31 @@ namespace AngleSharp.Css.Dom
 
         private static void MatchAll(this ISelector selector, IEnumerable<IElement> elements, IElement? scope, List<IElement> result)
         {
+            var stack = new Stack<INode>();
             foreach (var element in elements)
             {
-                foreach (var descendentAndSelf in element.DescendentsAndSelf<IElement>())
+                stack.Clear();
+                var nodes = element.GetDescendantsAndSelf(
+                    stack,
+                    filter: static (node, state) => node is IElement e && state.Selector.Match(e, state.Scope),
+                    state: new SelectorState(selector, scope));
+
+                foreach (var descendentAndSelf in nodes)
                 {
-                    if (selector.Match(descendentAndSelf, scope))
-                    {
-                        result.Add(descendentAndSelf);
-                    }
+                    result.Add((IElement) descendentAndSelf);
                 }
+            }
+        }
+
+        private readonly struct SelectorState
+        {
+            public readonly ISelector Selector;
+            public readonly IElement? Scope;
+
+            public SelectorState(ISelector selector, IElement? scope)
+            {
+                Selector = selector;
+                Scope = scope;
             }
         }
     }

--- a/src/AngleSharp/Dom/Internal/NodeList.cs
+++ b/src/AngleSharp/Dom/Internal/NodeList.cs
@@ -4,6 +4,7 @@ namespace AngleSharp.Dom
     using System.Collections;
     using System.Collections.Generic;
     using System.IO;
+    using System.Runtime.CompilerServices;
 
     /// <summary>
     /// Represents a list of Node instances or nodes.
@@ -34,17 +35,27 @@ namespace AngleSharp.Dom
 
         public Node this[Int32 index]
         {
+            [MethodImpl(MethodImplOptions.AggressiveInlining)]
             get => _entries[index];
+            [MethodImpl(MethodImplOptions.AggressiveInlining)]
             set => _entries[index] = value;
         }
 
-        INode INodeList.this[Int32 index] => this[index];
+        INode INodeList.this[Int32 index]
+        {
+            [MethodImpl(MethodImplOptions.AggressiveInlining)]
+            get => this[index];
+        }
 
         #endregion
 
         #region Properties
 
-        public Int32 Length => _entries.Count;
+        public Int32 Length
+        {
+            [MethodImpl(MethodImplOptions.AggressiveInlining)]
+            get => _entries.Count;
+        }
 
         #endregion
 

--- a/src/AngleSharp/Dom/QueryExtensions.cs
+++ b/src/AngleSharp/Dom/QueryExtensions.cs
@@ -23,7 +23,18 @@ namespace AngleSharp.Dom
         /// <param name="selectorText">A string containing one or more CSS selectors separated by commas.</param>
         /// <param name="scopeNode">The optional node to take as scope.</param>
         /// <returns>An element object.</returns>
-        public static IElement? QuerySelector(this INodeList nodes, String selectorText, INode? scopeNode = null)
+        public static IElement? QuerySelector(this INodeList nodes, String selectorText, INode? scopeNode = null) => QuerySelector<INodeList>(nodes, selectorText, scopeNode);
+
+        /// <summary>
+        /// Returns the first element within the document (using depth-first pre-order traversal
+        /// of the document's nodes) that matches the specified group of selectors.
+        /// Requires either a non-empty nodelist or a valid scope node.
+        /// </summary>
+        /// <param name="nodes">The nodes to take as source.</param>
+        /// <param name="selectorText">A string containing one or more CSS selectors separated by commas.</param>
+        /// <param name="scopeNode">The optional node to take as scope.</param>
+        /// <returns>An element object.</returns>
+        public static IElement? QuerySelector<T>(this T nodes, String selectorText, INode? scopeNode = null) where T : class, INodeList
         {
             var scope = GetScope(scopeNode);
             var sg = CreateSelector(nodes, scope, selectorText);
@@ -45,7 +56,18 @@ namespace AngleSharp.Dom
         /// <param name="selectorText">A string containing one or more CSS selectors separated by commas.</param>
         /// <param name="scopeNode">The optional node to take as scope.</param>
         /// <returns>A HTMLCollection with all elements that match the selection.</returns>
-        public static IHtmlCollection<IElement> QuerySelectorAll(this INodeList nodes, String selectorText, INode? scopeNode = null)
+        public static IHtmlCollection<IElement> QuerySelectorAll(this INodeList nodes, String selectorText, INode? scopeNode = null) => QuerySelectorAll<INodeList>(nodes, selectorText, scopeNode);
+
+        /// <summary>
+        /// Returns a list of the elements within the document (using depth-first pre-order traversal
+        /// of the document's nodes) that match the specified group of selectors.
+        /// Requires either a non-empty nodelist or a valid scope node.
+        /// </summary>
+        /// <param name="nodes">The nodes to take as source.</param>
+        /// <param name="selectorText">A string containing one or more CSS selectors separated by commas.</param>
+        /// <param name="scopeNode">The optional node to take as scope.</param>
+        /// <returns>A HTMLCollection with all elements that match the selection.</returns>
+        public static IHtmlCollection<IElement> QuerySelectorAll<T>(this T nodes, String selectorText, INode? scopeNode = null) where T : class, INodeList
         {
             var scope = GetScope(scopeNode);
             var sg = CreateSelector(nodes, scope, selectorText);
@@ -64,7 +86,15 @@ namespace AngleSharp.Dom
         /// <param name="elements">The elements to take as source.</param>
         /// <param name="classNames">A string representing the list of class names to match; class names are separated by whitespace.</param>
         /// <returns>A collection of HTML elements.</returns>
-        public static IHtmlCollection<IElement> GetElementsByClassName(this INodeList elements, String classNames)
+        public static IHtmlCollection<IElement> GetElementsByClassName(this INodeList elements, String classNames) => GetElementsByClassName<INodeList>(elements, classNames);
+
+        /// <summary>
+        /// Returns a set of elements which have all the given class names.
+        /// </summary>
+        /// <param name="elements">The elements to take as source.</param>
+        /// <param name="classNames">A string representing the list of class names to match; class names are separated by whitespace.</param>
+        /// <returns>A collection of HTML elements.</returns>
+        public static IHtmlCollection<IElement> GetElementsByClassName<T>(this T elements, String classNames) where T : class, INodeList
         {
             var result = new List<IElement>();
             var names = classNames.SplitSpaces();
@@ -83,7 +113,15 @@ namespace AngleSharp.Dom
         /// <param name="elements">The elements to take as source.</param>
         /// <param name="tagName">A string representing the name of the elements. The special string "*" represents all elements.</param>
         /// <returns>A NodeList of found elements in the order they appear in the tree.</returns>
-        public static IHtmlCollection<IElement> GetElementsByTagName(this INodeList elements, String tagName)
+        public static IHtmlCollection<IElement> GetElementsByTagName(this INodeList elements, String tagName) => GetElementsByTagName<INodeList>(elements, tagName);
+
+        /// <summary>
+        /// Returns a NodeList of elements with the given tag name. The complete document is searched, including the root node.
+        /// </summary>
+        /// <param name="elements">The elements to take as source.</param>
+        /// <param name="tagName">A string representing the name of the elements. The special string "*" represents all elements.</param>
+        /// <returns>A NodeList of found elements in the order they appear in the tree.</returns>
+        public static IHtmlCollection<IElement> GetElementsByTagName<T>(this T elements, String tagName) where T : class, INodeList
         {
             var result = new List<IElement>();
             elements.GetElementsByTagName(tagName is "*" ? null : tagName, result);
@@ -98,7 +136,17 @@ namespace AngleSharp.Dom
         /// <param name="namespaceUri">The namespace URI of elements to look for.</param>
         /// <param name="localName">Either the local name of elements to look for or the special value "*", which matches all elements.</param>
         /// <returns>A NodeList of found elements in the order they appear in the tree.</returns>
-        public static IHtmlCollection<IElement> GetElementsByTagName(this INodeList elements, String? namespaceUri, String localName)
+        public static IHtmlCollection<IElement> GetElementsByTagName(this INodeList elements, String? namespaceUri, String localName) => GetElementsByTagName<INodeList>(elements, namespaceUri, localName);
+
+        /// <summary>
+        /// Returns a list of elements with the given tag name belonging to the given namespace.
+        /// The complete document is searched, including the root node.
+        /// </summary>
+        /// <param name="elements">The elements to take as source.</param>
+        /// <param name="namespaceUri">The namespace URI of elements to look for.</param>
+        /// <param name="localName">Either the local name of elements to look for or the special value "*", which matches all elements.</param>
+        /// <returns>A NodeList of found elements in the order they appear in the tree.</returns>
+        public static IHtmlCollection<IElement> GetElementsByTagName<T>(this T elements, String? namespaceUri, String localName) where T : class, INodeList
         {
             var result = new List<IElement>();
             elements.GetElementsByTagName(namespaceUri, localName is "*" ? null : localName, result);
@@ -116,8 +164,16 @@ namespace AngleSharp.Dom
         /// <param name="elements">The elements to take as source.</param>
         /// <param name="selectors">A selector object.</param>
         /// <returns>An element object.</returns>
-        public static T? QuerySelector<T>(this INodeList elements, ISelector selectors)
-            where T : class, IElement
+        public static T? QuerySelector<T>(this INodeList elements, ISelector selectors) where T : class => QuerySelector<INodeList, T>(elements, selectors);
+
+        /// <summary>
+        /// Returns the first element within the document (using depth-first pre-order traversal
+        /// of the document's nodes) that matches the given selector.
+        /// </summary>
+        /// <param name="elements">The elements to take as source.</param>
+        /// <param name="selectors">A selector object.</param>
+        /// <returns>An element object.</returns>
+        public static T? QuerySelector<TNodeList, T>(this TNodeList elements, ISelector selectors) where T : class where TNodeList: class, INodeList
         {
             return elements.QuerySelector(selectors) as T;
         }
@@ -156,13 +212,55 @@ namespace AngleSharp.Dom
         }
 
         /// <summary>
+        /// Returns the first element within the document (using depth-first pre-order traversal
+        /// of the document's nodes) that matches the specified group of selectors.
+        /// </summary>
+        /// <param name="elements">The elements to take as source.</param>
+        /// <param name="selector">A selector object.</param>
+        /// <returns>An element object.</returns>
+        public static IElement? QuerySelector<T>(this T elements, ISelector selector) where T : INodeList
+        {
+            for (var i = 0; i < elements.Length; i++)
+            {
+                if (elements[i] is IElement element)
+                {
+                    if (selector.Match(element))
+                    {
+                        return element;
+                    }
+
+                    if (element.HasChildNodes)
+                    {
+                        element = QuerySelector(element.ChildNodes, selector)!;
+
+                        if (element != null)
+                        {
+                            return element;
+                        }
+                    }
+                }
+            }
+
+            return null;
+        }
+
+        /// <summary>
         /// Returns a list of the elements within the document (using depth-first pre-order traversal
         /// of the document's nodes) that matches the selector.
         /// </summary>
         /// <param name="elements">The elements to take as source.</param>
         /// <param name="selector">A selector object.</param>
         /// <returns>A HTMLCollection with all elements that match the selection.</returns>
-        public static IHtmlCollection<IElement> QuerySelectorAll(this INodeList elements, ISelector selector)
+        public static IHtmlCollection<IElement> QuerySelectorAll(this INodeList elements, ISelector selector) => QuerySelectorAll<INodeList>(elements, selector);
+
+        /// <summary>
+        /// Returns a list of the elements within the document (using depth-first pre-order traversal
+        /// of the document's nodes) that matches the selector.
+        /// </summary>
+        /// <param name="elements">The elements to take as source.</param>
+        /// <param name="selector">A selector object.</param>
+        /// <returns>A HTMLCollection with all elements that match the selection.</returns>
+        public static IHtmlCollection<IElement> QuerySelectorAll<T>(this T elements, ISelector selector) where T : class, INodeList
         {
             var result = new List<IElement>();
             elements.QuerySelectorAll(selector, result);
@@ -176,7 +274,16 @@ namespace AngleSharp.Dom
         /// <param name="elements">The elements to take as source.</param>
         /// <param name="selector">A selector object.</param>
         /// <param name="result">A reference to the list where to store the results.</param>
-        public static void QuerySelectorAll(this INodeList elements, ISelector selector, List<IElement> result)
+        public static void QuerySelectorAll(this INodeList elements, ISelector selector, List<IElement> result) => QuerySelectorAll<INodeList>(elements, selector, result);
+
+        /// <summary>
+        /// Returns a list of the elements within the document (using depth-first pre-order traversal
+        /// of the document's nodes) that match the specified group of selectors.
+        /// </summary>
+        /// <param name="elements">The elements to take as source.</param>
+        /// <param name="selector">A selector object.</param>
+        /// <param name="result">A reference to the list where to store the results.</param>
+        public static void QuerySelectorAll<T>(this T elements, ISelector selector, List<IElement> result) where T : class, INodeList
         {
             for (var i = 0; i < elements.Length; i++)
             {
@@ -199,7 +306,15 @@ namespace AngleSharp.Dom
         /// <param name="list">The list that is considered.</param>
         /// <param name="tokens">The tokens to consider.</param>
         /// <returns>True if the string contained all tokens, otherwise false.</returns>
-        public static Boolean Contains(this ITokenList list, String[] tokens)
+        public static Boolean Contains(this ITokenList list, String[] tokens) => Contains<ITokenList>(list, tokens);
+
+        /// <summary>
+        /// Returns true if the underlying string contains all of the tokens, otherwise false.
+        /// </summary>
+        /// <param name="list">The list that is considered.</param>
+        /// <param name="tokens">The tokens to consider.</param>
+        /// <returns>True if the string contained all tokens, otherwise false.</returns>
+        public static Boolean Contains<T>(this T list, String[] tokens) where T : class, ITokenList
         {
             for (var i = 0; i < tokens.Length; i++)
             {
@@ -222,7 +337,7 @@ namespace AngleSharp.Dom
         /// <param name="elements">The elements to take as source.</param>
         /// <param name="classNames">An array with class names to consider.</param>
         /// <param name="result">A reference to the list where to store the results.</param>
-        private static void GetElementsByClassName(this INodeList elements, String[] classNames, List<IElement> result)
+        private static void GetElementsByClassName<T>(this T elements, String[] classNames, List<IElement> result) where T : class, INodeList
         {
             for (var i = 0; i < elements.Length; i++)
             {
@@ -248,7 +363,7 @@ namespace AngleSharp.Dom
         /// <param name="elements">The elements to take as source.</param>
         /// <param name="tagName">A string representing the name of the elements. The special string "*" represents all elements.</param>
         /// <param name="result">A reference to the list where to store the results.</param>
-        private static void GetElementsByTagName(this INodeList elements, String? tagName, List<IElement> result)
+        private static void GetElementsByTagName<T>(this T elements, String? tagName, List<IElement> result) where T : class, INodeList
         {
             for (var i = 0; i < elements.Length; i++)
             {
@@ -275,7 +390,7 @@ namespace AngleSharp.Dom
         /// <param name="namespaceUri">The namespace URI of elements to look for.</param>
         /// <param name="localName">Either the local name of elements to look for or the special value "*", which matches all elements.</param>
         /// <param name="result">A reference to the list where to store the results.</param>
-        private static void GetElementsByTagName(this INodeList elements, String? namespaceUri, String? localName, List<IElement> result)
+        private static void GetElementsByTagName<T>(this T elements, String? namespaceUri, String? localName, List<IElement> result)  where T : class, INodeList
         {
             for (var i = 0; i < elements.Length; i++)
             {
@@ -299,7 +414,7 @@ namespace AngleSharp.Dom
             (scopeNode as IDocument)?.DocumentElement ??
             (scopeNode as IShadowRoot)?.Host;
 
-        private static ISelector? CreateSelector(INodeList nodes, INode? scope, String selectorText)
+        private static ISelector? CreateSelector<T>(T nodes, INode? scope, String selectorText) where T : class, INodeList
         {
             var node = nodes.Length > 0 ? nodes[0] : scope;
             var sg = default(ISelector);


### PR DESCRIPTION
# Types of Changes

## Prerequisites

Please make sure you can check the following two boxes:

- [x] I have read the **CONTRIBUTING** document
- [x] My code follows the code style of this project

## Contribution Type

What types of changes does your code introduce? Put an `x` in all the boxes that apply:

- [ ] Bug fix (non-breaking change which fixes an issue, please reference the issue id)
- [ ] New feature (non-breaking change which adds functionality, make sure to open an associated issue first)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] My change requires a change to the documentation
- [ ] I have updated the documentation accordingly
- [ ] I have added tests to cover my changes
- [x] All new and existing tests passed

## Description

#584 seemed like an interesting long-standing issue as optimizations are always fun. This PR basically reduces interface dispatch cost and optimizes node iteration for `MatchAll` and `MatchAny`.

* reduce memory usage in `NodeExtensions` by reusing stack instance, affects scenarios querying non-roots
* pass filter logic (and state) into `GetDescendantsAndSelf` to minimize items returned from enumerator
* force inline for `NodeList` members
* make `QueryExtensions` methods take `INodeList` input as generic type to remove virtual dispatch when call site knows the actual type
* update to latest BenchmarkDotNet, add `net6.0` target to benchmark project (realistic benchmarks for modern workloads)

fixes #584

## Benchmark results

```

BenchmarkDotNet v0.13.7, Windows 11 (10.0.23521.1000)
AMD Ryzen 9 5950X, 1 CPU, 32 logical and 16 physical cores
.NET SDK 8.0.100-preview.7.23376.3
  [Host]   : .NET 6.0.21 (6.0.2123.36311), X64 RyuJIT AVX2
  ShortRun : .NET 6.0.21 (6.0.2123.36311), X64 RyuJIT AVX2

Job=ShortRun  IterationCount=3  LaunchCount=1  
WarmupCount=3  

```

### AngleSharp.Benchmarks.SelectorBenchmark

| **Diff**|Selector|Mean|Error|Allocated|
|------- |-------|-------:|-------|-------:|
| Old |.note|162.2 μs|48.42 μs|17.04 KB|
| **New** | **.note** | **106.10 μs (-35%)** | **10.612 μs** | **17.04 KB (0%)** |
| Old |#title|159.3 μs|9.09 μs|16.8 KB|
| **New** | **#title** | **104.93 μs (-34%)** | **25.131 μs** | **16.8 KB (0%)** |
| Old |a[href]|160.1 μs|5.89 μs|21.05 KB|
| **New** | **a[href]** | **117.24 μs (-27%)** | **7.712 μs** | **21.05 KB (0%)** |
| Old |a[href][lang][class]|170.3 μs|10.04 μs|17.12 KB|
| **New** | **a[href][lang][class]** | **121.18 μs (-29%)** | **6.808 μs** | **17.12 KB (0%)** |
| Old |body|155.1 μs|5.56 μs|16.8 KB|
| **New** | **body** | **103.34 μs (-33%)** | **6.323 μs** | **16.8 KB (0%)** |
| Old |body div|167.9 μs|10.41 μs|24.5 KB|
| **New** | **body div** | **109.53 μs (-35%)** | **20.872 μs** | **24.5 KB (0%)** |
| Old |div|158.5 μs|2.75 μs|17.84 KB|
| **New** | **div** | **99.94 μs (-37%)** | **13.797 μs** | **17.84 KB (0%)** |
| Old |div #title|166.0 μs|31.90 μs|17.22 KB|
| **New** | **div #title** | **109.41 μs (-34%)** | **7.478 μs** | **17.22 KB (0%)** |
| Old |div + p|243.4 μs|6.31 μs|32.81 KB|
| **New** | **div + p** | **175.63 μs (-28%)** | **3.018 μs** | **32.8 KB (0%)** |
| Old |div > p|178.7 μs|11.65 μs|36.38 KB|
| **New** | **div > p** | **118.76 μs (-34%)** | **11.107 μs** | **36.38 KB (0%)** |
| Old |div > p > a|168.6 μs|8.40 μs|34.85 KB|
| **New** | **div > p > a** | **120.81 μs (-28%)** | **10.098 μs** | **34.85 KB (0%)** |
| Old |div ~ p|960.0 μs|156.94 μs|731.67 KB|
| **New** | **div ~ p** | **876.05 μs (-9%)** | **114.184 μs** | **731.67 KB (0%)** |
| Old |div p|189.9 μs|5.54 μs|62.18 KB|
| **New** | **div p** | **136.30 μs (-28%)** | **16.232 μs** | **62.18 KB (0%)** |
| Old |div p a|225.3 μs|18.13 μs|78.78 KB|
| **New** | **div p a** | **158.94 μs (-29%)** | **4.447 μs** | **78.78 KB (0%)** |
| Old |div, p, a|179.0 μs|3.70 μs|33.19 KB|
| **New** | **div, p, a** | **133.19 μs (-26%)** | **8.271 μs** | **33.19 KB (0%)** |
| Old |div:not(.example)|159.1 μs|1.91 μs|17.52 KB|
| **New** | **div:not(.example)** | **107.77 μs (-32%)** | **10.480 μs** | **17.52 KB (0%)** |
| Old |div.example|159.7 μs|82.68 μs|18.01 KB|
| **New** | **div.example** | **106.78 μs (-33%)** | **7.062 μs** | **18.01 KB (0%)** |
| Old |div.e(...).note [21]|179.1 μs|11.68 μs|18.39 KB|
| **New** | **div.e(...).note [21]** | **128.61 μs (-28%)** | **3.825 μs** | **18.39 KB (0%)** |
| Old |div[class!=made_up]|160.4 μs|24.60 μs|18.07 KB|
| **New** | **div[class!=made_up]** | **110.34 μs (-31%)** | **11.459 μs** | **18.07 KB (0%)** |
| Old |div[class]|153.6 μs|9.55 μs|18.02 KB|
| **New** | **div[class]** | **107.88 μs (-30%)** | **6.337 μs** | **18.02 KB (0%)** |
| Old |div[class*=e]|159.8 μs|13.64 μs|18.05 KB|
| **New** | **div[class*=e]** | **108.30 μs (-32%)** | **12.215 μs** | **18.05 KB (0%)** |
| Old |div[class^=exa]|170.7 μs|59.14 μs|18.06 KB|
| **New** | **div[class^=exa]** | **109.30 μs (-36%)** | **8.698 μs** | **18.06 KB (0%)** |
| Old |div[c(...)mple] [28]|167.5 μs|21.36 μs|18.18 KB|
| **New** | **div[c(...)mple] [28]** | **107.00 μs (-36%)** | **3.059 μs** | **18.18 KB (0%)** |
| Old |div[class=example]|162.4 μs|9.58 μs|18.09 KB|
| **New** | **div[class=example]** | **110.83 μs (-32%)** | **18.372 μs** | **18.09 KB (0%)** |
| Old |div[class\|=dialog]|153.9 μs|7.02 μs|16.98 KB|
| **New** | **div[class\|=dialog]** | **109.27 μs (-29%)** | **8.509 μs** | **16.98 KB (0%)** |
| Old |div[class~=example]|163.7 μs|6.93 μs|26.02 KB|
| **New** | **div[class~=example]** | **113.05 μs (-31%)** | **6.515 μs** | **26.02 KB (0%)** |
| Old |div[class$=mple]|157.7 μs|65.60 μs|18.06 KB|
| **New** | **div[class$=mple]** | **106.89 μs (-32%)** | **12.072 μs** | **18.06 KB (0%)** |
| Old |h1[id(...)tors) [26]|156.1 μs|11.43 μs|17.55 KB|
| **New** | **h1[id(...)tors) [26]** | **111.38 μs (-29%)** | **2.009 μs** | **17.59 KB (0%)** |
| Old |h1#title|168.8 μs|44.50 μs|16.97 KB|
| **New** | **h1#title** | **109.20 μs (-35%)** | **23.056 μs** | **16.97 KB (0%)** |
| Old |h1#title + div > p|230.8 μs|6.79 μs|38.77 KB|
| **New** | **h1#title + div > p** | **164.57 μs (-29%)** | **9.085 μs** | **38.77 KB (0%)** |
| Old |p:con(...)tors) [21]|360.0 μs|7.11 μs|234.51 KB|
| **New** | **p:con(...)tors) [21]** | **295.80 μs (-18%)** | **34.521 μs** | **247.17 KB (+5%)** |
| Old |p:first-child|163.6 μs|5.55 μs|17.98 KB|
| **New** | **p:first-child** | **115.14 μs (-30%)** | **17.388 μs** | **17.98 KB (0%)** |
| Old |p:last-child|165.7 μs|11.70 μs|17.46 KB|
| **New** | **p:last-child** | **112.19 μs (-32%)** | **2.951 μs** | **17.46 KB (0%)** |
| Old |p:nth-child(2n)|736.3 μs|58.25 μs|21.17 KB|
| **New** | **p:nth-child(2n)** | **674.85 μs (-8%)** | **80.690 μs** | **21.17 KB (0%)** |
| Old |p:nth-child(2n+1)|779.3 μs|90.54 μs|21.2 KB|
| **New** | **p:nth-child(2n+1)** | **696.89 μs (-11%)** | **116.719 μs** | **21.2 KB (0%)** |
| Old |p:nth-child(even)|745.9 μs|296.13 μs|21.15 KB|
| **New** | **p:nth-child(even)** | **678.07 μs (-9%)** | **13.369 μs** | **21.15 KB (0%)** |
| Old |p:nth-child(n)|791.3 μs|452.90 μs|25.17 KB|
| **New** | **p:nth-child(n)** | **676.86 μs (-14%)** | **11.371 μs** | **25.17 KB (0%)** |
| Old |p:nth-child(odd)|733.6 μs|60.70 μs|21.15 KB|
| **New** | **p:nth-child(odd)** | **673.66 μs (-8%)** | **15.086 μs** | **21.15 KB (0%)** |
| Old |p:only-child|285.9 μs|28.29 μs|16.96 KB|
| **New** | **p:only-child** | **222.05 μs (-22%)** | **49.198 μs** | **16.95 KB (0%)** |
| Old |ul .tocline2|193.7 μs|76.40 μs|18.84 KB|
| **New** | **ul .tocline2** | **108.13 μs (-44%)** | **4.266 μs** | **18.84 KB (0%)** |
| Old |ul.toc > li.tocline2|183.0 μs|48.48 μs|18.25 KB|
| **New** | **ul.toc > li.tocline2** | **113.93 μs (-38%)** | **17.205 μs** | **18.25 KB (0%)** |
| Old |ul.toc li.tocline2|178.3 μs|47.72 μs|19.16 KB|
| **New** | **ul.toc li.tocline2** | **117.20 μs (-34%)** | **29.391 μs** | **19.16 KB (0%)** |



