### PR TITLE
Fix AoT warning

### DIFF
--- a/src/AngleSharp/Common/ObjectExtensions.cs
+++ b/src/AngleSharp/Common/ObjectExtensions.cs
@@ -166,7 +166,11 @@ namespace AngleSharp.Common
         /// </summary>
         /// <param name="code">A specific error code.</param>
         /// <returns>The description of the error.</returns>
+#if NET6_0_OR_GREATER
+        public static String GetMessage<[DynamicallyAccessedMembers(DynamicallyAccessedMemberTypes.PublicFields)] T>(this T code)
+#else
         public static String GetMessage<T>(this T code)
+#endif
             where T : Enum
         {
             var field = typeof(T).GetField(code.ToString());


### PR DESCRIPTION
# Types of Changes

## Prerequisites

Please make sure you can check the following two boxes:

- [x] I have read the **CONTRIBUTING** document
- [x] My code follows the code style of this project

## Contribution Type

- [x] Bug fix (non-breaking change which fixes an issue, please reference the issue id)
- [ ] New feature (non-breaking change which adds functionality, make sure to open an associated issue first)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] My change requires a change to the documentation
- [ ] I have updated the documentation accordingly
- [ ] I have added tests to cover my changes
- [ ] All new and existing tests passed

## Description

Fix IL2090 warning when referencing AngleSharp from a trimmed application.

```
ILC : Trim analysis warning IL2090: AngleSharp.Common.ObjectExtensions.GetMessage<T>(!!0): 'this' argument does not satisfy 'DynamicallyAccessedMemberTypes.PublicFields' in call to 'System.Type.GetField(String)'. The generic parameter 'T' of 'AngleSharp.Common.ObjectExtensions.GetMessage<T>(!!0)' does not have matching annotations. The source value must declare at least the same requirements as those declared on the target location it is assigned to. [C:\Coding\aspnet-contrib\AspNet.Security.OpenId.Providers\samples\Mvc.Client\Mvc.Client.csproj]
```

See https://github.com/aspnet-contrib/AspNet.Security.OpenId.Providers/pull/162 for context.