### PR TITLE
Add `ISvgStyleElement` and the associated implementation

### DIFF
--- a/src/AngleSharp.Core.Tests/Css/StyleExtensions.cs
+++ b/src/AngleSharp.Core.Tests/Css/StyleExtensions.cs
@@ -1,5 +1,12 @@
 namespace AngleSharp.Core.Tests.Css
 {
+    using AngleSharp.Css;
+    using AngleSharp.Css.Dom;
+    using AngleSharp.Dom;
+    using AngleSharp.Html.Parser;
+    using AngleSharp.Io;
+    using AngleSharp.Text;
+    using NUnit.Framework;
     using System;
     using System.Collections;
     using System.Collections.Generic;
@@ -7,14 +14,6 @@ namespace AngleSharp.Core.Tests.Css
     using System.Linq;
     using System.Threading;
     using System.Threading.Tasks;
-    using AngleSharp.Css;
-    using AngleSharp.Css.Dom;
-    using AngleSharp.Html.Parser;
-    using AngleSharp.Io;
-    using Dom;
-    using Mocks;
-    using NUnit.Framework;
-    using Text;
 
     public class StylesheetExtensions
     {
@@ -24,7 +23,7 @@ namespace AngleSharp.Core.Tests.Css
         [TestCase(10000)]
         public void TestStyleSheetsDoesNotThrowStackOverflowException(Int32 count)
         {
-            var thread = new Thread( () =>
+            var thread = new Thread(() =>
             {
                 var beginTags = String.Join("", Enumerable.Repeat("<div>", count));
                 var endTags = String.Join("", Enumerable.Repeat("</div>", count));
@@ -53,7 +52,7 @@ namespace AngleSharp.Core.Tests.Css
             var stylingService = new MockStylingService();
             var cfg = Configuration.Default
                                         .WithOnly<IStylingService>(stylingService)
-                                        .WithMockRequester(req => request = req );
+                                        .WithMockRequester(req => request = req);
             var html = @"<!doctype html><head><link rel=stylesheet href=/mock-stylesheet-1.css /></head><body></body>";
             var document = await BrowsingContext.New(cfg).OpenAsync(m => m.Content(html));
 
@@ -72,6 +71,49 @@ namespace AngleSharp.Core.Tests.Css
 
             Assert.IsNotNull(request);
             Assert.AreEqual("/mock-stylesheet-2.css", request.Address.PathName);
+        }
+
+        [Test]
+        public async Task HtmlInlineStyleSheetShouldLoad()
+        {
+            var stylingService = new MockStylingService();
+            var cfg = Configuration.Default.WithOnly<IStylingService>(stylingService);
+            var html = @"<!doctype html><head><style>p { color: blue; }</style></head><body></body>";
+            var document = await BrowsingContext.New(cfg).OpenAsync(m => m.Content(html));
+
+            Assert.AreEqual(1, document.Head.ChildNodes.Length);
+
+            var htmlHeadStyle = document.Head.ChildNodes[0];
+            Assert.AreEqual("style", htmlHeadStyle.GetTagName());
+            Assert.AreEqual(NodeType.Element, htmlHeadStyle.NodeType);
+
+            var style = htmlHeadStyle as ILinkStyle;
+            Assert.IsNotNull(style);
+            Assert.AreEqual(style.Sheet.OwnerNode.TextContent, "p { color: blue; }");
+        }
+
+        [Test]
+        public async Task SvgInlineStyleSheetShouldLoad()
+        {
+            var stylingService = new MockStylingService();
+            var cfg = Configuration.Default.WithOnly<IStylingService>(stylingService);
+            var svg = @"<svg><style>circle { fill: gold; }</style></svg>";
+            var document = await BrowsingContext.New(cfg).OpenAsync(m => m.Content(svg));
+
+            Assert.AreEqual(1, document.Body.ChildNodes.Length);
+
+            var svgBodySvg = document.Body.ChildNodes[0];
+            Assert.AreEqual(1, svgBodySvg.ChildNodes.Length);
+            Assert.AreEqual("svg", svgBodySvg.GetTagName());
+            Assert.AreEqual(NodeType.Element, svgBodySvg.NodeType);
+
+            var svgBodySvgStyle = svgBodySvg.ChildNodes[0];
+            Assert.AreEqual("style", svgBodySvgStyle.GetTagName());
+            Assert.AreEqual(NodeType.Element, svgBodySvgStyle.NodeType);
+
+            var style = svgBodySvgStyle as ILinkStyle;
+            Assert.IsNotNull(style);
+            Assert.AreEqual(style.Sheet.OwnerNode.TextContent, "circle { fill: gold; }");
         }
     }
 

--- a/src/AngleSharp/Svg/Dom/ISvgStyleElement.cs
+++ b/src/AngleSharp/Svg/Dom/ISvgStyleElement.cs
@@ -1,0 +1,31 @@
+namespace AngleSharp.Svg.Dom
+{
+    using AngleSharp.Attributes;
+    using AngleSharp.Dom;
+    using System;
+
+    /// <summary>
+    /// Represents a style SVG element.
+    /// </summary>
+    [DomName("SVGStyleElement")]
+    public interface ISvgStyleElement : ISvgElement, ILinkStyle
+    {
+        /// <summary>
+        /// Gets or sets if the style is enabled or disabled.
+        /// </summary>
+        [DomName("disabled")]
+        Boolean IsDisabled { get; set; }
+
+        /// <summary>
+        /// Gets or sets the use with one or more target media.
+        /// </summary>
+        [DomName("media")]
+        String? Media { get; set; }
+
+        /// <summary>
+        /// Gets or sets the content type of the style sheet language.
+        /// </summary>
+        [DomName("type")]
+        String? Type { get; set; }
+    }
+}

--- a/src/AngleSharp/Svg/Dom/Internal/SvgStyleElement.cs
+++ b/src/AngleSharp/Svg/Dom/Internal/SvgStyleElement.cs
@@ -1,0 +1,129 @@
+namespace AngleSharp.Svg.Dom
+{
+    using AngleSharp.Css;
+    using AngleSharp.Dom;
+    using AngleSharp.Io;
+    using System;
+    using System.Threading;
+    using System.Threading.Tasks;
+
+    /// <summary>
+    /// Represents the SVG style element.
+    /// </summary>
+    sealed class SvgStyleElement : SvgElement, ISvgStyleElement
+    {
+        #region Fields
+
+        private IStyleSheet? _sheet;
+
+        #endregion
+
+        #region ctor
+
+        public SvgStyleElement(Document owner, String? prefix = null)
+            : base(owner, TagNames.Style, prefix, NodeFlags.Special | NodeFlags.LiteralText)
+        {
+        }
+
+        #endregion
+
+        #region Properties
+
+        public IStyleSheet? Sheet => _sheet;
+
+        public Boolean IsDisabled
+        {
+            get => this.GetBoolAttribute(AttributeNames.Disabled);
+            set
+            {
+                this.SetBoolAttribute(AttributeNames.Disabled, value);
+
+                if (_sheet != null)
+                {
+                    _sheet.IsDisabled = value;
+                }
+            }
+        }
+
+        public String? Media
+        {
+            get => this.GetOwnAttribute(AttributeNames.Media);
+            set => this.SetOwnAttribute(AttributeNames.Media, value);
+        }
+
+        public String? Type
+        {
+            get => this.GetOwnAttribute(AttributeNames.Type);
+            set => this.SetOwnAttribute(AttributeNames.Type, value);
+        }
+
+        #endregion
+
+        #region Internal Methods
+
+        internal override void SetupElement()
+        {
+            base.SetupElement();
+            UpdateSheet();
+        }
+
+        internal void UpdateMedia(String value)
+        {
+            if (_sheet != null)
+            {
+                _sheet.Media.MediaText = value;
+            }
+        }
+
+        #endregion
+
+        #region Helpers
+
+        protected override void NodeIsInserted(Node newNode)
+        {
+            base.NodeIsInserted(newNode);
+            UpdateSheet();
+        }
+
+        protected override void NodeIsRemoved(Node removedNode, Node? oldPreviousSibling)
+        {
+            base.NodeIsRemoved(removedNode, oldPreviousSibling);
+            UpdateSheet();
+        }
+
+        private void UpdateSheet()
+        {
+            var document = Owner;
+
+            if (document != null)
+            {
+                var context = Context;
+                var type = Type ?? MimeTypeNames.Css;
+                var engine = context.GetStyling(type);
+
+                if (engine != null)
+                {
+                    var task = CreateSheetAsync(engine, document);
+                    document.DelayLoad(task);
+                }
+            }
+        }
+
+        private async Task CreateSheetAsync(IStylingService engine, IDocument document)
+        {
+            var cancel = CancellationToken.None;
+            var response = VirtualResponse.Create(res => res.Content(TextContent).Address(default(Url)));
+            var options = new StyleOptions(document)
+            {
+                Element = this,
+                IsDisabled = IsDisabled,
+                IsAlternate = false,
+            };
+            var task = engine.ParseStylesheetAsync(response, options, cancel);
+            _sheet = await task.ConfigureAwait(false);
+            UpdateMedia(Media!);
+        }
+
+        #endregion
+    }
+}

--- a/src/AngleSharp/Svg/SvgElementFactory.cs
+++ b/src/AngleSharp/Svg/SvgElementFactory.cs
@@ -19,6 +19,7 @@ namespace AngleSharp.Svg
             { TagNames.Desc, (document, prefix) => new SvgDescElement(document, prefix) },
             { TagNames.ForeignObject, (document, prefix) => new SvgForeignObjectElement(document, prefix) },
             { TagNames.Title, (document, prefix) => new SvgTitleElement(document, prefix) },
+            { TagNames.Style, (document, prefix) => new SvgStyleElement(document, prefix) },
         };
 
         internal static readonly SvgElementFactory Instance = new();


### PR DESCRIPTION
# Types of Changes

## Prerequisites

Please make sure you can check the following two boxes:

- [x] I have read the **CONTRIBUTING** document
- [x] My code follows the code style of this project

## Contribution Type

What types of changes does your code introduce? Put an `x` in all the boxes that apply:

- [ ] Bug fix (non-breaking change which fixes an issue, please reference the issue id)
- [x] New feature (non-breaking change which adds functionality, make sure to open an associated issue first)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] My change requires a change to the documentation
- [ ] I have updated the documentation accordingly
- [x] I have added tests to cover my changes
- [x] All new and existing tests passed

## Description

The `IHtmlStyleElement` and its implementation serve as a reference here.

Added tests for the use case of inline style sheets in HTML and SVG documents.

Fixes #1232