### PR TITLE
Add support for targetting iframes

### DIFF
--- a/.editorconfig
+++ b/.editorconfig
@@ -20,3 +20,4 @@ csharp_prefer_braces = true:suggestion
 csharp_using_directive_placement = inside_namespace:suggestion
 csharp_style_var_for_built_in_types=true:suggestion
 csharp_style_var_when_type_is_apparent=true:suggestion
+csharp_new_line_before_open_brace = all

--- a/src/AngleSharp.Core.Tests/Html/IframeTargets.cs
+++ b/src/AngleSharp.Core.Tests/Html/IframeTargets.cs
@@ -1,0 +1,405 @@
+namespace AngleSharp.Core.Tests.Html;
+
+using AngleSharp.Html.Dom;
+using AngleSharp.Io;
+using NUnit.Framework;
+using System;
+using System.IO;
+using System.Text;
+using System.Threading.Tasks;
+
+file static class HtmlExtensions
+{
+    public static String ToHtmlDataUri(this String html)
+    {
+        return $"data:text/html;charset=UTF-8;base64,{Convert.ToBase64String(Encoding.UTF8.GetBytes(html))}";
+    }
+}
+
+[TestFixture]
+public class IframeTargets
+{
+    private static DefaultResponse CreateResponse(Dom.Url address, ReadOnlySpan<Byte> content)
+    {
+        return new()
+        {
+            Address = address,
+            StatusCode = System.Net.HttpStatusCode.OK,
+            Content = new MemoryStream(content.ToArray()),
+        };
+    }
+
+    private static DefaultResponse CreateNotFoundResponse(Dom.Url address)
+    {
+        return new()
+        {
+            Address = address,
+            StatusCode = System.Net.HttpStatusCode.NotFound,
+        };
+    }
+
+    [Test]
+    public async Task AnchorTargetsIframeInDocument()
+    {
+        var context = BrowsingContext.New(Configuration.Default.WithVirtualRequester(req => req.Address.Href switch
+        {
+            "https://localhost/iframe.html" => CreateResponse(req.Address,
+                """
+                <html>
+                <body>
+                    <h1>iframe content</h1>
+                </body>
+                </html>
+                """u8
+            ),
+            "https://localhost/" => CreateResponse(req.Address,
+                """
+                <html>
+                <body>
+                    <iframe id="iframe" name="iframe"></iframe>
+                    <a href="iframe.html" id="link" target="iframe">Load frame</a>
+                </body>
+                </html>
+                """u8
+            ),
+            _ => CreateNotFoundResponse(req.Address),
+        }));
+
+        var doc = await context.OpenAsync("https://localhost/");
+        var link = doc.GetElementById("link") as IHtmlAnchorElement;
+        Assert.IsNotNull(link);
+        link.DoClick();
+
+        await Task.Delay(1000);
+
+        var iframe = doc.GetElementById("iframe") as IHtmlInlineFrameElement;
+        Assert.IsNotNull(iframe?.ContentDocument);
+
+        var headerTexts = iframe.ContentDocument.GetElementsByTagName("h1");
+        Assert.IsNotNull(headerTexts);
+        Assert.AreEqual(1, headerTexts.Length);
+        Assert.AreEqual("iframe content", headerTexts[0].InnerHtml);
+    }
+
+    [Test]
+    public async Task AnchorTargetsNestedIframeInDocument()
+    {
+        var context = BrowsingContext.New(Configuration.Default.WithVirtualRequester(req => req.Address.Href switch
+        {
+            "https://localhost/inner-iframe.html" => CreateResponse(req.Address,
+                """
+                <html>
+                <body>
+                    <h1>iframe content</h1>
+                </body>
+                </html>
+                """u8
+            ),
+            "https://localhost/iframe.html" => CreateResponse(req.Address,
+                """
+                <html>
+                <body>
+                    <iframe id="inner-iframe" name="inner-iframe"></iframe>
+                </body>
+                </html>
+                """u8
+            ),
+            "https://localhost/" => CreateResponse(req.Address,
+                """
+                <html>
+                <body>
+                    <iframe id="iframe" name="iframe" src="iframe.html"></iframe>
+                    <a href="inner-iframe.html" id="link" target="inner-iframe">Load frame</a>
+                </body>
+                </html>
+                """u8
+            ),
+            _ => CreateNotFoundResponse(req.Address),
+        }));
+
+        var doc = await context.OpenAsync("https://localhost/");
+        var link = doc.GetElementById("link") as IHtmlAnchorElement;
+        Assert.IsNotNull(link);
+        link.DoClick();
+
+        await Task.Delay(1000);
+
+        var iframe = doc.GetElementById("iframe") as IHtmlInlineFrameElement;
+        Assert.IsNotNull(iframe?.ContentDocument);
+
+        var innerIframe = iframe.ContentDocument.GetElementById("inner-iframe") as IHtmlInlineFrameElement;
+        Assert.IsNotNull(innerIframe?.ContentDocument);
+
+        var headerTexts = innerIframe.ContentDocument.GetElementsByTagName("h1");
+        Assert.IsNotNull(headerTexts);
+        Assert.AreEqual(1, headerTexts.Length);
+        Assert.AreEqual("iframe content", headerTexts[0].InnerHtml);
+    }
+
+    [Test]
+    public async Task AnchorTargetsSiblingIframeInIframe()
+    {
+        var context = BrowsingContext.New(Configuration.Default.WithVirtualRequester(req => req.Address.Href switch
+        {
+            "https://localhost/inner-iframe.html" => CreateResponse(req.Address,
+                """
+                <html>
+                <body>
+                    <h1>iframe content</h1>
+                </body>
+                </html>
+                """u8
+            ),
+            "https://localhost/source-iframe.html" => CreateResponse(req.Address,
+                """
+                <html>
+                <body>
+                    <a href="inner-iframe.html" id="link" target="inner-iframe">Load frame</a>
+                </body>
+                </html>
+                """u8
+            ),
+            "https://localhost/target-iframe.html" => CreateResponse(req.Address,
+                """
+                <html>
+                <body>
+                    <iframe id="inner-iframe" name="inner-iframe"></iframe>
+                </body>
+                </html>
+                """u8
+            ),
+            "https://localhost/" => CreateResponse(req.Address,
+                """
+                <html>
+                <body>
+                    <iframe id="source-iframe" name="source-iframe" src="source-iframe.html"></iframe>
+                    <iframe id="target-iframe" name="target-iframe" src="target-iframe.html"></iframe>
+                </body>
+                </html>
+                """u8
+            ),
+            _ => CreateNotFoundResponse(req.Address),
+        }));
+
+        var doc = await context.OpenAsync("https://localhost/");
+
+        var sourceIframe = doc.GetElementById("source-iframe") as IHtmlInlineFrameElement;
+        Assert.IsNotNull(sourceIframe?.ContentDocument);
+
+        var link = sourceIframe.ContentDocument.GetElementById("link") as IHtmlAnchorElement;
+        Assert.IsNotNull(link);
+        link.DoClick();
+
+        await Task.Delay(1000);
+
+        var targetIframe = doc.GetElementById("target-iframe") as IHtmlInlineFrameElement;
+        Assert.IsNotNull(targetIframe?.ContentDocument);
+
+        var innerIframe = targetIframe.ContentDocument.GetElementById("inner-iframe") as IHtmlInlineFrameElement;
+        Assert.IsNotNull(innerIframe?.ContentDocument);
+
+        var headerTexts = innerIframe.ContentDocument.GetElementsByTagName("h1");
+        Assert.IsNotNull(headerTexts);
+        Assert.AreEqual(1, headerTexts.Length);
+        Assert.AreEqual("iframe content", headerTexts[0].InnerHtml);
+    }
+
+    [Test]
+    public async Task AnchorTargetsIframeInDifferentWindow()
+    {
+        var context = BrowsingContext.New(Configuration.Default.WithVirtualRequester(req => req.Address.Href switch
+        {
+            "https://localhost/inner-iframe.html" => CreateResponse(req.Address,
+                """
+                <html>
+                <body>
+                    <h1>iframe content</h1>
+                </body>
+                </html>
+                """u8
+            ),
+            "https://localhost/new-window.html" => CreateResponse(req.Address,
+                """
+                <html>
+                <body>
+                    <a href="inner-iframe.html" id="frame-link" target="iframe">Load frame</a>
+                </body>
+                </html>
+                """u8
+            ),
+            "https://localhost/" => CreateResponse(req.Address,
+                """
+                <html>
+                <body>
+                    <iframe id="iframe" name="iframe"></iframe>
+                    <a href="new-window.html" id="window-link" target="new-window">Load window</a>
+                </body>
+                </html>
+                """u8
+            ),
+            _ => CreateNotFoundResponse(req.Address),
+        }));
+
+        var doc = await context.OpenAsync("https://localhost/");
+
+        var newWindowLink = doc.GetElementById("window-link") as IHtmlAnchorElement;
+        Assert.IsNotNull(newWindowLink);
+        newWindowLink.DoClick();
+
+        await Task.Delay(1000);
+
+        var newWindowDoc = context.FindChild("new-window")?.Active;
+        Assert.IsNotNull(newWindowDoc);
+
+        var frameLink = newWindowDoc.GetElementById("frame-link") as IHtmlAnchorElement;
+        Assert.IsNotNull(frameLink);
+        frameLink.DoClick();
+
+        await Task.Delay(1000);
+
+        var iframe = doc.GetElementById("iframe") as IHtmlInlineFrameElement;
+        Assert.IsNotNull(iframe?.ContentDocument);
+
+        var headerTexts = iframe.ContentDocument.GetElementsByTagName("h1");
+        Assert.IsNotNull(headerTexts);
+        Assert.AreEqual(1, headerTexts.Length);
+        Assert.AreEqual("iframe content", headerTexts[0].InnerHtml);
+    }
+
+    [Test]
+    public async Task AnchorTargetsCurrentWindowWithTop()
+    {
+        var context = BrowsingContext.New(Configuration.Default.WithVirtualRequester(req => req.Address.Href switch
+        {
+            "https://localhost/inner-iframe.html" => CreateResponse(req.Address,
+                """
+                <html>
+                <body>
+                    <h1>iframe content</h1>
+                </body>
+                </html>
+                """u8
+            ),
+            "https://localhost/iframe.html" => CreateResponse(req.Address,
+                """
+                <html>
+                <body>
+                    <a href="inner-iframe.html" id="frame-link" target="_top">Load frame</a>
+                </body>
+                </html>
+                """u8
+            ),
+            "https://localhost/new-window.html" => CreateResponse(req.Address,
+                """
+                <html>
+                <body>
+                    <iframe id="iframe" name="iframe" src="iframe.html"></iframe>
+                </body>
+                </html>
+                """u8
+            ),
+            "https://localhost/" => CreateResponse(req.Address,
+                """
+                <html>
+                <body>
+                    <a href="new-window.html" id="window-link" target="new-window">Load window</a>
+                </body>
+                </html>
+                """u8
+            ),
+            _ => CreateNotFoundResponse(req.Address),
+        }));
+
+        var doc = await context.OpenAsync("https://localhost/");
+
+        var newWindowLink = doc.GetElementById("window-link") as IHtmlAnchorElement;
+        Assert.IsNotNull(newWindowLink);
+        newWindowLink.DoClick();
+
+        await Task.Delay(1000);
+
+        var newWindow = context.FindChild("new-window");
+        Assert.IsNotNull(newWindow);
+
+        var iframe = newWindow.Active.GetElementById("iframe") as IHtmlInlineFrameElement;
+        Assert.IsNotNull(iframe?.ContentDocument);
+
+        var frameLink = iframe.ContentDocument.GetElementById("frame-link") as IHtmlAnchorElement;
+        Assert.IsNotNull(frameLink);
+        frameLink.DoClick();
+
+        await Task.Delay(1000);
+
+        Assert.IsNotNull(newWindow.Active);
+
+        // Make sure the new window has navigated after clicking the frame link
+        var headerTexts = newWindow.Active.GetElementsByTagName("h1");
+        Assert.IsNotNull(headerTexts);
+        Assert.AreEqual(1, headerTexts.Length);
+        Assert.AreEqual("iframe content", headerTexts[0].InnerHtml);
+
+        // Make sure the original window has not navigated after clicking the frame link
+        Assert.AreEqual("Load window", context.Active?.GetElementById("window-link")?.InnerHtml);
+    }
+    [Test]
+    public async Task AnchorTargetsSelfAsParentInNewWindow()
+    {
+        var context = BrowsingContext.New(Configuration.Default.WithVirtualRequester(req => req.Address.Href switch
+        {
+            "https://localhost/next-page.html" => CreateResponse(req.Address,
+                """
+                <html>
+                <body>
+                  <h1>Next Page</h1>
+                </body>
+                </html>
+                """u8
+            ),
+            "https://localhost/new-window.html" => CreateResponse(req.Address,
+                """
+                <html>
+                <body>
+                  <a id="window-link" href="next-page.html" target="_parent">Load next page</a>
+                </body>
+                </html>
+                """u8
+            ),
+            "https://localhost/" => CreateResponse(req.Address,
+                """
+                <html>
+                <body>
+                  <a id="link" href="new-window.html" target="new-window">Load window</a>
+                </body>
+                </html>
+                """u8
+            ),
+            _ => CreateNotFoundResponse(req.Address),
+        }));
+
+        var doc = await context.OpenAsync("https://localhost/");
+
+        var link = doc.GetElementById("link") as IHtmlAnchorElement;
+        Assert.IsNotNull(link);
+        link.DoClick();
+
+        await Task.Delay(1000);
+
+        var newWindowContext = context.FindChild("new-window");
+        Assert.IsNotNull(newWindowContext?.Active);
+
+        var windowLink = newWindowContext.Active.GetElementById("window-link") as IHtmlAnchorElement;
+        Assert.IsNotNull(windowLink);
+        windowLink.DoClick();
+
+        await Task.Delay(1000);
+
+        var headerTexts = newWindowContext.Active.GetElementsByTagName("h1");
+        Assert.IsNotNull(headerTexts);
+        Assert.AreEqual(1, headerTexts.Length);
+        Assert.AreEqual("Next Page", headerTexts[0].InnerHtml);
+
+        // Make sure the original window has not navigated after clicking the frame link
+        Assert.AreEqual("Load window", context.Active?.GetElementById("link")?.InnerHtml);
+
+    }
+}

