### PR TITLE
Add back missing NET6+ targets to AngleSharp.nuspec

### DIFF
--- a/src/AngleSharp.nuspec
+++ b/src/AngleSharp.nuspec
@@ -25,6 +25,12 @@
       <group targetFramework="net472">
         <dependency id="System.Text.Encoding.CodePages" version="8.0.0" />
       </group>
+      <group targetFramework="net60">
+      </group>
+      <group targetFramework="net70">
+      </group>
+      <group targetFramework="net80">
+      </group>
     </dependencies>
   </metadata>
 </package>


### PR DESCRIPTION
# Types of Changes

## Prerequisites

Please make sure you can check the following two boxes:

- [x] I have read the **CONTRIBUTING** document
- [x] My code follows the code style of this project

## Contribution Type

What types of changes does your code introduce? Put an `x` in all the boxes that apply:

- [ ] Bug fix (non-breaking change which fixes an issue, please reference the issue id)
- [ ] New feature (non-breaking change which adds functionality, make sure to open an associated issue first)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] My change requires a change to the documentation
- [ ] I have updated the documentation accordingly
- [ ] I have added tests to cover my changes
- [ ] All new and existing tests passed

## Description

While there's still ongoing discussion about pros and cons for using csproj instead of nuspec file on #1189 I think it's better to fix what I broke as an intermediate solution. Bringing back explicit dependency targets without the actual dependencies.
