### PR TITLE
Improve ChildSelector performance

### DIFF
--- a/src/AngleSharp/Css/Dom/Internal/FirstChildSelector.cs
+++ b/src/AngleSharp/Css/Dom/Internal/FirstChildSelector.cs
@@ -21,20 +21,38 @@ namespace AngleSharp.Css.Dom
 
             if (parent != null)
             {
-                var n = Math.Sign(Step);
-                var k = 0;
-
-                for (var i = 0; i < parent.ChildNodes.Length; i++)
+                // remove interface dispatch overhead
+                if (parent.ChildNodes is NodeList nodeList)
                 {
-                    if (parent.ChildNodes[i] is IElement child && Kind.Match(child, scope))
-                    {
-                        k += 1;
+                    return DoMatch(new ConcreteNodeListAccessor(nodeList), element, scope);
+                }
 
-                        if (child == element)
-                        {
-                            var diff = k - Offset;
-                            return diff == 0 || (Math.Sign(diff) == n && diff % Step == 0);
-                        }
+                return DoMatch(new InterfaceNodeListAccessor(parent.ChildNodes), element, scope);
+            }
+
+            return false;
+        }
+
+        private Boolean DoMatch<T>(T nodes, IElement element, IElement? scope) where T : INodeListAccessor
+        {
+            var step = Step;
+            var n = Math.Sign(step);
+            var k = 0;
+            var kind = Kind;
+            var matchAll = ReferenceEquals(Kind, AllSelector.Instance);
+            var offset = Offset;
+            var length = nodes.Length;
+
+            for (var i = 0; i < length; i++)
+            {
+                if (nodes[i] is IElement child && (matchAll || kind.Match(child, scope)))
+                {
+                    k += 1;
+
+                    if (child == element)
+                    {
+                        var diff = k - offset;
+                        return diff == 0 || (Math.Sign(diff) == n && diff % step == 0);
                     }
                 }
             }

--- a/src/AngleSharp/Css/Dom/Internal/FirstColumnSelector.cs
+++ b/src/AngleSharp/Css/Dom/Internal/FirstColumnSelector.cs
@@ -20,30 +20,46 @@ namespace AngleSharp.Css.Dom
 
             if (parent != null)
             {
-                var n = Math.Sign(Step);
-                var k = 0;
-
-                for (var i = 0; i < parent.ChildNodes.Length; i++)
+                // remove interface dispatch overhead
+                if (parent.ChildNodes is NodeList nodeList)
                 {
-                    if (parent.ChildNodes[i] is IHtmlTableCellElement child)
+                    return DoMatch(new ConcreteNodeListAccessor(nodeList), element);
+                }
+
+                return DoMatch(new InterfaceNodeListAccessor(parent.ChildNodes), element);
+            }
+
+            return false;
+        }
+
+        private Boolean DoMatch<T>(T nodes, IElement element) where T : INodeListAccessor
+        {
+            var step = Step;
+            var n = Math.Sign(step);
+            var k = 0;
+            var offset = Offset;
+            var length = nodes.Length;
+
+            for (var i = 0; i < length; i++)
+            {
+                if (nodes[i] is IHtmlTableCellElement child)
+                {
+                    var span = child.ColumnSpan;
+                    k += span;
+
+                    if (child == element)
                     {
-                        var span = child.ColumnSpan;
-                        k += span;
+                        var diff = k - offset;
 
-                        if (child == element)
+                        for (var index = 0; index < span; index++, diff--)
                         {
-                            var diff = k - Offset;
-
-                            for (var index = 0; index < span; index++, diff--)
+                            if (diff == 0 || (Math.Sign(diff) == n && diff % step == 0))
                             {
-                                if (diff == 0 || (Math.Sign(diff) == n && diff % Step == 0))
-                                {
-                                    return true;
-                                }
+                                return true;
                             }
-
-                            return false;
                         }
+
+                        return false;
                     }
                 }
             }

--- a/src/AngleSharp/Css/Dom/Internal/FirstTypeSelector.cs
+++ b/src/AngleSharp/Css/Dom/Internal/FirstTypeSelector.cs
@@ -20,20 +20,37 @@ namespace AngleSharp.Css.Dom
 
             if (parent != null)
             {
-                var n = Math.Sign(Step);
-                var k = 0;
-
-                for (var i = 0; i < parent.ChildNodes.Length; i++)
+                // remove interface dispatch overhead
+                if (parent.ChildNodes is NodeList nodeList)
                 {
-                    if (parent.ChildNodes[i] is IElement child && child.NodeName.Is(element.NodeName))
-                    {
-                        k += 1;
+                    return DoMatch(new ConcreteNodeListAccessor(nodeList), element);
+                }
 
-                        if (child == element)
-                        {
-                            var diff = k - Offset;
-                            return diff == 0 || (Math.Sign(diff) == n && diff % Step == 0);
-                        }
+                return DoMatch(new InterfaceNodeListAccessor(parent.ChildNodes), element);
+            }
+
+            return false;
+        }
+
+        private Boolean DoMatch<T>(T nodes, IElement element) where T : INodeListAccessor
+        {
+            var k = 0;
+            var step = Step;
+            var n = Math.Sign(step);
+            var offset = Offset;
+            var length = nodes.Length;
+            var nodeName = element.NodeName;
+
+            for (var i = 0; i < length; i++)
+            {
+                if (nodes[i] is IElement child && child.NodeName.Is(nodeName))
+                {
+                    k += 1;
+
+                    if (child == element)
+                    {
+                        var diff = k - offset;
+                        return diff == 0 || (Math.Sign(diff) == n && diff % step == 0);
                     }
                 }
             }

--- a/src/AngleSharp/Css/Dom/Internal/LastChildSelector.cs
+++ b/src/AngleSharp/Css/Dom/Internal/LastChildSelector.cs
@@ -21,20 +21,37 @@ namespace AngleSharp.Css.Dom
 
             if (parent != null)
             {
-                var n = Math.Sign(Step);
-                var k = 0;
-
-                for (var i = parent.ChildNodes.Length - 1; i >= 0; i--)
+                // remove interface dispatch overhead
+                if (parent.ChildNodes is NodeList nodeList)
                 {
-                    if (parent.ChildNodes[i] is IElement child && Kind.Match(child, scope))
-                    {
-                        k += 1;
+                    return DoMatch(new ConcreteNodeListAccessor(nodeList), element, scope);
+                }
 
-                        if (child == element)
-                        {
-                            var diff = k - Offset;
-                            return diff == 0 || (Math.Sign(diff) == n && diff % Step == 0);
-                        }
+                return DoMatch(new InterfaceNodeListAccessor(parent.ChildNodes), element, scope);
+            }
+
+            return false;
+        }
+
+        private Boolean DoMatch<T>(T nodes, IElement element, IElement? scope) where T : INodeListAccessor
+        {
+            var step = Step;
+            var n = Math.Sign(step);
+            var k = 0;
+            var kind = Kind;
+            var matchAll = ReferenceEquals(Kind, AllSelector.Instance);
+            var offset = Offset;
+
+            for (var i = nodes.Length - 1; i >= 0; i--)
+            {
+                if (nodes[i] is IElement child && (matchAll || kind.Match(child, scope)))
+                {
+                    k += 1;
+
+                    if (child == element)
+                    {
+                        var diff = k - offset;
+                        return diff == 0 || (Math.Sign(diff) == n && diff % step == 0);
                     }
                 }
             }

--- a/src/AngleSharp/Css/Dom/Internal/LastColumnSelector.cs
+++ b/src/AngleSharp/Css/Dom/Internal/LastColumnSelector.cs
@@ -20,30 +20,45 @@ namespace AngleSharp.Css.Dom
 
             if (parent != null)
             {
-                var n = Math.Sign(Step);
-                var k = 0;
-
-                for (var i = parent.ChildNodes.Length - 1; i >= 0; i--)
+                // remove interface dispatch overhead
+                if (parent.ChildNodes is NodeList nodeList)
                 {
-                    if (parent.ChildNodes[i] is IHtmlTableCellElement child)
+                    return DoMatch(new ConcreteNodeListAccessor(nodeList), element);
+                }
+
+                return DoMatch(new InterfaceNodeListAccessor(parent.ChildNodes), element);
+            }
+
+            return false;
+        }
+
+        private Boolean DoMatch<T>(T nodes, IElement element) where T : INodeListAccessor
+        {
+            var step = Step;
+            var n = Math.Sign(step);
+            var k = 0;
+            var offset = Offset;
+
+            for (var i = nodes.Length - 1; i >= 0; i--)
+            {
+                if (nodes[i] is IHtmlTableCellElement child)
+                {
+                    var span = child.ColumnSpan;
+                    k += span;
+
+                    if (child == element)
                     {
-                        var span = child.ColumnSpan;
-                        k += span;
+                        var diff = k - offset;
 
-                        if (child == element)
+                        for (var index = 0; index < span; index++, diff--)
                         {
-                            var diff = k - Offset;
-
-                            for (var index = 0; index < span; index++, diff--)
+                            if (diff == 0 || (Math.Sign(diff) == n && diff % step == 0))
                             {
-                                if (diff == 0 || (Math.Sign(diff) == n && diff % Step == 0))
-                                {
-                                    return true;
-                                }
+                                return true;
                             }
-
-                            return false;
                         }
+
+                        return false;
                     }
                 }
             }

--- a/src/AngleSharp/Css/Dom/Internal/LastTypeSelector.cs
+++ b/src/AngleSharp/Css/Dom/Internal/LastTypeSelector.cs
@@ -20,20 +20,36 @@ namespace AngleSharp.Css.Dom
 
             if (parent != null)
             {
-                var n = Math.Sign(Step);
-                var k = 0;
-
-                for (var i = parent.ChildNodes.Length - 1; i >= 0; i--)
+                // remove interface dispatch overhead
+                if (parent.ChildNodes is NodeList nodeList)
                 {
-                    if (parent.ChildNodes[i] is IElement child && child.NodeName.Is(element.NodeName))
-                    {
-                        k += 1;
+                    return DoMatch(new ConcreteNodeListAccessor(nodeList), element);
+                }
 
-                        if (child == element)
-                        {
-                            var diff = k - Offset;
-                            return diff == 0 || (Math.Sign(diff) == n && diff % Step == 0);
-                        }
+                return DoMatch(new InterfaceNodeListAccessor(parent.ChildNodes), element);
+            }
+
+            return false;
+        }
+
+        private Boolean DoMatch<T>(T nodes, IElement element) where T : INodeListAccessor
+        {
+            var step = Step;
+            var n = Math.Sign(step);
+            var k = 0;
+            var offset = Offset;
+            var nodeName = element.NodeName;
+
+            for (var i = nodes.Length - 1; i >= 0; i--)
+            {
+                if (nodes[i] is IElement child && child.NodeName.Is(nodeName))
+                {
+                    k += 1;
+
+                    if (child == element)
+                    {
+                        var diff = k - offset;
+                        return diff == 0 || (Math.Sign(diff) == n && diff % step == 0);
                     }
                 }
             }

--- a/src/AngleSharp/Dom/Internal/NodeList.cs
+++ b/src/AngleSharp/Dom/Internal/NodeList.cs
@@ -13,7 +13,7 @@ namespace AngleSharp.Dom
     {
         #region Fields
 
-        private readonly List<Node> _entries;
+        internal readonly List<Node> _entries;
 
         /// <summary>
         /// Gets an empty node-list. Shouldn't be modified.
@@ -96,5 +96,58 @@ namespace AngleSharp.Dom
         IEnumerator IEnumerable.GetEnumerator() => _entries.GetEnumerator();
 
         #endregion
+    }
+
+    /// <summary>
+    /// Helper interface which can remove interface dispatch overhead when used in combination with generic methods.
+    /// </summary>
+    internal interface INodeListAccessor
+    {
+        Int32 Length { get; }
+        INode this[Int32 index] { get; }
+    }
+
+    internal readonly struct ConcreteNodeListAccessor : INodeListAccessor
+    {
+        private readonly List<Node> _nodeList;
+
+        public ConcreteNodeListAccessor(NodeList nodeList)
+        {
+            _nodeList = nodeList._entries;
+        }
+
+        public Int32 Length
+        {
+            [MethodImpl(MethodImplOptions.AggressiveInlining)]
+            get => _nodeList.Count;
+        }
+
+        public INode this[Int32 index]
+        {
+            [MethodImpl(MethodImplOptions.AggressiveInlining)]
+            get => _nodeList[index];
+        }
+    }
+
+    internal readonly struct InterfaceNodeListAccessor : INodeListAccessor
+    {
+        private readonly INodeList _nodeList;
+
+        public InterfaceNodeListAccessor(INodeList nodeList)
+        {
+            _nodeList = nodeList;
+        }
+
+        public Int32 Length
+        {
+            [MethodImpl(MethodImplOptions.AggressiveInlining)]
+            get => _nodeList.Length;
+        }
+
+        public INode this[Int32 index]
+        {
+            [MethodImpl(MethodImplOptions.AggressiveInlining)]
+            get => _nodeList[index];
+        }
     }
 }


### PR DESCRIPTION
# Types of Changes

## Prerequisites

Please make sure you can check the following two boxes:

- [x] I have read the **CONTRIBUTING** document
- [x] My code follows the code style of this project

## Contribution Type

What types of changes does your code introduce? Put an `x` in all the boxes that apply:

- [ ] Bug fix (non-breaking change which fixes an issue, please reference the issue id)
- [ ] New feature (non-breaking change which adds functionality, make sure to open an associated issue first)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] My change requires a change to the documentation
- [ ] I have updated the documentation accordingly
- [ ] I have added tests to cover my changes
- [x] All new and existing tests passed

## Description

After the last optimization pass the child selector performance didn't look all right to me be, seemed like an outlier compared to other selectors. I went through the code and tried to improve things. Used the struct via generic constraint interface trick to get rid of interface dispatch still allowing both `INodeList` and `NodeList` to be selector's input. The gist is to have a second `DoMatch` method that is being called that ensures less interface dispatch - struct will be inlined in terms of calls as its compile time constant.

Please note, I would highly recommend removing the `INodeList` interface and just substituting it with concrete sealed type `NodeList` (public API checked). `NodeList` is the only implementation after all. The interface dispatch has real cost here for such integral type. Of course it would be major breaking change. The interface also returns `INode` instead of `Node` unlike what `NodeList` does, all access to node properties will cause interface dispatch again.

## Benchmarks

```

BenchmarkDotNet v0.13.7, Windows 11 (10.0.23526.1000)
AMD Ryzen 9 5950X, 1 CPU, 32 logical and 16 physical cores
.NET SDK 8.0.100-preview.7.23376.3
  [Host]   : .NET 6.0.21 (6.0.2123.36311), X64 RyuJIT AVX2
  ShortRun : .NET 6.0.21 (6.0.2123.36311), X64 RyuJIT AVX2

Job=ShortRun  IterationCount=3  LaunchCount=1  
WarmupCount=3  

```

## AngleSharp.Benchmarks.SelectorBenchmark

| **Diff**|Selector|Mean|Error|Allocated|
|------- |-------|-------:|-------|-------:|
| Old |p:first-child|113.7 μs|2.92 μs|17.98 KB|
| **New** | **p:first-child** | **111.6 μs (-2%)** | **6.88 μs** | **17.98 KB (0%)** |
| Old |p:last-child|116.8 μs|4.33 μs|17.46 KB|
| **New** | **p:last-child** | **115.4 μs (-1%)** | **4.57 μs** | **17.46 KB (0%)** |
| Old |p:nth-child(2n)|673.9 μs|7.17 μs|21.17 KB|
| **New** | **p:nth-child(2n)** | **326.1 μs (-52%)** | **18.40 μs** | **21.18 KB (0%)** |
| Old |p:nth-child(2n+1)|679.3 μs|5.51 μs|21.2 KB|
| **New** | **p:nth-child(2n+1)** | **324.8 μs (-52%)** | **27.78 μs** | **21.21 KB (0%)** |
| Old |p:nth-child(even)|683.4 μs|125.11 μs|21.15 KB|
| **New** | **p:nth-child(even)** | **316.8 μs (-54%)** | **9.39 μs** | **21.15 KB (0%)** |
| Old |p:nth-child(n)|676.9 μs|81.74 μs|25.17 KB|
| **New** | **p:nth-child(n)** | **327.5 μs (-52%)** | **7.90 μs** | **25.17 KB (0%)** |
| Old |p:nth-child(odd)|683.7 μs|34.28 μs|21.15 KB|
| **New** | **p:nth-child(odd)** | **320.6 μs (-53%)** | **18.94 μs** | **21.16 KB (0%)** |
| Old |p:only-child|216.1 μs|6.90 μs|16.95 KB|
| **New** | **p:only-child** | **217.5 μs (+1%)** | **13.76 μs** | **16.95 KB (0%)** |




