### PR TITLE
Have IHtmlCollection<T> implement IReadOnlyList<T>

### DIFF
--- a/src/AngleSharp/Dom/IHtmlCollection.cs
+++ b/src/AngleSharp/Dom/IHtmlCollection.cs
@@ -1,43 +1,56 @@
-namespace AngleSharp.Dom
+namespace AngleSharp.Dom;
+
+using AngleSharp.Attributes;
+using System;
+using System.Collections.Generic;
+
+/// <summary>
+/// HTMLCollection is an interface representing a generic collection
+/// (array) of elements (in document order) and offers methods and
+/// properties for selecting from the list.
+/// </summary>
+[DomName("HTMLCollection")]
+public interface IHtmlCollection<T> :
+#if NET8_0_OR_GREATER
+    IReadOnlyList<T>
+#else
+    IEnumerable<T>
+#endif
+
+    where T : IElement
 {
-    using AngleSharp.Attributes;
-    using System;
-    using System.Collections.Generic;
+    /// <summary>
+    /// Gets the number of items in the collection.
+    /// </summary>
+    [DomName("length")]
+    Int32 Length { get; }
 
     /// <summary>
-    /// HTMLCollection is an interface representing a generic collection
-    /// (array) of elements (in document order) and offers methods and
-    /// properties for selecting from the list.
+    /// Gets the specific node at the given zero-based index into the list.
     /// </summary>
-    [DomName("HTMLCollection")]
-    public interface IHtmlCollection<T> : IEnumerable<T>
-        where T : IElement
-    {
-        /// <summary>
-        /// Gets the number of items in the collection.
-        /// </summary>
-        [DomName("length")]
-        Int32 Length { get; }
+    /// <param name="index">The zero-based index.</param>
+    /// <returns>Returns the element at the specified index.</returns>
+    [DomName("item")]
+    [DomAccessor(Accessors.Getter)]
+#if NET8_0_OR_GREATER
+    abstract T IReadOnlyList<T>.this[Int32 index] { get; }
+#else
+    T this[Int32 index] { get; }
+#endif
 
-        /// <summary>
-        /// Gets the specific node at the given zero-based index into the list.
-        /// </summary>
-        /// <param name="index">The zero-based index.</param>
-        /// <returns>Returns the element at the specified index.</returns>
-        [DomName("item")]
-        [DomAccessor(Accessors.Getter)]
-        T this[Int32 index] { get; }
+    /// <summary>
+    /// Gets the specific node whose ID or, as a fallback, name matches the
+    /// string specified by name. Matching by name is only done as a last
+    /// resort, only in HTML, and only if the referenced element supports 
+    /// the name attribute.
+    /// </summary>
+    /// <param name="id">The id or name to match.</param>
+    /// <returns>Returns the element with the specified name.</returns>
+    [DomName("namedItem")]
+    [DomAccessor(Accessors.Getter)]
+    T? this[String id] { get; }
 
-        /// <summary>
-        /// Gets the specific node whose ID or, as a fallback, name matches the
-        /// string specified by name. Matching by name is only done as a last
-        /// resort, only in HTML, and only if the referenced element supports 
-        /// the name attribute.
-        /// </summary>
-        /// <param name="id">The id or name to match.</param>
-        /// <returns>Returns the element with the specified name.</returns>
-        [DomName("namedItem")]
-        [DomAccessor(Accessors.Getter)]
-        T? this[String id] { get; }
-    }
+#if NET8_0_OR_GREATER
+    Int32 IReadOnlyCollection<T>.Count => Length;
+#endif
 }

