### PR TITLE
Performance improvement in Node.set_Owner

### DIFF
--- a/src/AngleSharp/Dom/Internal/Node.cs
+++ b/src/AngleSharp/Dom/Internal/Node.cs
@@ -196,12 +196,12 @@ namespace AngleSharp.Dom
             }
             set
             {
-                foreach (var descendantAndSelf in this.DescendantsAndSelf<Node>())
+                if (!Object.ReferenceEquals(Owner, value))
                 {
-                    var oldDocument = descendantAndSelf.Owner;
-
-                    if (!Object.ReferenceEquals(oldDocument, value))
+                    foreach (var descendantAndSelf in this.DescendantsAndSelf<Node>())
                     {
+                        var oldDocument = descendantAndSelf.Owner;
+
                         descendantAndSelf._owner = value;
 
                         if (oldDocument != null)


### PR DESCRIPTION
# Types of Changes

Improve performance in `Node.set_Owner` when the new value equals the existing one.

## Prerequisites

Please make sure you can check the following two boxes:

- [X] I have read the **CONTRIBUTING** document
- [X] My code follows the code style of this project

## Contribution Type

What types of changes does your code introduce? Put an `x` in all the boxes that apply:

- [ ] Bug fix (non-breaking change which fixes an issue, please reference the issue id)
- [ ] New feature (non-breaking change which adds functionality, make sure to open an associated issue first)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] My change requires a change to the documentation
- [ ] I have updated the documentation accordingly
- [ ] I have added tests to cover my changes
- [ ] All new and existing tests passed

## Description

Added a check if `Owner` is equal to the new value before the loop.
This was also the case before *someone* broke it in https://github.com/AngleSharp/AngleSharp/commit/9b9a1be03bdf5841091479c9a4998c19074061ed

Adding/Moving a lot of children to a new parent under the same `Owner` is now a lot faster.