### PR TITLE
Issue 1210 isstepmismatch validation

### DIFF
--- a/src/AngleSharp.Core.Tests/Html/ValidityStepMismatch.cs
+++ b/src/AngleSharp.Core.Tests/Html/ValidityStepMismatch.cs
@@ -673,7 +673,7 @@ namespace AngleSharp.Core.Tests.Html
             element.RemoveAttribute("selected");
             
             element.SetAttribute("min", "-124.763068");
-            element.SetAttribute("step", ".000007");
+            element.SetAttribute("step", "0.000007");
             element.Value = "-117.000012"; // valid
 
             Assert.AreEqual("number", element.Type);
@@ -700,7 +700,7 @@ namespace AngleSharp.Core.Tests.Html
             element.RemoveAttribute("selected");
 
             element.SetAttribute("min", "124.763");
-            element.SetAttribute("step", ".002");
+            element.SetAttribute("step", "0.002");
             element.Value = "124.764";  // invalid
 
             Assert.AreEqual("number", element.Type);

--- a/src/AngleSharp.Core.Tests/Html/ValidityStepMismatch.cs
+++ b/src/AngleSharp.Core.Tests/Html/ValidityStepMismatch.cs
@@ -395,7 +395,7 @@ namespace AngleSharp.Core.Tests.Html
             element.RemoveAttribute("multiple");
             element.RemoveAttribute("checked");
             element.RemoveAttribute("selected");
-            element.SetAttribute("step", "");   // todo: default to 1
+            element.SetAttribute("step", "");
             element.Value = "1970-W01";
             Assert.AreEqual("week", element.Type);
             Assert.AreEqual(false, element.Validity.IsStepMismatch);

--- a/src/AngleSharp.Core.Tests/Html/ValidityStepMismatch.cs
+++ b/src/AngleSharp.Core.Tests/Html/ValidityStepMismatch.cs
@@ -673,14 +673,13 @@ namespace AngleSharp.Core.Tests.Html
             element.RemoveAttribute("selected");
             
             element.SetAttribute("min", "-124.763068");
-            element.SetAttribute("step", ".000001");
-            element.Value = "-117";
+            element.SetAttribute("step", ".000007");
+            element.Value = "-117.000012"; // valid
 
             Assert.AreEqual("number", element.Type);
             Assert.AreEqual(true, element.Validity.IsValid);
             Assert.AreEqual(false, element.Validity.IsStepMismatch);
         }
-
 
         [Test]
         public void TestStepmismatchInputNumber6()
@@ -702,7 +701,7 @@ namespace AngleSharp.Core.Tests.Html
 
             element.SetAttribute("min", "124.763");
             element.SetAttribute("step", ".002");
-            element.Value = "124";
+            element.Value = "124.764";  // invalid
 
             Assert.AreEqual("number", element.Type);
             Assert.AreEqual(false, element.Validity.IsValid);

--- a/src/AngleSharp.Core.Tests/Html/ValidityStepMismatch.cs
+++ b/src/AngleSharp.Core.Tests/Html/ValidityStepMismatch.cs
@@ -395,7 +395,7 @@ namespace AngleSharp.Core.Tests.Html
             element.RemoveAttribute("multiple");
             element.RemoveAttribute("checked");
             element.RemoveAttribute("selected");
-            element.SetAttribute("step", "");
+            element.SetAttribute("step", "");   // todo: default to 1
             element.Value = "1970-W01";
             Assert.AreEqual("week", element.Type);
             Assert.AreEqual(false, element.Validity.IsStepMismatch);
@@ -651,6 +651,61 @@ namespace AngleSharp.Core.Tests.Html
             element.SetAttribute("step", "2");
             element.Value = "3";
             Assert.AreEqual("number", element.Type);
