### PR TITLE
Remove unnecessary System.Text.Encoding.CodePages ref from NET 6+

### DIFF
--- a/README.md
+++ b/README.md
@@ -70,7 +70,7 @@ Every collection in AngleSharp supports LINQ statements. AngleSharp also provide
 AngleSharp has been created as a .NET Standard 2.0 compatible library. This includes, but is not limited to:
 
 - .NET Core (2.0 and later)
-- .NET Framework (4.6.1 and later)
+- .NET Framework (4.6.2 and later)
 - Xamarin.Android (7.0 and 8.0)
 - Xamarin.iOS (10.0 and 10.14)
 - Xamarin.Mac (3.0 and 3.8)

--- a/docs/general/01-Basics.md
+++ b/docs/general/01-Basics.md
@@ -6,9 +6,9 @@ section: "AngleSharp.Core"
 
 ## Requirements
 
-AngleSharp comes currently in two flavors: on Windows for .NET 4.6.1 or newer and in general targeting .NET Standard 2.0 platforms.
+AngleSharp comes currently in two flavors: on Windows for .NET 4.6.2 or newer and in general targeting .NET Standard 2.0 platforms.
 
-Most of the features of the library do not require .NET 4.6.1, which means you could create your own fork and modify it to work with previous versions of the .NET-Framework.
+Most of the features of the library do not require .NET 4.6.2, which means you could create your own fork and modify it to work with previous versions of the .NET-Framework.
 
 ## Getting AngleSharp over NuGet
 

--- a/src/AngleSharp.Benchmarks/AngleSharp.Benchmarks.csproj
+++ b/src/AngleSharp.Benchmarks/AngleSharp.Benchmarks.csproj
@@ -10,7 +10,7 @@
   </ItemGroup>
 
   <ItemGroup>
-    <PackageReference Include="BenchmarkDotNet" Version="0.13.7" />
+    <PackageReference Include="BenchmarkDotNet" Version="0.13.12" />
     <PackageReference Include="CsQuery" Version="1.3.5-beta5" Condition=" '$(TargetFramework)' == 'net472' " />
     <PackageReference Include="HtmlAgilityPack" Version="1.11.46" />
     <PackageReference Include="System.Net.Http" Version="4.3.4" />

--- a/src/AngleSharp.Core.Tests/AngleSharp.Core.Tests.csproj
+++ b/src/AngleSharp.Core.Tests/AngleSharp.Core.Tests.csproj
@@ -1,7 +1,7 @@
 <Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
-    <TargetFrameworks Condition=" '$(OS)' != 'Windows_NT' ">net6.0;net7.0;net8.0</TargetFrameworks>
-    <TargetFrameworks Condition=" '$(OS)' == 'Windows_NT' ">net461;net472;net6.0;net7.0;net8.0</TargetFrameworks>
+    <TargetFrameworks>net6.0;net7.0;net8.0</TargetFrameworks>
+    <TargetFrameworks Condition=" '$(OS)' == 'Windows_NT' ">$(TargetFrameworks);net462;net472</TargetFrameworks>
     <IsPackable>false</IsPackable>
     <CopyLocalLockFileAssemblies>true</CopyLocalLockFileAssemblies> <!-- https://github.com/Tyrrrz/GitHubActionsTestLogger/issues/5 -->
   </PropertyGroup>
@@ -12,10 +12,10 @@
 
   <ItemGroup>
     <PackageReference Include="Newtonsoft.Json" Version="13.0.1" />
-    <PackageReference Include="GitHubActionsTestLogger" Version="2.0.1" PrivateAssets="all" />
+    <PackageReference Include="GitHubActionsTestLogger" Version="2.3.3" PrivateAssets="all" />
     <PackageReference Include="NUnit" Version="3.14.0" />
     <PackageReference Include="NUnit3TestAdapter" Version="4.5.0" />
-    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.8.0" />
+    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.9.0" />
     <PackageReference Include="Microsoft.Net.Http" Version="2.2.29" Condition="'$(TargetFramework)' == 'net472' or '$(TargetFramework)' == 'net461'" />
   </ItemGroup>
 

--- a/src/AngleSharp.Core.Tests/AngleSharp.Core.Tests.csproj
+++ b/src/AngleSharp.Core.Tests/AngleSharp.Core.Tests.csproj
@@ -16,7 +16,7 @@
     <PackageReference Include="NUnit" Version="3.14.0" />
     <PackageReference Include="NUnit3TestAdapter" Version="4.5.0" />
     <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.9.0" />
-    <PackageReference Include="Microsoft.Net.Http" Version="2.2.29" Condition="'$(TargetFramework)' == 'net472' or '$(TargetFramework)' == 'net461'" />
+    <PackageReference Include="Microsoft.Net.Http" Version="2.2.29" Condition="!$([MSBuild]::IsTargetFrameworkCompatible('$(TargetFramework)', 'net6.0'))" />
   </ItemGroup>
 
   <ItemGroup>

