### PR TITLE
INode.HasChildNodes is now exposed as a method to DOM

### DIFF
--- a/src/AngleSharp/Attributes/Accessors.cs
+++ b/src/AngleSharp/Attributes/Accessors.cs
@@ -31,6 +31,10 @@
         /// <summary>
         /// Specifies that the method should be handled by an event remover.
         /// </summary>
-        Remover = 0x10
+        Remover = 0x10,
+        /// <summary>
+        /// Specifies that the getter only property should be handled by a method.
+        /// </summary>
+        Method = 0x20,
     }
 }

--- a/src/AngleSharp/Dom/INode.cs
+++ b/src/AngleSharp/Dom/INode.cs
@@ -198,6 +198,7 @@ namespace AngleSharp.Dom
         /// Gets an indicator if the element has any child nodes, or not.
         /// </summary>
         [DomName("hasChildNodes")]
+        [DomAccessor(Accessors.Method)]
         [MemberNotNullWhen(true, nameof(ChildNodes), nameof(FirstChild), nameof(LastChild))]
         Boolean HasChildNodes { get; }
 


### PR DESCRIPTION
# Types of Changes

## Prerequisites

Please make sure you can check the following two boxes:

- [x] I have read the **CONTRIBUTING** document
- [x] My code follows the code style of this project

## Contribution Type

What types of changes does your code introduce? Put an `x` in all the boxes that apply:

- [x] Bug fix (non-breaking change which fixes an issue, please reference the issue id)
- [x] New feature (non-breaking change which adds functionality, make sure to open an associated issue first)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] My change requires a change to the documentation
- [ ] I have updated the documentation accordingly
- [ ] I have added tests to cover my changes
- [x] All new and existing tests passed

## Description

Fixes #1219

`Accessors` enum has now a new member: `Method`. This was required to expose `HasChildNodes` to DOM as a method, instead as a getter-only property.

Current pull request is only a part of the fix. Seconds part: AngleSharp/AngleSharp.Js#106
