### PR TITLE
Text source array pool

### DIFF
--- a/src/AngleSharp/AngleSharp.Core.csproj
+++ b/src/AngleSharp/AngleSharp.Core.csproj
@@ -19,7 +19,6 @@
     <PackageReference Include="ConfigureAwaitChecker.Analyzer" Version="5.0.0.1" PrivateAssets="all" />
     <PackageReference Include="Microsoft.SourceLink.GitHub" Version="1.1.1" PrivateAssets="All" />
     <PackageReference Include="Nullable" Version="1.3.1" PrivateAssets="all" />
-    <PackageReference Include="Microsoft.IO.RecyclableMemoryStream" Version="2.3.2" />
   </ItemGroup>
 
   <ItemGroup Condition=" '$(TargetFramework)' == 'netstandard2.0' or '$(TargetFramework)' == 'net461' or '$(TargetFramework)' == 'net472' or '$(TargetFramework)' == 'net6.0' ">

--- a/src/AngleSharp/AngleSharp.Core.csproj
+++ b/src/AngleSharp/AngleSharp.Core.csproj
@@ -19,6 +19,7 @@
     <PackageReference Include="ConfigureAwaitChecker.Analyzer" Version="5.0.0.1" PrivateAssets="all" />
     <PackageReference Include="Microsoft.SourceLink.GitHub" Version="1.1.1" PrivateAssets="All" />
     <PackageReference Include="Nullable" Version="1.3.1" PrivateAssets="all" />
+    <PackageReference Include="Microsoft.IO.RecyclableMemoryStream" Version="2.3.2" />
   </ItemGroup>
 
   <ItemGroup Condition=" '$(TargetFramework)' == 'netstandard2.0' or '$(TargetFramework)' == 'net461' or '$(TargetFramework)' == 'net472' or '$(TargetFramework)' == 'net6.0' ">

--- a/src/AngleSharp/Text/TextSource.cs
+++ b/src/AngleSharp/Text/TextSource.cs
@@ -9,15 +9,12 @@ namespace AngleSharp.Text
     using System.Text;
     using System.Threading;
     using System.Threading.Tasks;
-    using Microsoft.IO;
 
     /// <summary>
     /// A stream abstraction to handle encoding and more.
     /// </summary>
     public sealed class TextSource : IDisposable
     {
-        private static readonly RecyclableMemoryStreamManager RecyclableMemoryStreamManager = new RecyclableMemoryStreamManager();
-
         #region Fields
 
         private const Int32 BufferSize = 4096;
@@ -46,7 +43,7 @@ namespace AngleSharp.Text
                 _chars = ArrayPool<Char>.Shared.Rent(BufferSize + 1);
             }
 
-            _raw = RecyclableMemoryStreamManager.GetStream();
+            _raw = new MemoryStream();
             _index = 0;
             _encoding = encoding ?? TextEncoding.Utf8;
             _decoder = _encoding.GetDecoder();


### PR DESCRIPTION
# Types of Changes

## Prerequisites

Please make sure you can check the following two boxes:

- [x] I have read the **CONTRIBUTING** document
- [x] My code follows the code style of this project

## Contribution Type

What types of changes does your code introduce? Put an `x` in all the boxes that apply:

- [ ] Bug fix (non-breaking change which fixes an issue, please reference the issue id)
- [ ] New feature (non-breaking change which adds functionality, make sure to open an associated issue first)
- [x] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] My change requires a change to the documentation
- [ ] I have updated the documentation accordingly
- [ ] I have added tests to cover my changes
- [ ] All new and existing tests passed

## Description

Array pooling for buffers in TextSource + MemoryStream pooling via MS lib.

Not so sure about MemoryStream pooling though.

Before