--- a/src/AngleSharp/Dom/IStringList.cs
+++ b/src/AngleSharp/Dom/IStringList.cs
@@ -1,38 +1,50 @@
-﻿namespace AngleSharp.Dom
+namespace AngleSharp.Dom;
+
+using AngleSharp.Attributes;
+using System;
+using System.Collections.Generic;
+
+/// <summary>
+/// Represents a string list.
+/// </summary>
+[DomName("DOMStringList")]
+public interface IStringList :
+#if NET8_0_OR_GREATER
+    IReadOnlyList<String>
+#else
+    IEnumerable<String>
+#endif
 {
-    using AngleSharp.Attributes;
-    using System;
-    using System.Collections.Generic;
+    /// <summary>
+    /// Gets the value at the specified index.
+    /// </summary>
+    /// <param name="index">The index of the value.</param>
+    /// <returns>The string value at the given index.</returns>
+    [DomName("item")]
+    [DomAccessor(Accessors.Getter)]
+#if NET8_0_OR_GREATER
+    abstract String IReadOnlyList<String>.this[Int32 index] { get; }
+#else
+    String this[Int32 index] { get; }
+#endif
 
     /// <summary>
-    /// Represents a string list.
+    /// Gets the number of entries.
     /// </summary>
-    [DomName("DOMStringList")]
-    public interface IStringList : IEnumerable<String>
-    {
-        /// <summary>
-        /// Gets the value at the specified index.
-        /// </summary>
-        /// <param name="index">The index of the value.</param>
-        /// <returns>The string value at the given index.</returns>
-        [DomName("item")]
-        [DomAccessor(Accessors.Getter)]
-        String this[Int32 index] { get; }
-        
-        /// <summary>
-        /// Gets the number of entries.
-        /// </summary>
-        [DomName("length")]
-        Int32 Length { get; }
-        
-        /// <summary>
-        /// Returns a boolean indicating if the specified entry is available.
-        /// </summary>
-        /// <param name="entry">The entry that will be looked for.</param>
-        /// <returns>
-        /// True if the element is available, otherwise false.
-        /// </returns>
-        [DomName("contains")]
-        Boolean Contains(String entry);
-    }
+    [DomName("length")]
+    Int32 Length { get; }
+
+    /// <summary>
+    /// Returns a boolean indicating if the specified entry is available.
+    /// </summary>
+    /// <param name="entry">The entry that will be looked for.</param>
+    /// <returns>
+    /// True if the element is available, otherwise false.
+    /// </returns>
+    [DomName("contains")]
+    Boolean Contains(String entry);
+
+#if NET8_0_OR_GREATER
+    Int32 IReadOnlyCollection<String>.Count => Length;
+#endif
 }

--- a/src/AngleSharp/Dom/ITokenList.cs
+++ b/src/AngleSharp/Dom/ITokenList.cs
@@ -1,63 +1,75 @@
-﻿namespace AngleSharp.Dom
+namespace AngleSharp.Dom;
+
+using AngleSharp.Attributes;
+using System;
+using System.Collections.Generic;
+
+/// <summary>
+/// This type represents a set of space-separated tokens.
+/// </summary>
+[DomName("DOMTokenList")]
+public interface ITokenList :
+#if NET8_0_OR_GREATER
+    IReadOnlyList<String>
+#else
+    IEnumerable<String>
+#endif
 {
-    using AngleSharp.Attributes;
-    using System;
-    using System.Collections.Generic;
+    /// <summary>
+    /// Gets the number of contained tokens.
+    /// </summary>
+    [DomName("length")]
+    Int32 Length { get; }
 
     /// <summary>
-    /// This type represents a set of space-separated tokens.
+    /// Gets an item in the list by its index.
     /// </summary>
-    [DomName("DOMTokenList")]
-    public interface ITokenList : IEnumerable<String>
-    {
-        /// <summary>
-        /// Gets the number of contained tokens.
-        /// </summary>
-        [DomName("length")]
-        Int32 Length { get; }
+    /// <param name="index">The index of the item.</param>
+    /// <returns>The item at the specified index.</returns>
+    [DomName("item")]
+    [DomAccessor(Accessors.Getter)]
+#if NET8_0_OR_GREATER
+    abstract String IReadOnlyList<String>.this[Int32 index] { get; }
+#else
+    String this[Int32 index] { get; }
+#endif
 
-        /// <summary>
-        /// Gets an item in the list by its index.
-        /// </summary>
-        /// <param name="index">The index of the item.</param>
-        /// <returns>The item at the specified index.</returns>
-        [DomName("item")]
-        [DomAccessor(Accessors.Getter)]
-        String this[Int32 index] { get; }
+    /// <summary>
+    /// Returns true if the underlying string contains a token, otherwise
+    /// false.
+    /// </summary>
+    /// <param name="token">The token to search for.</param>
+    /// <returns>The result of the search.</returns>
+    [DomName("contains")]
+    Boolean Contains(String token);
 
-        /// <summary>
-        /// Returns true if the underlying string contains a token, otherwise
-        /// false.
-        /// </summary>
-        /// <param name="token">The token to search for.</param>
-        /// <returns>The result of the search.</returns>
-        [DomName("contains")]
-        Boolean Contains(String token);
+    /// <summary>
+    /// Adds some tokens to the underlying string.
+    /// </summary>
+    /// <param name="tokens">A list of tokens to add.</param>
+    [DomName("add")]
+    void Add(params String[] tokens);
 
-        /// <summary>
-        /// Adds some tokens to the underlying string.
-        /// </summary>
-        /// <param name="tokens">A list of tokens to add.</param>
-        [DomName("add")]
-        void Add(params String[] tokens);
+    /// <summary>
+    /// Remove some tokens from the underlying string.
+    /// </summary>
+    /// <param name="tokens">A list of tokens to remove.</param>
+    [DomName("remove")]
+    void Remove(params String[] tokens);
 
-        /// <summary>
-        /// Remove some tokens from the underlying string.
-        /// </summary>
-        /// <param name="tokens">A list of tokens to remove.</param>
-        [DomName("remove")]
-        void Remove(params String[] tokens);
+    /// <summary>
+    /// Removes the specified token from string and returns false.
+    /// If token doesn't exist it's added and the function returns true.
+    /// </summary>
+    /// <param name="token">The token to toggle.</param>
+    /// <param name="force"></param>
+    /// <returns>
+    /// True if the token has been added, otherwise false.
+    /// </returns>
+    [DomName("toggle")]
+    Boolean Toggle(String token, Boolean force = false);
 
-        /// <summary>
-        /// Removes the specified token from string and returns false.
-        /// If token doesn't exist it's added and the function returns true.
-        /// </summary>
-        /// <param name="token">The token to toggle.</param>
-        /// <param name="force"></param>
-        /// <returns>
-        /// True if the token has been added, otherwise false.
-        /// </returns>
-        [DomName("toggle")]
-        Boolean Toggle(String token, Boolean force = false);
-    }
+#if NET8_0_OR_GREATER
+    Int32 IReadOnlyCollection<String>.Count => Length;
+#endif
 }