+            Assert.AreEqual(true, element.Validity.IsStepMismatch);
+        }
+
+        [Test]
+        public void TestStepmismatchInputNumber5()
+        {
+            var document = ("").ToHtmlDocument();
+            var element = document.CreateElement("input") as HtmlInputElement;
+            Assert.IsNotNull(element);
+            element.Type = "number";
+            element.RemoveAttribute("required");
+            element.RemoveAttribute("pattern");
+            element.RemoveAttribute("step");
+            element.RemoveAttribute("max");
+            element.RemoveAttribute("min");
+            element.RemoveAttribute("maxlength");
+            element.RemoveAttribute("value");
+            element.RemoveAttribute("multiple");
+            element.RemoveAttribute("checked");
+            element.RemoveAttribute("selected");
+            
+            element.SetAttribute("min", "-124.763068");
+            element.SetAttribute("step", ".000001");
+            element.Value = "-117";
+
+            Assert.AreEqual("number", element.Type);
+            Assert.AreEqual(true, element.Validity.IsValid);
+            Assert.AreEqual(false, element.Validity.IsStepMismatch);
+        }
+
+
+        [Test]
+        public void TestStepmismatchInputNumber6()
+        {
+            var document = ("").ToHtmlDocument();
+            var element = document.CreateElement("input") as HtmlInputElement;
+            Assert.IsNotNull(element);
+            element.Type = "number";
+            element.RemoveAttribute("required");
+            element.RemoveAttribute("pattern");
+            element.RemoveAttribute("step");
+            element.RemoveAttribute("max");
+            element.RemoveAttribute("min");
+            element.RemoveAttribute("maxlength");
+            element.RemoveAttribute("value");
+            element.RemoveAttribute("multiple");
+            element.RemoveAttribute("checked");
+            element.RemoveAttribute("selected");
+
+            element.SetAttribute("min", "124.763");
+            element.SetAttribute("step", ".002");
+            element.Value = "124";
+
+            Assert.AreEqual("number", element.Type);
+            Assert.AreEqual(false, element.Validity.IsValid);
             Assert.AreEqual(true, element.Validity.IsStepMismatch);
         }
     }

--- a/src/AngleSharp/Html/InputTypes/BaseInputType.cs
+++ b/src/AngleSharp/Html/InputTypes/BaseInputType.cs
@@ -142,9 +142,10 @@ namespace AngleSharp.Html.InputTypes
         protected Boolean IsStepMismatch()
         {
             var step = GetStep();
-            var value = ConvertToNumber(_input.Value);
+            var value = ConvertToNumber(_input.Value) ?? default;
             var offset = GetStepBase();
-            return step != 0.0 && (value - offset) % step != 0.0;
+
+            return step != 0.0 && Math.Floor((value - offset) % step) != 0.0;
         }
 
         /// <summary>

--- a/src/AngleSharp/Html/InputTypes/BaseInputType.cs
+++ b/src/AngleSharp/Html/InputTypes/BaseInputType.cs
@@ -141,11 +141,11 @@ namespace AngleSharp.Html.InputTypes
         /// </summary>
         protected Boolean IsStepMismatch()
         {
-            var step = GetStep();
-            var value = ConvertToNumber(_input.Value) ?? default;
-            var offset = GetStepBase();
+            var step = (Decimal)GetStep();
+            var value = (Decimal)(ConvertToNumber(_input.Value) ?? 0);
+            var offset = (Decimal)GetStepBase();
 
-            return step != 0.0 && Math.Floor((value - offset) % step) != 0.0;
+            return step != Decimal.Zero && (value - offset) % step != Decimal.Zero;
         }
 
         /// <summary>


### PR DESCRIPTION
# Types of Changes

## Prerequisites

Please make sure you can check the following two boxes:

- [x] I have read the **CONTRIBUTING** document
- [x] My code follows the code style of this project

## Contribution Type

What types of changes does your code introduce? Put an `x` in all the boxes that apply:

- [x] Bug fix (non-breaking change which fixes an issue, please reference the issue id)
- [x] New feature (non-breaking change which adds functionality, make sure to open an associated issue first)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] My change requires a change to the documentation
- [ ] I have updated the documentation accordingly
- [x] I have added tests to cover my changes
- [x] All new and existing tests passed

## Description

Fix issue #1210 IsStepMismatch validation not valid with floating point numbers. Does not match expected documented behavior or that of browsers.

Modified `BasicTypeInput` `IsStepMismatch()` method to handle floating-point numbers more appropriately. Added two tests to prove assertions of both valid and invalid floating-point numbers are made as expected. In addition to automated testing, verified tests match validity state of same elements in chromium browser.