|                     Method |      UrlTest |        Mean |         Error |      StdDev |      Gen0 |      Gen1 |     Gen2 |   Allocated |
|--------------------------- |------------- |------------:|--------------:|------------:|----------:|----------:|---------:|------------:|
|                 AngleSharp |            ? |    104.6 us |       9.80 us |     0.54 us |   15.1367 |    2.9297 |        - |   124.77 KB |
|          AngleSharpDispose |            ? |          NA |            NA |          NA |        NA |        NA |       NA |          NA |
|      AngleSharpParseStream |            ? |          NA |            NA |          NA |        NA |        NA |       NA |          NA |
| AngleSharpParseStreamAsync |            ? |          NA |            NA |          NA |        NA |        NA |       NA |          NA |
|                            |              |             |               |             |           |           |          |             |
|                 AngleSharp |       amazon |    208.8 us |      10.51 us |     0.58 us |   15.1367 |    2.6855 |        - |   124.95 KB |
|          AngleSharpDispose |       amazon |    208.4 us |      23.00 us |     1.26 us |   13.6719 |    1.9531 |        - |   112.41 KB |
|      AngleSharpParseStream |       amazon |    221.1 us |      67.15 us |     3.68 us |   20.7520 |    3.4180 |        - |   170.68 KB |
| AngleSharpParseStreamAsync |       amazon |    268.2 us |     700.17 us |    38.38 us |   23.9258 |    4.1504 |        - |   195.97 KB |
|                            |              |             |               |             |           |           |          |             |
|                 AngleSharp |     blogspot |    241.4 us |     159.86 us |     8.76 us |    9.0332 |    0.9766 |        - |    75.77 KB |
|          AngleSharpDispose |     blogspot |    154.8 us |     713.48 us |    39.11 us |    8.3008 |    0.7324 |        - |    69.04 KB |
|      AngleSharpParseStream |     blogspot |    145.2 us |     158.81 us |     8.70 us |   10.9863 |    1.4648 |        - |     91.7 KB |
| AngleSharpParseStreamAsync |     blogspot |    135.7 us |     160.09 us |     8.78 us |   11.2305 |    1.2207 |        - |    91.84 KB |
|                            |              |             |               |             |           |           |          |             |
|                 AngleSharp | en.wikipedia | 28,649.7 us |  29,394.44 us | 1,611.21 us | 1406.2500 |  843.7500 | 312.5000 | 10556.47 KB |
|          AngleSharpDispose | en.wikipedia | 24,929.7 us |   5,630.81 us |   308.64 us | 1593.7500 | 1093.7500 | 468.7500 | 11910.31 KB |
|      AngleSharpParseStream | en.wikipedia | 28,866.8 us | 101,428.72 us | 5,559.65 us | 1750.0000 | 1218.7500 | 531.2500 | 13337.67 KB |
| AngleSharpParseStreamAsync | en.wikipedia | 33,596.3 us |  24,072.01 us | 1,319.47 us | 1714.2857 | 1214.2857 | 500.0000 | 13388.65 KB |
|                            |              |             |               |             |           |           |          |             |
|                 AngleSharp |        weibo |    112.3 us |     155.38 us |     8.52 us |   15.1367 |    2.9297 |        - |   124.77 KB |
|          AngleSharpDispose |        weibo |    100.8 us |      10.42 us |     0.57 us |   13.5498 |    2.1973 |        - |   111.38 KB |
|      AngleSharpParseStream |        weibo |    132.0 us |      10.29 us |     0.56 us |   25.6348 |    3.1738 |        - |   209.95 KB |
| AngleSharpParseStreamAsync |        weibo |    139.7 us |      30.82 us |     1.69 us |   28.0762 |    6.8359 |        - |   230.66 KB |
|                            |              |             |               |             |           |           |          |             |
|                 AngleSharp |        yahoo | 11,065.5 us |   1,554.66 us |    85.22 us |  921.8750 |  812.5000 | 593.7500 |   8657.8 KB |
|          AngleSharpDispose |        yahoo | 11,216.0 us |   3,050.22 us |   167.19 us | 1062.5000 |  968.7500 | 734.3750 | 10463.96 KB |
|      AngleSharpParseStream |        yahoo | 12,106.8 us |     755.28 us |    41.40 us | 1312.5000 | 1093.7500 | 750.0000 | 12345.14 KB |
| AngleSharpParseStreamAsync |        yahoo | 12,213.1 us |   1,419.38 us |    77.80 us | 1265.6250 | 1031.2500 | 703.1250 |  12381.3 KB |
|                            |              |             |               |             |           |           |          |             |
|                 AngleSharp |      youtube |    218.9 us |      10.35 us |     0.57 us |   15.8691 |    2.9297 |        - |    131.3 KB |
|          AngleSharpDispose |      youtube |    214.8 us |      16.76 us |     0.92 us |   14.4043 |    2.1973 |        - |    119.5 KB |
|      AngleSharpParseStream |      youtube |    224.5 us |       8.78 us |     0.48 us |   19.0430 |    3.6621 |        - |   155.86 KB |
| AngleSharpParseStreamAsync |      youtube |    235.8 us |      36.79 us |     2.02 us |   19.0430 |    3.6621 |        - |   156.07 KB |


After