--- a/src/AngleSharp/Dom/Internal/HtmlFormControlsCollection.cs
+++ b/src/AngleSharp/Dom/Internal/HtmlFormControlsCollection.cs
@@ -63,7 +63,11 @@ namespace AngleSharp.Dom
 
         IEnumerator IEnumerable.GetEnumerator() => _elements.GetEnumerator();
 
+#if NET8_0_OR_GREATER
+        IHtmlElement IReadOnlyList<IHtmlElement>.this[Int32 index] => this[index];
+#else
         IHtmlElement IHtmlCollection<IHtmlElement>.this[Int32 index] => this[index];
+#endif
 
         IHtmlElement? IHtmlCollection<IHtmlElement>.this[String id] => this[id];
 

--- a/src/AngleSharp/Html/Dom/IHtmlFormControlsCollection.cs
+++ b/src/AngleSharp/Html/Dom/IHtmlFormControlsCollection.cs
@@ -1,7 +1,9 @@
-﻿namespace AngleSharp.Html.Dom
+namespace AngleSharp.Html.Dom
 {
     using AngleSharp.Attributes;
     using AngleSharp.Dom;
+    using System;
+    using System.Collections.Generic;
 
     /// <summary>
     /// Represents a collection of HTML form controls.


### PR DESCRIPTION
# Types of Changes
Makes the `IHTmlCollection<T>` interface implement `IReadOnlyList<T>`, which is the conventional interface for types that expose a count property and enables index access, features that `IHtmlCollection<T>` already provides.

Closes #1226

## Prerequisites

Please make sure you can check the following two boxes:

- [x] I have read the **CONTRIBUTING** document
- [x] My code follows the code style of this project

## Contribution Type

What types of changes does your code introduce? Put an `x` in all the boxes that apply:

- [ ] Bug fix (non-breaking change which fixes an issue, please reference the issue id)
- [x] New feature (non-breaking change which adds functionality, make sure to open an associated issue first)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] My change requires a change to the documentation
- [ ] I have updated the documentation accordingly
- [ ] I have added tests to cover my changes
- [x] All new and existing tests passed

## Description

Upgrades `IHtmlCollection<T>` to implement `IReadOnlyList<T>` instead of just `IEnumerable<T>` since it already implements all its functionality.