--- a/src/AngleSharp.Core.Tests/Html/IframeTargets.cs
+++ b/src/AngleSharp.Core.Tests/Html/IframeTargets.cs
@@ -5,16 +5,7 @@ using AngleSharp.Io;
 using NUnit.Framework;
 using System;
 using System.IO;
-using System.Text;
 using System.Threading.Tasks;
-
-file static class HtmlExtensions
-{
-    public static String ToHtmlDataUri(this String html)
-    {
-        return $"data:text/html;charset=UTF-8;base64,{Convert.ToBase64String(Encoding.UTF8.GetBytes(html))}";
-    }
-}
 
 [TestFixture]
 public class IframeTargets
@@ -44,6 +35,7 @@ public class IframeTargets
         var context = BrowsingContext.New(Configuration.Default.WithVirtualRequester(req => req.Address.Href switch
         {
             "https://localhost/iframe.html" => CreateResponse(req.Address,
+                // language=html
                 """
                 <html>
                 <body>
@@ -53,6 +45,7 @@ public class IframeTargets
                 """u8
             ),
             "https://localhost/" => CreateResponse(req.Address,
+                // language=html
                 """
                 <html>
                 <body>
@@ -87,6 +80,7 @@ public class IframeTargets
         var context = BrowsingContext.New(Configuration.Default.WithVirtualRequester(req => req.Address.Href switch
         {
             "https://localhost/inner-iframe.html" => CreateResponse(req.Address,
+                // language=html
                 """
                 <html>
                 <body>
@@ -96,6 +90,7 @@ public class IframeTargets
                 """u8
             ),
             "https://localhost/iframe.html" => CreateResponse(req.Address,
+                // language=html
                 """
                 <html>
                 <body>
@@ -105,6 +100,7 @@ public class IframeTargets
                 """u8
             ),
             "https://localhost/" => CreateResponse(req.Address,
+                // language=html
                 """
                 <html>
                 <body>
@@ -142,6 +138,7 @@ public class IframeTargets
         var context = BrowsingContext.New(Configuration.Default.WithVirtualRequester(req => req.Address.Href switch
         {
             "https://localhost/inner-iframe.html" => CreateResponse(req.Address,
+                // language=html
                 """
                 <html>
                 <body>
@@ -151,6 +148,7 @@ public class IframeTargets
                 """u8
             ),
             "https://localhost/iframe.html" => CreateResponse(req.Address,
+                // language=html
                 """
                 <html>
                 <body>
@@ -160,6 +158,7 @@ public class IframeTargets
                 """u8
             ),
             "https://localhost/" => CreateResponse(req.Address,
+                // language=html
                 """
                 <html>
                 <body>
@@ -197,6 +196,7 @@ public class IframeTargets
         var context = BrowsingContext.New(Configuration.Default.WithVirtualRequester(req => req.Address.Href switch
         {
             "https://localhost/inner-iframe.html" => CreateResponse(req.Address,
+                // language=html
                 """
                 <html>
                 <body>
@@ -206,6 +206,7 @@ public class IframeTargets
                 """u8
             ),
             "https://localhost/source-iframe.html" => CreateResponse(req.Address,
+                // language=html
                 """
                 <html>
                 <body>
@@ -215,6 +216,7 @@ public class IframeTargets
                 """u8
             ),
             "https://localhost/target-iframe.html" => CreateResponse(req.Address,
+                // language=html
                 """
                 <html>
                 <body>
@@ -224,6 +226,7 @@ public class IframeTargets
                 """u8
             ),
             "https://localhost/" => CreateResponse(req.Address,
+                // language=html
                 """
                 <html>
                 <body>
@@ -265,6 +268,7 @@ public class IframeTargets
         var context = BrowsingContext.New(Configuration.Default.WithVirtualRequester(req => req.Address.Href switch
         {
             "https://localhost/inner-iframe.html" => CreateResponse(req.Address,
+                // language=html
                 """
                 <html>
                 <body>
@@ -274,6 +278,7 @@ public class IframeTargets
                 """u8
             ),
             "https://localhost/new-window.html" => CreateResponse(req.Address,
+                // language=html
                 """
                 <html>
                 <body>
@@ -283,6 +288,7 @@ public class IframeTargets
                 """u8
             ),
             "https://localhost/" => CreateResponse(req.Address,
+                // language=html
                 """
                 <html>
                 <body>
@@ -327,6 +333,7 @@ public class IframeTargets
         var context = BrowsingContext.New(Configuration.Default.WithVirtualRequester(req => req.Address.Href switch
         {
             "https://localhost/inner-iframe.html" => CreateResponse(req.Address,
+                // language=html
                 """
                 <html>
                 <body>
@@ -336,6 +343,7 @@ public class IframeTargets
                 """u8
             ),
             "https://localhost/iframe.html" => CreateResponse(req.Address,
+                // language=html
                 """
                 <html>
                 <body>
@@ -345,6 +353,7 @@ public class IframeTargets
                 """u8
             ),
             "https://localhost/new-window.html" => CreateResponse(req.Address,
+                // language=html
                 """
                 <html>
                 <body>
@@ -354,6 +363,7 @@ public class IframeTargets
                 """u8
             ),
             "https://localhost/" => CreateResponse(req.Address,
+                // language=html
                 """
                 <html>
                 <body>
@@ -402,6 +412,7 @@ public class IframeTargets
         var context = BrowsingContext.New(Configuration.Default.WithVirtualRequester(req => req.Address.Href switch
         {
             "https://localhost/next-page.html" => CreateResponse(req.Address,
+                // language=html
                 """
                 <html>
                 <body>
@@ -411,6 +422,7 @@ public class IframeTargets
                 """u8
             ),
             "https://localhost/new-window.html" => CreateResponse(req.Address,
+                // language=html
                 """
                 <html>
                 <body>
@@ -420,6 +432,7 @@ public class IframeTargets
                 """u8
             ),
             "https://localhost/" => CreateResponse(req.Address,
+                // language=html
                 """
                 <html>
                 <body>

--- a/src/AngleSharp.Core.Tests/Html/IframeTargets.cs
+++ b/src/AngleSharp.Core.Tests/Html/IframeTargets.cs
@@ -470,4 +470,281 @@ public class IframeTargets
         Assert.AreEqual("Load window", context.Active?.GetElementById("link")?.InnerHtml);
 
     }
+
+    // I have not been able to find any standard which dictates what is supposed to happen
+    // when multiple iframes within a single root browsing context have the same name as the
+    // target of a navigation element.  Testing with a FireFox based browser, the behavior
+    // appears to be a depth first search in the current browsing context of iframes in
+    // document order until one is found, and, if not, then the same search is repeated
+    // in the parent browsing context, or opened as a new window if none was found within
+    // the root browsing context.
+
+    [Test]
+    public async Task AnchorTargetsFirstAvailableIframeWhenNamesCollide()
+    {
+        // In this test, with two iframes on the page, when only the second iframe had a nested iframe
+        // named 'destination,' a link targeting the 'destination' iframe opens in the nested iframe
+        // within the second iframe.  However, on the same page, if the first iframe has a nested iframe
+        // named 'destination' loaded in, even after the initial page load, or even after the nested
+        // within the second iframe has loaded, the link will target within the first iframe.
+        var context = BrowsingContext.New(Configuration.Default.WithVirtualRequester(req => req.Address.Href switch
+        {
+            "https://localhost/destination.html" => CreateResponse(req.Address,
+                // language=html
+                """
+                <html>
+                  <body>
+                    <h2>Page here</h2>
+                  </body>
+                </html>
+                """u8
+            ),
+            "https://localhost/frame-1.html" => CreateResponse(req.Address,
+                // language=html
+                """
+                <html>
+                  <body>
+                    <iframe id='destination' name='destination'></iframe>
+                  </body>
+                </html>
+                """u8
+            ),
+            "https://localhost/frame-2.html" => CreateResponse(req.Address,
+                // language=html
+                """
+                <html>
+                  <body>
+                    <iframe id='destination' name='destination'></iframe>
+                  </body>
+                </html>
+                """u8
+            ),
+            "https://localhost/" => CreateResponse(req.Address,
+                // language=html
+                """
+                <html>
+                  <body>
+                    <iframe id='frame-1' name='frame-1'></iframe>
+                    <iframe id='frame-2' src='frame-2.html'></iframe>
+                    <a id='load-frame-1' href='frame-1.html' target='frame-1'>Load frame 1</a>
+                    <a id='link' href='destination.html' target='destination'>Open link</a>
+                  </body>
+                </html>
+                """u8
+            ),
+            _ => CreateNotFoundResponse(req.Address),
+        }));
+
+        var doc = await context.OpenAsync("https://localhost/");
+
+        var link = doc.GetElementById("link") as IHtmlAnchorElement;
+        Assert.IsNotNull(link);
+        link.DoClick();
+
+        await Task.Delay(1000);
+
+        var iframe2 = doc.GetElementById("frame-2") as IHtmlInlineFrameElement;
+        Assert.IsNotNull(iframe2?.ContentDocument);
+
+        var iframe2Destination = iframe2.ContentDocument.GetElementById("destination") as IHtmlInlineFrameElement;
+        Assert.IsNotNull(iframe2Destination?.ContentDocument);
+
+        var iframe2DestinationHeaders = iframe2Destination.ContentDocument.GetElementsByTagName("h2");
+        Assert.IsNotNull(iframe2DestinationHeaders);
+        Assert.AreEqual(1, iframe2DestinationHeaders.Length);
+        Assert.AreEqual("Page here", iframe2DestinationHeaders[0].InnerHtml);
+
+        var loadIframe1Link = doc.GetElementById("load-frame-1") as IHtmlAnchorElement;
+        Assert.IsNotNull(loadIframe1Link);
+        loadIframe1Link.DoClick();
+
+        await Task.Delay(1000);
+        link.DoClick();
+
+        await Task.Delay(1000);
+
+        var iframe1 = doc.GetElementById("frame-1") as IHtmlInlineFrameElement;
+        Assert.IsNotNull(iframe1?.ContentDocument);
+
+        var iframe1Destination = iframe1.ContentDocument.GetElementById("destination") as IHtmlInlineFrameElement;
+        Assert.IsNotNull(iframe1Destination?.ContentDocument);
+
+        var iframe1DestinationHeaders = iframe1Destination.ContentDocument.GetElementsByTagName("h2");
+        Assert.IsNotNull(iframe1DestinationHeaders);
+        Assert.AreEqual(1, iframe1DestinationHeaders.Length);
+        Assert.AreEqual("Page here", iframe1DestinationHeaders[0].InnerHtml);
+    }
+
+    [Test]
+    public async Task AnchorTargetsOnlyFirstAvailableIframeWhenNamesCollide()
+    {
+        // In this test, with two iframes on the page, when both contain a nested iframe named 'destination',
+        // a link targeting the 'destination' iframe opens within the first iframe, and ignores the second
+        // iframe.
+        var context = BrowsingContext.New(Configuration.Default.WithVirtualRequester(req => req.Address.Href switch
+        {
+            "https://localhost/destination.html" => CreateResponse(req.Address,
+                // language=html
+                """
+                <html>
+                  <body>
+                    <h2>Page here</h2>
+                  </body>
+                </html>
+                """u8
+            ),
+            "https://localhost/frame-1.html" => CreateResponse(req.Address,
+                // language=html
+                """
+                <html>
+                  <body>
+                    <iframe id='destination' name='destination'></iframe>
+                  </body>
+                </html>
+                """u8
+            ),
+            "https://localhost/frame-2.html" => CreateResponse(req.Address,
+                // language=html
+                """
+                <html>
+                  <body>
+                    <iframe id='destination' name='destination'></iframe>
+                  </body>
+                </html>
+                """u8
+            ),
+            "https://localhost/" => CreateResponse(req.Address,
+                // language=html
+                """
+                <html>
+                  <body>
+                    <iframe id='frame-1' src='frame-1.html'></iframe>
+                    <iframe id='frame-2' src='frame-2.html'></iframe>
+                    <a id='link' href='destination.html' target='destination'>Open link</a>
+                  </body>
+                </html>
+                """u8
+            ),
+            _ => CreateNotFoundResponse(req.Address),
+        }));
+
+        var doc = await context.OpenAsync("https://localhost/");
+
+        var link = doc.GetElementById("link") as IHtmlAnchorElement;
+        Assert.IsNotNull(link);
+        link.DoClick();
+
+        await Task.Delay(1000);
+
+        var iframe1 = doc.GetElementById("frame-1") as IHtmlInlineFrameElement;
+        Assert.IsNotNull(iframe1?.ContentDocument);
+
+        var iframe1Destination = iframe1.ContentDocument.GetElementById("destination") as IHtmlInlineFrameElement;
+        Assert.IsNotNull(iframe1Destination?.ContentDocument);
+
+        var iframe1DestinationHeaders = iframe1Destination.ContentDocument.GetElementsByTagName("h2");
+        Assert.IsNotNull(iframe1DestinationHeaders);
+        Assert.AreEqual(1, iframe1DestinationHeaders.Length);
+        Assert.AreEqual("Page here", iframe1DestinationHeaders[0].InnerHtml);
+
+        var iframe2 = doc.GetElementById("frame-2") as IHtmlInlineFrameElement;
+        Assert.IsNotNull(iframe2?.ContentDocument);
+
+        var iframe2Destination = iframe2.ContentDocument.GetElementById("destination") as IHtmlInlineFrameElement;
+        if (iframe2Destination?.ContentDocument is null)
+        {
+            Assert.Pass("iframe-2 content document is null");
+        }
+
+        var iframe2DestinationHeaders = iframe2Destination.ContentDocument.GetElementsByTagName("h2");
+        Assert.That(iframe2DestinationHeaders, Is.Null.Or.Empty);
+    }
+
+    [Test]
+    public async Task AnchorTargetsFirstLoadedIframeWhenNamesCollide()
+    {
+        // In this test, with one iframe on the page at load, and one more iframe inserted to an earlier
+        // position after load, with both having a nested iframe named 'destination', a link targeting
+        // 'destination' opens within the iframe that was loaded into the document first, regardless
+        // of document order.
+        var context = BrowsingContext.New(Configuration.Default.WithVirtualRequester(req => req.Address.Href switch
+        {
+            "https://localhost/destination.html" => CreateResponse(req.Address,
+                // language=html
+                """
+                <html>
+                  <body>
+                    <h2>Page here</h2>
+                  </body>
+                </html>
+                """u8
+            ),
+            "https://localhost/frame-1.html" => CreateResponse(req.Address,
+                // language=html
+                """
+                <html>
+                  <body>
+                    <iframe id='destination' name='destination'></iframe>
+                  </body>
+                </html>
+                """u8
+            ),
+            "https://localhost/frame-2.html" => CreateResponse(req.Address,
+                // language=html
+                """
+                <html>
+                  <body>
+                    <iframe id='destination' name='destination'></iframe>
+                  </body>
+                </html>
+                """u8
+            ),
+            "https://localhost/" => CreateResponse(req.Address,
+                // language=html
+                """
+                <html>
+                  <body>
+                    <iframe id='frame-2' src='frame-2.html'></iframe>
+                    <a id='link' href='destination.html' target='destination'>Open link</a>
+                  </body>
+                </html>
+                """u8
+            ),
+            _ => CreateNotFoundResponse(req.Address),
+        }));
+
+        var doc = await context.OpenAsync("https://localhost/");
+        var iframe1 = doc.CreateElement("iframe") as IHtmlInlineFrameElement;
+        iframe1.Id = "frame-1";
+        iframe1.Source = "frame-1.html";
+        var iframe2 = doc.GetElementById("frame-2") as IHtmlInlineFrameElement;
+        doc.Body.InsertBefore(iframe1, iframe2);
+
+        var link = doc.GetElementById("link") as IHtmlAnchorElement;
+        Assert.IsNotNull(link);
+        link.DoClick();
+
+        await Task.Delay(1000);
+
+        Assert.IsNotNull(iframe2?.ContentDocument);
+
+        var iframe2Destination = iframe2.ContentDocument.GetElementById("destination") as IHtmlInlineFrameElement;
+        Assert.IsNotNull(iframe2Destination?.ContentDocument);
+
+        var iframe2DestinationHeaders = iframe2Destination.ContentDocument.GetElementsByTagName("h2");
+        Assert.IsNotNull(iframe2DestinationHeaders);
+        Assert.AreEqual(1, iframe2DestinationHeaders.Length);
+        Assert.AreEqual("Page here", iframe2DestinationHeaders[0].InnerHtml);
+
+        Assert.IsNotNull(iframe2?.ContentDocument);
+
+        var iframe1Destination = iframe1.ContentDocument.GetElementById("destination") as IHtmlInlineFrameElement;
+        if (iframe1Destination?.ContentDocument is null)
+        {
+            Assert.Pass("iframe-1 content document is null");
+        }
+
+        var iframe1DestinationHeaders = iframe1Destination.ContentDocument.GetElementsByTagName("h2");
+        Assert.That(iframe1DestinationHeaders, Is.Null.Or.Empty);
+    }
 }

--- a/src/AngleSharp/BrowsingContext.cs
+++ b/src/AngleSharp/BrowsingContext.cs
@@ -218,6 +218,18 @@ namespace AngleSharp
                 reference.TryGetTarget(out context);
             }
 
+            if (context is null && Active is Document active)
+            {
+                foreach (var childContext in active.GetAttachedReferences<IBrowsingContext>())
+                {
+                    context = childContext.FindChild(name);
+                    if (context is not null)
+                    {
+                        break;
+                    }
+                }
+            }
+
             return context;
         }
 

--- a/src/AngleSharp/BrowsingContext.cs
+++ b/src/AngleSharp/BrowsingContext.cs
@@ -105,7 +105,7 @@ namespace AngleSharp
         /// a window. Useful for properly determining the proper target
         /// for `_top` and `_parent`.
         ///</summary>
-        public Boolean IsFrame => _isFrameContext;
+        internal Boolean IsFrame => _isFrameContext;
 
         /// <summary>
         /// Gets the session history of the given browsing context, if any.
@@ -190,9 +190,20 @@ namespace AngleSharp
         /// </summary>
         /// <param name="name">The name of the child context, if any.</param>
         /// <param name="security">The security flags to apply.</param>
+        /// <returns></returns>
+        public IBrowsingContext CreateChild(String? name, Sandboxes security)
+        {
+            return CreateChild(name, security, false);
+        }
+
+        /// <summary>
+        /// Creates a new named browsing context as child of the given parent.
+        /// </summary>
+        /// <param name="name">The name of the child context, if any.</param>
+        /// <param name="security">The security flags to apply.</param>
         /// <param name="isFrameContext">Whether the child context is for a frame.</param>
         /// <returns></returns>
-        public IBrowsingContext CreateChild(String? name, Sandboxes security, Boolean isFrameContext = false)
+        internal IBrowsingContext CreateChild(String? name, Sandboxes security, Boolean isFrameContext)
         {
             var context = new BrowsingContext(this, security, isFrameContext);
 

--- a/src/AngleSharp/BrowsingContext.cs
+++ b/src/AngleSharp/BrowsingContext.cs
@@ -18,6 +18,7 @@ namespace AngleSharp
         private readonly Sandboxes _security;
         private readonly IBrowsingContext? _parent;
         private readonly IDocument? _creator;
+        private readonly Boolean _isFrameContext;
         private readonly IHistory? _history;
         private readonly Dictionary<String, WeakReference<IBrowsingContext>> _children;
 
@@ -54,11 +55,12 @@ namespace AngleSharp
             _history = GetService<IHistory>();
         }
 
-        internal BrowsingContext(IBrowsingContext parent, Sandboxes security)
+        internal BrowsingContext(IBrowsingContext parent, Sandboxes security, Boolean isFrameContext)
             : this(parent.OriginalServices, security)
         {
             _parent = parent;
             _creator = _parent.Active;
+            _isFrameContext = isFrameContext;
         }
 
         #endregion
@@ -97,6 +99,13 @@ namespace AngleSharp
         /// documents.
         /// </summary>
         public IBrowsingContext? Parent => _parent;
+
+        /// <summary>
+        /// Determines if the current context is for a frame rather than
+        /// a window. Useful for properly determining the proper target
+        /// for `_top` and `_parent`.
+        ///</summary>
+        public Boolean IsFrame => _isFrameContext;
 
         /// <summary>
         /// Gets the session history of the given browsing context, if any.
@@ -181,10 +190,11 @@ namespace AngleSharp
         /// </summary>
         /// <param name="name">The name of the child context, if any.</param>
         /// <param name="security">The security flags to apply.</param>
+        /// <param name="isFrameContext">Whether the child context is for a frame.</param>
         /// <returns></returns>
-        public IBrowsingContext CreateChild(String? name, Sandboxes security)
+        public IBrowsingContext CreateChild(String? name, Sandboxes security, Boolean isFrameContext = false)
         {
-            var context = new BrowsingContext(this, security);
+            var context = new BrowsingContext(this, security, isFrameContext);
 
             if (name is { Length: > 0 })
             {

--- a/src/AngleSharp/BrowsingContextExtensions.cs
+++ b/src/AngleSharp/BrowsingContextExtensions.cs
@@ -500,11 +500,27 @@ namespace AngleSharp
             }
             else if (target is "_parent")
             {
-                return context.Parent ?? context;
+                // A frame context should always have a parent.
+                if (context.IsFrame)
+                {
+                    return context.Parent!;
+                }
+                // A window context should target itself as a parent
+                // even if it has another parent window.
+                return context;
             }
             else if (target is  "_top")
             {
-                return context;
+                var targetContext = context;
+                // Keep walking up the tree until we find a non-frame context.
+                // Given that it should not be possible to create a circular
+                // chain, and that a frame context cannot be created without
+                // a parent, this should be fine.
+                while (targetContext is { IsFrame: true })
+                {
+                    targetContext = targetContext.Parent;
+                }
+                return targetContext;
             }
 
             return context.FindChild(target);

--- a/src/AngleSharp/BrowsingContextExtensions.cs
+++ b/src/AngleSharp/BrowsingContextExtensions.cs
@@ -501,7 +501,7 @@ namespace AngleSharp
             else if (target is "_parent")
             {
                 // A frame context should always have a parent.
-                if (context.IsFrame)
+                if (context is BrowsingContext { IsFrame: true })
                 {
                     return context.Parent!;
                 }
@@ -516,7 +516,7 @@ namespace AngleSharp
                 // Given that it should not be possible to create a circular
                 // chain, and that a frame context cannot be created without
                 // a parent, this should be fine.
-                while (targetContext is { IsFrame: true })
+                while (targetContext is BrowsingContext { IsFrame: true })
                 {
                     targetContext = targetContext.Parent;
                 }

--- a/src/AngleSharp/Html/Dom/Internal/HtmlFrameElementBase.cs
+++ b/src/AngleSharp/Html/Dom/Internal/HtmlFrameElementBase.cs
@@ -50,7 +50,7 @@ namespace AngleSharp.Html.Dom
             set => this.SetOwnAttribute(AttributeNames.Scrolling, value);
         }
 
-        public IDocument? ContentDocument => _request?.Document;
+        public IDocument? ContentDocument => _context?.Active;
 
         public String? LongDesc
         {
@@ -79,6 +79,7 @@ namespace AngleSharp.Html.Dom
         {
             base.SetupElement();
 
+            _context ??= NewChildContext();
             if (this.GetOwnAttribute(AttributeNames.Src) != null)
             {
                 UpdateSource();

--- a/src/AngleSharp/Html/Dom/Internal/HtmlFrameElementBase.cs
+++ b/src/AngleSharp/Html/Dom/Internal/HtmlFrameElementBase.cs
@@ -104,7 +104,7 @@ namespace AngleSharp.Html.Dom
         private IBrowsingContext NewChildContext()
         {
             //TODO
-            var childContext = Context.CreateChild(null, Sandboxes.None, true);
+            var childContext = Context.CreateChild(Name, Sandboxes.None, true);
             Owner.AttachReference(childContext);
             return childContext;
         }

--- a/src/AngleSharp/Html/Dom/Internal/HtmlFrameElementBase.cs
+++ b/src/AngleSharp/Html/Dom/Internal/HtmlFrameElementBase.cs
@@ -104,7 +104,7 @@ namespace AngleSharp.Html.Dom
         private IBrowsingContext NewChildContext()
         {
             //TODO
-            var childContext = Context.CreateChild(null, Sandboxes.None);
+            var childContext = Context.CreateChild(null, Sandboxes.None, true);
             Owner.AttachReference(childContext);
             return childContext;
         }

--- a/src/AngleSharp/Html/Dom/Internal/HtmlFrameElementBase.cs
+++ b/src/AngleSharp/Html/Dom/Internal/HtmlFrameElementBase.cs
@@ -104,8 +104,15 @@ namespace AngleSharp.Html.Dom
 
         private IBrowsingContext NewChildContext()
         {
-            //TODO
-            var childContext = Context.CreateChild(Name, Sandboxes.None, true);
+            var childContext = default(IBrowsingContext);
+            if (Context is BrowsingContext context)
+            {
+                childContext  = context.CreateChild(Name, Sandboxes.None, true);
+            }
+            else
+            {
+                childContext  = Context.CreateChild(Name, Sandboxes.None);
+            }
             Owner.AttachReference(childContext);
             return childContext;
         }

--- a/src/AngleSharp/IBrowsingContext.cs
+++ b/src/AngleSharp/IBrowsingContext.cs
@@ -39,6 +39,13 @@ namespace AngleSharp
         IBrowsingContext? Parent { get; }
 
         /// <summary>
+        /// Determines if the current context is for a frame rather than
+        /// a window. Useful for properly determining the proper target
+        /// for `_top` and `_parent`.
+        ///</summary>
+        Boolean IsFrame { get; }
+
+        /// <summary>
         /// Gets the document that created the current context, if any. The
         /// creator is the active document of the parent at the time of
         /// creation.
@@ -70,8 +77,9 @@ namespace AngleSharp
         /// </summary>
         /// <param name="name">The name of the new context.</param>
         /// <param name="security">The sandboxing flag to use.</param>
+        /// <param name="isFrameContext">Whether the child context is for a frame.</param>
         /// <returns>The created browsing context.</returns>
-        IBrowsingContext CreateChild(String? name, Sandboxes security);
+        IBrowsingContext CreateChild(String? name, Sandboxes security, Boolean isFrameContext = false);
 
         /// <summary>
         /// Tries to find a browsing context with the given name.

--- a/src/AngleSharp/IBrowsingContext.cs
+++ b/src/AngleSharp/IBrowsingContext.cs
@@ -39,13 +39,6 @@ namespace AngleSharp
         IBrowsingContext? Parent { get; }
 
         /// <summary>
-        /// Determines if the current context is for a frame rather than
-        /// a window. Useful for properly determining the proper target
-        /// for `_top` and `_parent`.
-        ///</summary>
-        Boolean IsFrame { get; }
-
-        /// <summary>
         /// Gets the document that created the current context, if any. The
         /// creator is the active document of the parent at the time of
         /// creation.
@@ -77,9 +70,8 @@ namespace AngleSharp
         /// </summary>
         /// <param name="name">The name of the new context.</param>
         /// <param name="security">The sandboxing flag to use.</param>
-        /// <param name="isFrameContext">Whether the child context is for a frame.</param>
         /// <returns>The created browsing context.</returns>
-        IBrowsingContext CreateChild(String? name, Sandboxes security, Boolean isFrameContext = false);
+        IBrowsingContext CreateChild(String? name, Sandboxes security);
 
         /// <summary>
         /// Tries to find a browsing context with the given name.

--- a/src/AngleSharp/Io/Processors/DocumentRequestProcessor.cs
+++ b/src/AngleSharp/Io/Processors/DocumentRequestProcessor.cs
@@ -39,7 +39,7 @@ namespace AngleSharp.Io.Processors
 
         protected override async Task ProcessResponseAsync(IResponse response)
         {
-            var context = new BrowsingContext(_context, Sandboxes.None);
+            var context = new BrowsingContext(_context, Sandboxes.None, false);
             var encoding = _context.GetDefaultEncoding();
             var options = new CreateDocumentOptions(response, encoding, _parentDocument);
             var factory = _context.GetFactory<IDocumentFactory>();


### PR DESCRIPTION
# Types of Changes

## Prerequisites

Please make sure you can check the following two boxes:

- [x] I have read the **CONTRIBUTING** document
- [x] My code follows the code style of this project

## Contribution Type

What types of changes does your code introduce? Put an `x` in all the boxes that apply:

- [ ] Bug fix (non-breaking change which fixes an issue, please reference the issue id)
- [ ] New feature (non-breaking change which adds functionality, make sure to open an associated issue first)
- [x] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] My change requires a change to the documentation
- [ ] I have updated the documentation accordingly
- [x] I have added tests to cover my changes
- [ ] All new and existing tests passed

## Description

Currently, a named iframe creates an unnamed child browsing context, and a link or form which targets the iframe will instead create a separate named child browsing context not associated with the iframe.  Also, the `_top` target should target the "window" browsing context containing the current context, and "_parent" should not target the parent context if the current browsing context is a "window" context.

This pull request is a breaking change as it will change how child browsing context are created, as well as changing most current behavior when clicking a link or button which has a target defined.

Fixes #1205