|                     Method |      UrlTest |        Mean |        Error |      StdDev |      Gen0 |      Gen1 |      Gen2 |   Allocated |
|--------------------------- |------------- |------------:|-------------:|------------:|----------:|----------:|----------:|------------:|
|                 AngleSharp |            ? |    111.7 us |      7.22 us |     0.40 us |   15.1367 |    2.9297 |         - |   124.97 KB |
|          AngleSharpDispose |            ? |          NA |           NA |          NA |        NA |        NA |        NA |          NA |
|      AngleSharpParseStream |            ? |          NA |           NA |          NA |        NA |        NA |        NA |          NA |
| AngleSharpParseStreamAsync |            ? |          NA |           NA |          NA |        NA |        NA |        NA |          NA |
|                            |              |             |              |             |           |           |           |             |
|                 AngleSharp |       amazon |    218.4 us |     35.87 us |     1.97 us |   15.1367 |    3.4180 |         - |   125.16 KB |
|          AngleSharpDispose |       amazon |    209.0 us |     13.62 us |     0.75 us |   13.6719 |    1.9531 |         - |   112.62 KB |
|      AngleSharpParseStream |       amazon |    224.1 us |     15.66 us |     0.86 us |   18.7988 |    2.9297 |         - |   154.81 KB |
| AngleSharpParseStreamAsync |       amazon |    230.6 us |    107.63 us |     5.90 us |   20.9961 |    3.4180 |         - |   172.08 KB |
|                            |              |             |              |             |           |           |           |             |
|                 AngleSharp |     blogspot |    123.1 us |      4.01 us |     0.22 us |    9.2773 |    1.4648 |         - |    75.97 KB |
|          AngleSharpDispose |     blogspot |    124.4 us |     13.75 us |     0.75 us |    8.3008 |    0.7324 |         - |    69.24 KB |
|      AngleSharpParseStream |     blogspot |    126.9 us |      8.63 us |     0.47 us |    9.2773 |    0.9766 |         - |     76.4 KB |
| AngleSharpParseStreamAsync |     blogspot |    131.0 us |     15.86 us |     0.87 us |    9.2773 |    0.7324 |         - |    76.54 KB |
|                            |              |             |              |             |           |           |           |             |
|                 AngleSharp | en.wikipedia | 26,160.6 us |  9,250.90 us |   507.07 us | 1437.5000 |  875.0000 |  312.5000 | 10556.87 KB |
|          AngleSharpDispose | en.wikipedia | 25,080.8 us |  5,477.81 us |   300.26 us | 1593.7500 | 1093.7500 |  468.7500 | 11909.95 KB |
|      AngleSharpParseStream | en.wikipedia | 25,701.7 us | 35,159.64 us | 1,927.22 us | 1750.0000 | 1218.7500 |  531.2500 | 13328.96 KB |
| AngleSharpParseStreamAsync | en.wikipedia | 24,517.5 us |  2,476.74 us |   135.76 us | 1750.0000 | 1218.7500 |  531.2500 | 13371.74 KB |
|                            |              |             |              |             |           |           |           |             |
|                 AngleSharp |        weibo |    107.2 us |     16.48 us |     0.90 us |   15.2588 |    3.0518 |         - |   124.97 KB |
|          AngleSharpDispose |        weibo |    105.6 us |     13.29 us |     0.73 us |   13.5498 |    2.1973 |         - |   111.58 KB |
|      AngleSharpParseStream |        weibo |    134.8 us |      4.52 us |     0.25 us |   22.7051 |    3.6621 |         - |   186.05 KB |
| AngleSharpParseStreamAsync |        weibo |    141.5 us |      5.45 us |     0.30 us |   23.1934 |    4.3945 |         - |   190.74 KB |
|                            |              |             |              |             |           |           |           |             |
|                 AngleSharp |        yahoo | 11,026.0 us |  1,160.49 us |    63.61 us |  750.0000 |  562.5000 |  421.8750 |  8616.35 KB |
|          AngleSharpDispose |        yahoo | 13,848.1 us |  7,491.03 us |   410.61 us | 1046.8750 | 1031.2500 |  718.7500 | 10416.35 KB |
|      AngleSharpParseStream |        yahoo | 11,955.0 us |    816.57 us |    44.76 us | 1562.5000 | 1453.1250 | 1015.6250 | 12266.99 KB |
| AngleSharpParseStreamAsync |        yahoo | 12,050.9 us |    572.39 us |    31.37 us | 1546.8750 | 1453.1250 | 1000.0000 | 12293.97 KB |
|                            |              |             |              |             |           |           |           |             |
|                 AngleSharp |      youtube |    229.7 us |     96.31 us |     5.28 us |   15.8691 |    3.1738 |         - |   131.51 KB |
|          AngleSharpDispose |      youtube |    226.1 us |     54.91 us |     3.01 us |   14.6484 |    2.1973 |         - |    119.7 KB |
|      AngleSharpParseStream |      youtube |    224.8 us |     26.66 us |     1.46 us |   16.1133 |    2.4414 |         - |   131.97 KB |
| AngleSharpParseStreamAsync |      youtube |    230.1 us |     64.43 us |     3.53 us |   16.1133 |    2.4414 |         - |   132.18 KB |

