### PR TITLE
Fixed the loading of link element source

### DIFF
--- a/src/AngleSharp/Dom/Internal/DefaultAttributeObserver.cs
+++ b/src/AngleSharp/Dom/Internal/DefaultAttributeObserver.cs
@@ -31,6 +31,7 @@ namespace AngleSharp.Dom
             RegisterObserver<HtmlElement>(AttributeNames.DropZone, (element, value) => element.UpdateDropZone(value));
             RegisterObserver<HtmlBaseElement>(AttributeNames.Href, (element, value) => element.UpdateUrl(value));
             RegisterObserver<HtmlEmbedElement>(AttributeNames.Src, (element, value) => element.UpdateSource(value));
+            RegisterObserver<HtmlLinkElement>(AttributeNames.Rel, (element, value) => element.UpdateRel(value));
             RegisterObserver<HtmlLinkElement>(AttributeNames.Sizes, (element, value) => element.UpdateSizes(value));
             RegisterObserver<HtmlLinkElement>(AttributeNames.Media, (element, value) => element.UpdateMedia(value));
             RegisterObserver<HtmlLinkElement>(AttributeNames.Disabled, (element, value) => element.UpdateDisabled(value));


### PR DESCRIPTION
# Types of Changes

## Prerequisites

Please make sure you can check the following two boxes:

- [x] I have read the **CONTRIBUTING** document
- [x] My code follows the code style of this project

## Contribution Type

What types of changes does your code introduce? Put an `x` in all the boxes that apply:

- [x] Bug fix (non-breaking change which fixes an issue, please reference the issue id)
- [ ] New feature (non-breaking change which adds functionality, make sure to open an associated issue first)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] My change requires a change to the documentation
- [ ] I have updated the documentation accordingly
- [x] I have added tests to cover my changes
- [x] All new and existing tests passed

## Description

This is a fix for #1184 

The issue was that the `_relation` variable was only set during the `SetupElement` method. But when adding a new link element the `rel` attribute is often not set at this point. So if `rel` and `href` are set after creation it will never call `_relation?.LoadAsync()`, and therefore the resource loader won't kick in.

Changes:
- Updated `HtmlLinkElement` to make sure that it attempts to load the relation when either the `rel`, `href` attributes have changed, or when the parent has changed (i.e. when it's added to the document). I took inspiration from the `HtmlScriptElement` where something similar happens.
- Updated `DefaultAttributeObserver` to trigger the new `UpdateRel` method when the `rel` attribute changes.
- Added a new unit test to prove that newly added links now trigger the right resource loader.
