### PR TITLE
Use a fully SemVer compatible versioning scheme, fixes #1171

### DIFF
--- a/nuke/Build.cs
+++ b/nuke/Build.cs
@@ -90,11 +90,11 @@ class Build : NukeBuild
 
             if (ScheduledTargets.Contains(Default))
             {
-                Version = $"{Version}-ci-{buildNumber}";
+                Version = $"{Version}-ci.{buildNumber}";
             }
             else if (ScheduledTargets.Contains(PrePublish))
             {
-                Version = $"{Version}-alpha-{buildNumber}";
+                Version = $"{Version}-beta.{buildNumber}";
             }
         }
 

--- a/nuke/ReleaseNotesParser.cs
+++ b/nuke/ReleaseNotesParser.cs
@@ -17,16 +17,6 @@ using Microsoft.Build.Exceptions;
 /// </remarks>
 public sealed class ReleaseNotesParser
 {
-    private readonly Regex _versionRegex;
-
-    /// <summary>
-    /// Initializes a new instance of the <see cref="ReleaseNotesParser"/> class.
-    /// </summary>
-    public ReleaseNotesParser()
-    {
-        _versionRegex = new Regex(@"(?<Version>\d+(\s*\.\s*\d+){0,3})(?<Release>-[a-z][0-9a-z-]*)?");
-    }
-
     /// <summary>
     /// Parses all release notes.
     /// </summary>


### PR DESCRIPTION
# Types of Changes

## Prerequisites

Please make sure you can check the following two boxes:

- [X] I have read the **CONTRIBUTING** document
- [X] My code follows the code style of this project

## Contribution Type

What types of changes does your code introduce? Put an `x` in all the boxes that apply:

- [X] Bug fix (non-breaking change which fixes an issue, please reference the issue id) #1171
- [ ] New feature (non-breaking change which adds functionality, make sure to open an associated issue first)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] My change requires a change to the documentation
- [ ] I have updated the documentation accordingly
- [ ] I have added tests to cover my changes
- [X] All new and existing tests passed

## Description

See #1171. Hopefully fixes #1171.

@FlorianRappl I'd be happy to contribute this - be aware though that this is the first time I'm looking at AngleSharp's sources and also the first time I edit a Nuke build. Thus, I wouldn't say with confidence that I got everything about this right.

## Notes 

* `_versionRegex` seems unused and SemVer-incompatible, thus I removed it.
* At a future time `-beta.` could be easily changed to `-alpha.` to be able to release alpha versions again, when targeting some future MAJOR.MINOR.PATCH.
* The CI action [runs fine](https://github.com/georg-jung/AngleSharp/actions/runs/8021008315), `.\build.ps1` and `.\build.ps1 -Target PrePublish` run fine locally too (but don't generate a prerelease package there).
* When merging these changes in my fork's devel branch to test a proper prerelease package is generated [that seems to happen](https://github.com/georg-jung/AngleSharp/actions/runs/8021250031/job/21912891256#step:4:94)
* The publishing itself etc. seem hard to test for me, given they directly publish to NuGet.org but don't emit artifacts on GitHub Actions