### PR TITLE
Fix Range bug Issue

### DIFF
--- a/src/AngleSharp.Core.Tests/Library/Range.cs
+++ b/src/AngleSharp.Core.Tests/Library/Range.cs
@@ -54,5 +54,23 @@ namespace AngleSharp.Core.Tests.Library
             Assert.AreEqual(common, range.CommonAncestor);
             Assert.IsFalse(range.IsCollapsed);
         }
+
+        [Test]
+        public void CanSelectRangeSomeRange_Issue1147()
+        {
+            var document = "<body></body>".ToHtmlDocument();
+            var text1 = document.Body.AppendChild(document.CreateTextNode("Text1"));
+            var text2 = document.Body.AppendChild(document.CreateTextNode("TextLonger2"));
+            var range = document.CreateRange();
+            range.StartWith(text1, "Text".Length);
+            range.EndWith(text2, "TextLonger".Length);
+
+            Assert.AreEqual("Text".Length, range.Start);
+            Assert.AreEqual(text1, range.Head);
+            Assert.AreEqual("TextLonger".Length, range.End);
+            Assert.AreEqual(text2, range.Tail);
+            Assert.AreEqual(document.Body, range.CommonAncestor);
+            Assert.IsFalse(range.IsCollapsed);
+        }
     }
 }

--- a/src/AngleSharp.Core.Tests/Library/Range.cs
+++ b/src/AngleSharp.Core.Tests/Library/Range.cs
@@ -1,7 +1,6 @@
 namespace AngleSharp.Core.Tests.Library
 {
     using NUnit.Framework;
-    using static System.Net.Mime.MediaTypeNames;
 
     [TestFixture]
     public class RangeTests
@@ -45,7 +44,7 @@ namespace AngleSharp.Core.Tests.Library
             var text2 = common.LastChild;
             var range = document.CreateRange();
             range.StartBefore(text1);
-            range.EndAfter(text2);
+            range.EndBefore(text2);
 
             Assert.AreEqual(0, range.Start);
             Assert.AreEqual(text1.Parent, range.Head);
@@ -56,21 +55,143 @@ namespace AngleSharp.Core.Tests.Library
         }
 
         [Test]
