### PR TITLE
New setting for disabling Stringbuilder pooling.

### DIFF
--- a/CONTRIBUTORS.md
+++ b/CONTRIBUTORS.md
@@ -56,6 +56,7 @@ AngleSharp contains code written by (in order of first pull request / commit):
 * [James Thompson](https://github.com/thompson-tomo)
 * [schaakverslaafd](https://github.com/schaakverslaafd)
 * [Tom van Enckevort](https://github.com/tomvanenckevort)
+* [Micah Bresette](https://github.com/micahbresette)
 
 Without these awesome people AngleSharp could not exist. Thanks to everyone for your contributions! :beers:
 

--- a/src/AngleSharp.Core.Tests/Library/OptimizationPool.cs
+++ b/src/AngleSharp.Core.Tests/Library/OptimizationPool.cs
@@ -1,4 +1,4 @@
-﻿namespace AngleSharp.Core.Tests.Library
+namespace AngleSharp.Core.Tests.Library
 {
     using AngleSharp.Text;
     using NUnit.Framework;
@@ -29,6 +29,7 @@
 
             StringBuilderPool.MaxCount = _defaultCount;
             StringBuilderPool.SizeLimit = _defaultLimit;
+            StringBuilderPool.DisablePooling = false;
         }
 
         [Test]
@@ -55,6 +56,19 @@
             var sb2 = StringBuilderPool.Obtain();
             Assert.AreEqual(String.Empty, sb2.ToPool());
             Assert.AreSame(sb1, sb2);
+        }
+
+        [Test]
+        public void RecycleStringBuilderGetString_DisabledPooling()
+        {
+            StringBuilderPool.DisablePooling = true;
+            var str = "Test";
+            var sb1 = StringBuilderPool.Obtain();
+            sb1.Append(str);
+            Assert.AreEqual(str, sb1.ToPool());
+            var sb2 = StringBuilderPool.Obtain();
+            Assert.AreEqual(String.Empty, sb2.ToPool());
+            Assert.AreNotSame(sb1, sb2);
         }
 
         [Test]

--- a/src/AngleSharp.Core.Tests/Library/OptimizationPool.cs
+++ b/src/AngleSharp.Core.Tests/Library/OptimizationPool.cs
@@ -29,7 +29,7 @@ namespace AngleSharp.Core.Tests.Library
 
             StringBuilderPool.MaxCount = _defaultCount;
             StringBuilderPool.SizeLimit = _defaultLimit;
-            StringBuilderPool.DisablePooling = false;
+            StringBuilderPool.IsPoolingDisabled = false;
         }
 
         [Test]
@@ -61,7 +61,7 @@ namespace AngleSharp.Core.Tests.Library
         [Test]
         public void RecycleStringBuilderGetString_DisabledPooling()
         {
-            StringBuilderPool.DisablePooling = true;
+            StringBuilderPool.IsPoolingDisabled = true;
             var str = "Test";
             var sb1 = StringBuilderPool.Obtain();
             sb1.Append(str);

--- a/src/AngleSharp/Text/StringBuilderPool.cs
+++ b/src/AngleSharp/Text/StringBuilderPool.cs
@@ -14,7 +14,7 @@ namespace AngleSharp.Text
         private static Int32 _count = 4;
         private static Int32 _limit = 85000;
         private static bool _isPoolingDisabled = false;
-        private static Int32 _defaultStringBuilderSize = 1024;
+        private static readonly Int32 _defaultStringBuilderSize = 1024;
 
         /// <summary>
         /// Gets or sets whether string builder pooling is disabled.  When disabled, Obtain() will always return a new instance.

--- a/src/AngleSharp/Text/StringBuilderPool.cs
+++ b/src/AngleSharp/Text/StringBuilderPool.cs
@@ -51,7 +51,7 @@ namespace AngleSharp.Text
         /// <returns>A stringbuilder to use.</returns>
         public static StringBuilder Obtain()
         {
-            StringBuilder result;
+            StringBuilder result = null;
 
             if (_isPoolingDisabled)
             {

--- a/src/AngleSharp/Text/StringBuilderPool.cs
+++ b/src/AngleSharp/Text/StringBuilderPool.cs
@@ -51,7 +51,7 @@ namespace AngleSharp.Text
         /// <returns>A stringbuilder to use.</returns>
         public static StringBuilder Obtain()
         {
-            StringBuilder result = null;
+            StringBuilder result;
 
             if (_isPoolingDisabled)
             {

--- a/src/AngleSharp/Text/StringBuilderPool.cs
+++ b/src/AngleSharp/Text/StringBuilderPool.cs
@@ -46,14 +46,16 @@ namespace AngleSharp.Text
         }
 
         /// <summary>
-        /// Either creates a fresh stringbuilder or gets a (cleaned) used one.
+        /// Either creates a fresh stringbuilder or gets a (cleaned) used one.  If <see cref="IsPoolingDisabled"/> is set to true, a new instance is always returned."/>
         /// </summary>
         /// <returns>A stringbuilder to use.</returns>
         public static StringBuilder Obtain()
         {
+            StringBuilder result = null;
+
             if (_isPoolingDisabled)
             {
-                return new StringBuilder(_defaultStringBuilderSize);
+                result = CreateStringBuilder();
             }
             else
             {
@@ -61,12 +63,16 @@ namespace AngleSharp.Text
                 {
                     if (_builder.Count == 0)
                     {
-                        return new StringBuilder(_defaultStringBuilderSize);
+                        result = CreateStringBuilder();
                     }
-
-                    return _builder.Pop().Clear();
+                    else
+                    {
+                        result = _builder.Pop().Clear();
+                    }
                 }
             }
+
+            return result;
         }
 
         /// <summary>
@@ -81,6 +87,12 @@ namespace AngleSharp.Text
             ReturnToPool(sb);
             return result;
         }
+
+        /// <summary>
+        /// Creates a new StringBuilder with a default capacity of 1024.
+        /// </summary>
+        /// <returns>A StringBuilder instance.</returns>
+        internal static StringBuilder CreateStringBuilder() => new StringBuilder(1024);
 
         /// <summary>
         /// Returns the given stringbuilder to the pool.


### PR DESCRIPTION
# Types of Changes

## Prerequisites

Please make sure you can check the following two boxes:

- [x] I have read the **CONTRIBUTING** document
- [x] My code follows the code style of this project

## Contribution Type

What types of changes does your code introduce? Put an `x` in all the boxes that apply:

- [ ] Bug fix (non-breaking change which fixes an issue, please reference the issue id)
- [x] New feature (non-breaking change which adds functionality, make sure to open an associated issue first)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] My change requires a change to the documentation
- [ ] I have updated the documentation accordingly
- [x] I have added tests to cover my changes
- [x] All new and existing tests passed

## Description

Added a new setting for disabling Stringbuilder pooling.  This can increase performance during heavy parallel processing as it will skip the lock.  However, by disabling pooling it can also increase overall memory consumption.

https://github.com/AngleSharp/AngleSharp/issues/1201