--- a/src/AngleSharp.Core.sln
+++ b/src/AngleSharp.Core.sln
@@ -12,6 +12,7 @@ Project("{2150E333-8FDC-42A3-9474-1A3956D46DE8}") = "Solution Items", "Solution 
 		AngleSharp.nuspec = AngleSharp.nuspec
 		Directory.Build.props = Directory.Build.props
 		..\.editorconfig = ..\.editorconfig
+		..\README.md = ..\README.md
 	EndProjectSection
 EndProject
 Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "AngleSharp.Core.Tests", "AngleSharp.Core.Tests\AngleSharp.Core.Tests.csproj", "{C3074D7E-CA6C-4F2C-813D-BD97462DC3EB}"

--- a/src/AngleSharp.nuspec
+++ b/src/AngleSharp.nuspec
@@ -19,20 +19,11 @@
       <group targetFramework="netstandard2.0">
         <dependency id="System.Text.Encoding.CodePages" version="7.0.0" />
       </group>
-      <group targetFramework="net461">
+      <group targetFramework="net462">
         <dependency id="System.Text.Encoding.CodePages" version="6.0.0" />
       </group>
       <group targetFramework="net472">
         <dependency id="System.Text.Encoding.CodePages" version="6.0.0" />
-      </group>
-      <group targetFramework="net60">
-        <dependency id="System.Text.Encoding.CodePages" version="6.0.0" />
-      </group>
-      <group targetFramework="net70">
-        <dependency id="System.Text.Encoding.CodePages" version="7.0.0" />
-      </group>
-      <group targetFramework="net80">
-        <dependency id="System.Text.Encoding.CodePages" version="8.0.0" />
       </group>
     </dependencies>
   </metadata>

--- a/src/AngleSharp/AngleSharp.Core.csproj
+++ b/src/AngleSharp/AngleSharp.Core.csproj
@@ -2,8 +2,8 @@
   <PropertyGroup>
     <AssemblyName>AngleSharp</AssemblyName>
     <RootNamespace>AngleSharp</RootNamespace>
-    <TargetFrameworks Condition=" '$(OS)' != 'Windows_NT' ">netstandard2.0;net6.0;net7.0;net8.0</TargetFrameworks>
-    <TargetFrameworks Condition=" '$(OS)' == 'Windows_NT' ">netstandard2.0;net461;net472;net6.0;net7.0;net8.0</TargetFrameworks>
+    <TargetFrameworks>netstandard2.0;net6.0;net7.0;net8.0</TargetFrameworks>
+    <TargetFrameworks Condition=" '$(OS)' == 'Windows_NT' ">$(TargetFrameworks);net462;net472</TargetFrameworks>
     <GenerateDocumentationFile>true</GenerateDocumentationFile>
     <Nullable>enable</Nullable>
     <RepositoryUrl>https://github.com/AngleSharp/AngleSharp</RepositoryUrl>
@@ -17,11 +17,11 @@
 
   <ItemGroup>
     <PackageReference Include="ConfigureAwaitChecker.Analyzer" Version="5.0.0.1" PrivateAssets="all" />
-    <PackageReference Include="Microsoft.SourceLink.GitHub" Version="1.1.1" PrivateAssets="All" />
+    <PackageReference Include="Microsoft.SourceLink.GitHub" Version="8.0.0" PrivateAssets="All" />
     <PackageReference Include="Nullable" Version="1.3.1" PrivateAssets="all" />
   </ItemGroup>
 
-  <ItemGroup Condition=" '$(TargetFramework)' == 'netstandard2.0' or '$(TargetFramework)' == 'net461' or '$(TargetFramework)' == 'net472' or '$(TargetFramework)' == 'net6.0' ">
+  <ItemGroup Condition="!$([MSBuild]::IsTargetFrameworkCompatible('$(TargetFramework)', 'net6.0'))">
     <PackageReference Include="System.Text.Encoding.CodePages" Version="6.0.0" />
   </ItemGroup>
 


### PR DESCRIPTION
# Types of Changes

## Prerequisites

Please make sure you can check the following two boxes:

- [x] I have read the **CONTRIBUTING** document
- [x] My code follows the code style of this project

## Contribution Type

What types of changes does your code introduce? Put an `x` in all the boxes that apply:

- [ ] Bug fix (non-breaking change which fixes an issue, please reference the issue id)
- [ ] New feature (non-breaking change which adds functionality, make sure to open an associated issue first)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] My change requires a change to the documentation
- [ ] I have updated the documentation accordingly
- [ ] I have added tests to cover my changes
- [x] All new and existing tests passed

## Description

NET 6+ doesn't need explicit reference to System.Text.Encoding.CodePages as it's part of runtime libraries. This trims down dependencies. I've changed minimum from NET 4.6.1 to 4.6.2 as it's the oldest supported FW platform and even Microsoft libaries aren't guaranteed to work with 4.6.1 (like Unsafe).
