### PR TITLE
Fix GitHub Actions warnings

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -18,7 +18,7 @@ jobs:
         id: check_job
         run: |
             echo "value: ${{ env.DOCS_PATH != null && github.ref == env.DOCS_BRANCH }}"
-            echo "::set-output name=value::${{ env.DOCS_PATH != null && github.ref == env.DOCS_BRANCH }}"
+            echo "value=${{ env.DOCS_PATH != null && github.ref == env.DOCS_BRANCH }}" >> "${GITHUB_OUTPUT}"
 
   documentation:
     needs: [can_document]
@@ -26,10 +26,10 @@ jobs:
     if: needs.can_document.outputs.value == 'true'
 
     steps:
-    - uses: actions/checkout@v2
+    - uses: actions/checkout@v4
 
     - name: Use Node.js
-      uses: actions/setup-node@v1
+      uses: actions/setup-node@v4
       with:
         node-version: "14.x"
         registry-url: 'https://registry.npmjs.org'
@@ -48,10 +48,10 @@ jobs:
     runs-on: ubuntu-latest
 
     steps:
-    - uses: actions/checkout@v2
+    - uses: actions/checkout@v4
 
     - name: Setup dotnet
-      uses: actions/setup-dotnet@v1
+      uses: actions/setup-dotnet@v3
       with:
         dotnet-version: |
           6.0.x
@@ -64,10 +64,10 @@ jobs:
     runs-on: windows-latest
 
     steps:
-    - uses: actions/checkout@v2
+    - uses: actions/checkout@v4
 
     - name: Setup dotnet
-      uses: actions/setup-dotnet@v1
+      uses: actions/setup-dotnet@v3
       with:
         dotnet-version: |
           6.0.x


### PR DESCRIPTION
# Types of Changes

## Prerequisites

Please make sure you can check the following two boxes:

- [x] I have read the **CONTRIBUTING** document
- [x] My code follows the code style of this project

## Contribution Type

What types of changes does your code introduce? Put an `x` in all the boxes that apply:

- [x] Bug fix (non-breaking change which fixes an issue, please reference the issue id)
- [ ] New feature (non-breaking change which adds functionality, make sure to open an associated issue first)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] My change requires a change to the documentation
- [ ] I have updated the documentation accordingly
- [ ] I have added tests to cover my changes
- [ ] All new and existing tests passed

## Description

Fix warnings in GitHub Actions CI workflows ([example](https://github.com/AngleSharp/AngleSharp/actions/runs/6810816362?pr=1144)) from using to-be-deprecated things by:
- Updating to latest GitHub Action versions which support Node.js 18.
- Using the `GITHUB_OUTPUT` to output step values.