-        public void CanSelectRangeSomeRange_Issue1147()
+        public void CanSelectSomeRange_Issue1147()
         {
             var document = "<body></body>".ToHtmlDocument();
             var text1 = document.Body.AppendChild(document.CreateTextNode("Text1"));
             var text2 = document.Body.AppendChild(document.CreateTextNode("TextLonger2"));
-            var range = document.CreateRange();
-            range.StartWith(text1, "Text".Length);
-            range.EndWith(text2, "TextLonger".Length);
+            var range1 = document.CreateRange();
+            var range2 = document.CreateRange();
+            range1.StartWith(text1, "Text".Length);
+            range1.EndWith(text2, "TextLonger".Length);
+            range2.StartWith(text1, "Text".Length);
+            range2.EndWith(text2, "TextLonger".Length);
+            range2.StartWith(text2, "TextLonger2".Length);
 
-            Assert.AreEqual("Text".Length, range.Start);
-            Assert.AreEqual(text1, range.Head);
-            Assert.AreEqual("TextLonger".Length, range.End);
-            Assert.AreEqual(text2, range.Tail);
-            Assert.AreEqual(document.Body, range.CommonAncestor);
-            Assert.IsFalse(range.IsCollapsed);
+            Assert.AreEqual("Text".Length, range1.Start);
+            Assert.AreEqual(text1, range1.Head);
+            Assert.AreEqual("TextLonger".Length, range1.End);
+            Assert.AreEqual(text2, range1.Tail);
+            Assert.AreEqual(document.Body, range1.CommonAncestor);
+            Assert.IsFalse(range1.IsCollapsed);
+            Assert.AreEqual("TextLonger2".Length, range2.Start);
+            Assert.AreEqual("TextLonger2".Length, range2.End);
+            Assert.IsTrue(range2.IsCollapsed);
+        }
+
+        [Test]
+        public void CheckCommonAncestor()
+        {
+            var document = "<body></body>".ToHtmlDocument();
+            var p1 = document.Body.AppendChild(document.CreateElement("p"));
+            var p2 = document.Body.AppendChild(document.CreateElement("p"));
+            var p11 = p1.AppendChild(document.CreateElement("p"));
+            var p12 = p1.AppendChild(document.CreateElement("p"));
+            var p21 = p2.AppendChild(document.CreateElement("p"));
+
+            var range1 = document.CreateRange();
+            var range2 = document.CreateRange();
+
+            range1.StartAfter(p11);
+            range1.EndBefore(p12);
+            range2.StartAfter(p11);
+            range2.EndBefore(p21);
+
+            Assert.AreEqual(p1, range1.CommonAncestor);
+            Assert.AreEqual(document.Body, range2.CommonAncestor);
+        }
+
+        [Test]
+        public void CanIntersects()
+        {
+            var document = "<body></body>".ToHtmlDocument();
+            var p1 = document.Body.AppendChild(document.CreateElement("p"));
+            var p2 = document.Body.AppendChild(document.CreateElement("p"));
+            var p3 = document.Body.AppendChild(document.CreateElement("p"));
+
+            var range1 = document.CreateRange();
+            var range2 = document.CreateRange();
+
+            range1.StartAfter(p1);
+            range1.EndBefore(p3);
+            range2.StartWith(p1, 0);
+            range2.EndWith(p3, 0);
+
+            Assert.IsFalse(range1.Intersects(p1));
+            Assert.IsTrue(range1.Intersects(p2));
+            Assert.IsFalse(range1.Intersects(p3));
+            Assert.IsTrue(range1.Intersects(document.Body));
+
+            Assert.IsTrue(range2.Intersects(p1));
+            Assert.IsTrue(range2.Intersects(p2));
+            Assert.IsTrue(range2.Intersects(p3));
+            Assert.IsTrue(range2.Intersects(document.Body));
+        }
+
+        [Test]
+        public void CanContains()
+        {
+            var document = "<body></body>".ToHtmlDocument();
+            var p1 = document.Body.AppendChild(document.CreateElement("p"));
+            var p2 = document.Body.AppendChild(document.CreateElement("p"));
+            var p3 = document.Body.AppendChild(document.CreateElement("p"));
+
+            var range1 = document.CreateRange();
+            var range2 = document.CreateRange();
+            var range3 = document.CreateRange();
+
+            range1.StartAfter(p1);
+            range1.EndBefore(p3);
+            range2.StartWith(p1, 0);
+            range2.EndWith(p3, 0);
+            range3.Select(document.Body);
+
+            Assert.IsFalse(range1.Contains(p1, 0));
+            Assert.IsTrue(range1.Contains(p2, 0));
+            Assert.IsFalse(range1.Contains(p3, 0));
+            Assert.IsFalse(range1.Contains(document.Body, 0));
+
+            Assert.IsFalse(range2.Contains(p1, 0));
+            Assert.IsTrue(range2.Contains(p2, 0));
+            Assert.IsFalse(range2.Contains(p3, 0));
+            Assert.IsFalse(range2.Contains(document.Body, 0));
+
+            Assert.IsTrue(range3.Contains(p1, 0));
+            Assert.IsTrue(range3.Contains(p2, 0));
+            Assert.IsTrue(range3.Contains(p3, 0));
+            Assert.IsTrue(range3.Contains(document.Body, 0));
+        }
+
+        [Test]
+        public void CanClearContent()
+        {
+            var document = @"
+<html>
+<head></head>
+<body>
+<p> No deletion before start <span id=""start""></span> This should be cleared </p>
+<p> <span id=""toDelete""></span>This should be deleted too <span id=""end""></span> This is not to be deleted</p>
+<p> This should not be deleted either</p>
+</body>
+</html>".ToHtmlDocument();
+            var start = document.QuerySelector("#start");
+            var end = document.QuerySelector("#end");
+            var toDelete = document.QuerySelector("#toDelete");
+
+            var range = document.CreateRange();
+
+            range.StartWith(start, 0);
+            range.EndWith(end, 0);
+
+            range.ClearContent();
+
+            var htmlRaw = document.DocumentElement.OuterHtml;
+            Assert.IsTrue(htmlRaw.Contains("No deletion before start"));
+            Assert.IsTrue(htmlRaw.Contains("This is not to be deleted"));
+            Assert.IsTrue(htmlRaw.Contains("This should not be deleted either"));
+            Assert.IsFalse(htmlRaw.Contains("This should be cleared"));
+            Assert.IsFalse(htmlRaw.Contains("This should be deleted too"));
+            Assert.IsFalse(document.Contains(toDelete));
         }
     }
 }

--- a/src/AngleSharp/Dom/IRange.cs
+++ b/src/AngleSharp/Dom/IRange.cs
@@ -1,4 +1,4 @@
-﻿namespace AngleSharp.Dom
+namespace AngleSharp.Dom
 {
     using AngleSharp.Attributes;
     using System;
@@ -206,7 +206,7 @@
         RangePosition CompareTo(INode node, Int32 offset);
 
         /// <summary>
-        /// Checks if the given node is contained in this range.
+        /// Checks if the given node is intersected by this range.
         /// </summary>
         /// <param name="node">The node to check for.</param>
         /// <returns>


### PR DESCRIPTION
# Types of Changes


## Prerequisites

Please make sure you can check the following two boxes:

- [x] I have read the **CONTRIBUTING** document
- [x] My code follows the code style of this project

## Contribution Type

What types of changes does your code introduce? Put an `x` in all the boxes that apply:

- [x] Bug fix (non-breaking change which fixes an issue, please reference the issue id)
- [ ] New feature (non-breaking change which adds functionality, make sure to open an associated issue first)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] My change requires a change to the documentation
- [ ] I have updated the documentation accordingly
- [ ] I have added tests to cover my changes
- [ ] All new and existing tests passed

## Description
Ref: [#1147](https://github.com/AngleSharp/AngleSharp/issues/1147)
Fix the issue of not setting up `Start` and `End` property after one of both is explicitly given. The core fix is to modify `CompareTo` function according to the described algorithm from https://dom.spec.whatwg.org/#boundary-points Additionally, added more operator functions with overridden `Equals` & `GetHasCode` functions as well.

Also, the test case for this issue is added in Library/Range.cs.
