### PR TITLE
HTML parser selector optimizations

### DIFF
--- a/src/AngleSharp/Common/BaseTokenizer.cs
+++ b/src/AngleSharp/Common/BaseTokenizer.cs
@@ -2,6 +2,7 @@ namespace AngleSharp.Common
 {
     using AngleSharp.Text;
     using System;
+    using System.Buffers;
     using System.Collections.Generic;
     using System.Text;
 
@@ -17,6 +18,7 @@ namespace AngleSharp.Common
         private readonly IReadOnlyTextSource _source;
         private readonly WritableTextSource? _wts;
         private readonly CharArrayTextSource? _cats;
+        private readonly ReadOnlyMemoryTextSource? _roms;
 
         private StringBuilder _stringBuilder;
         private IMutableCharBuffer _charBuffer;
@@ -59,6 +61,10 @@ namespace AngleSharp.Common
             else if (_source is CharArrayTextSource cats)
             {
                 _cats = cats;
+            }
+            else if (_source is ReadOnlyMemoryTextSource roms)
+            {
+                _roms = roms;
             }
 
             _current = Symbols.Null;
@@ -386,6 +392,92 @@ namespace AngleSharp.Common
             }
         }
 
+#if NET8_0_OR_GREATER
+        private static readonly SearchValues<Char> DataTextTerminators =
+            SearchValues.Create(['<', '&', '\0', '\r', '\n']);
+#endif
+
+        /// <summary>
+        /// Scans ahead in the underlying source for plain text runs,
+        /// bulk-appending characters until a DataText terminator is found.
+        /// Returns the next character that needs per-char handling.
+        /// </summary>
+        private protected Char ScanDataText()
+        {
+            ReadOnlySpan<Char> remaining;
+            Int32 index;
+
+            if (_cats is not null)
+            {
+                index = _cats.Index;
+                if (index >= _cats.Length) return GetNext();
+                remaining = _cats.Array.AsSpan(index, _cats.Length - index);
+            }
+            else if (_roms is not null)
+            {
+                index = _roms.Index;
+                if (index >= _roms.Length) return GetNext();
+                remaining = _roms.Memory.Span.Slice(index, _roms.Length - index);
+            }
+            else
+            {
+                return GetNext();
+            }
+
+#if NET8_0_OR_GREATER
+            var found = remaining.IndexOfAny(DataTextTerminators);
+#else
+            var found = remaining.IndexOfAny('<', '&', '\0');
+            var nlIdx = remaining.IndexOfAny('\r', '\n');
+            if (nlIdx >= 0 && (found < 0 || nlIdx < found))
+            {
+                found = nlIdx;
+            }
+#endif
+
+            var runLength = found <= 0 ? 0 : found;
+
+            if (runLength > 0)
+            {
+                var run = remaining.Slice(0, runLength);
+
+                if (_apb != null)
+                {
+                    _apb.Append(run);
+                }
+                else
+                {
+#if NETSTANDARD2_0 || NET462 || NET472
+                    for (var i = 0; i < run.Length; i++)
+                    {
+                        _sbb!._sb.Append(run[i]);
+                    }
+#else
+                    _sbb!._sb.Append(run);
+#endif
+                }
+
+                if (!_disableElementPositionTracking)
+                {
+                    _column += (UInt16)runLength;
+                }
+
+                var newIndex = index + runLength;
+                if (_cats is not null)
+                {
+                    _cats.Index = newIndex;
+                    _current = _cats.Array[newIndex - 1];
+                }
+                else
+                {
+                    _roms!.Index = newIndex;
+                    _current = _roms.Memory.Span[newIndex - 1];
+                }
+            }
+
+            return GetNext();
+        }
+
         #endregion
 
         #region Helpers
@@ -492,6 +584,11 @@ namespace AngleSharp.Common
             if (_cats is not null)
             {
                 return _cats.ReadCharacter();
+            }
+
+            if (_roms is not null)
+            {
+                return _roms.ReadCharacter();
             }
 
             return _source.ReadCharacter();

--- a/src/AngleSharp/Css/Parser/CssCombinator.cs
+++ b/src/AngleSharp/Css/Parser/CssCombinator.cs
@@ -120,19 +120,18 @@ namespace AngleSharp.Css.Parser
             public DescendantCombinator()
             {
                 Delimiter = CombinatorSymbols.Descendant;
-                Transform = el =>
+                Transform = GetAncestors;
+            }
+
+            private static IEnumerable<IElement> GetAncestors(IElement el)
+            {
+                var parent = el.ParentElement;
+
+                while (parent != null)
                 {
-                    var parents = new List<IElement>();
-                    var parent = el.ParentElement;
-
-                    while (parent != null)
-                    {
-                        parents.Add(parent);
-                        parent = parent.ParentElement;
-                    }
-
-                    return parents;
-                };
+                    yield return parent;
+                    parent = parent.ParentElement;
+                }
             }
         }
 

--- a/src/AngleSharp/Css/Parser/CssSelectorConstructor.cs
+++ b/src/AngleSharp/Css/Parser/CssSelectorConstructor.cs
@@ -7,6 +7,9 @@ namespace AngleSharp.Css.Parser
     using AngleSharp.Text;
     using System;
     using System.Collections.Generic;
+#if NET8_0_OR_GREATER
+    using System.Collections.Frozen;
+#endif
     using System.Globalization;
     using System.Linq;
 
@@ -18,7 +21,7 @@ namespace AngleSharp.Css.Parser
     {
         #region Fields
 
-        private static readonly Dictionary<String, Func<CssSelectorConstructor, FunctionState>> pseudoClassFunctions = new(StringComparer.OrdinalIgnoreCase)
+        private static readonly Dictionary<String, Func<CssSelectorConstructor, FunctionState>> _pseudoClassFunctionsDict = new(StringComparer.OrdinalIgnoreCase)
         {
             { PseudoClassNames.NthChild, ctx => new ChildFunctionState((step, offset, kind) => new FirstChildSelector(step, offset, kind), ctx, withOptionalSelector: true) },
             { PseudoClassNames.NthLastChild, ctx => new ChildFunctionState((step, offset, kind) => new LastChildSelector(step, offset, kind), ctx, withOptionalSelector: true) },
@@ -37,10 +40,18 @@ namespace AngleSharp.Css.Parser
             { PseudoClassNames.HostContext, ctx => new HostContextFunctionState(ctx) },
         };
 
-        private static readonly Dictionary<String, Func<CssSelectorConstructor, FunctionState>> pseudoElementFunctions = new(StringComparer.OrdinalIgnoreCase)
+        private static readonly Dictionary<String, Func<CssSelectorConstructor, FunctionState>> _pseudoElementFunctionsDict = new(StringComparer.OrdinalIgnoreCase)
         {
             { PseudoElementNames.Picker, _ => new PickerFunctionState() },
         };
+
+#if NET8_0_OR_GREATER
+        private static readonly FrozenDictionary<String, Func<CssSelectorConstructor, FunctionState>> pseudoClassFunctions = _pseudoClassFunctionsDict.ToFrozenDictionary(StringComparer.OrdinalIgnoreCase);
+        private static readonly FrozenDictionary<String, Func<CssSelectorConstructor, FunctionState>> pseudoElementFunctions = _pseudoElementFunctionsDict.ToFrozenDictionary(StringComparer.OrdinalIgnoreCase);
+#else
+        private static readonly Dictionary<String, Func<CssSelectorConstructor, FunctionState>> pseudoClassFunctions = _pseudoClassFunctionsDict;
+        private static readonly Dictionary<String, Func<CssSelectorConstructor, FunctionState>> pseudoElementFunctions = _pseudoElementFunctionsDict;
+#endif
 
         private readonly CssTokenizer _tokenizer = tokenizer;
         private readonly Stack<CssCombinator> _combinators = new Stack<CssCombinator>();

--- a/src/AngleSharp/Dom/QueryExtensions.cs
+++ b/src/AngleSharp/Dom/QueryExtensions.cs
@@ -6,6 +6,9 @@ using AngleSharp.Text;
 using System;
 using System.Collections.Generic;
 using System.Linq;
+#if NET5_0_OR_GREATER
+using System.Runtime.InteropServices;
+#endif
 
 /// <summary>
 /// Extensions for performing QuerySelector operations.
@@ -74,7 +77,9 @@ public static class QueryExtensions
 
         if (sg is not null)
         {
-            return sg.MatchAll(nodes.OfType<IElement>(), scope);
+            var result = new List<IElement>();
+            nodes.QuerySelectorAll(sg, scope, result);
+            return new HtmlCollection<IElement>(result);
         }
 
         return new HtmlCollection<IElement>(Array.Empty<IElement>());
@@ -283,18 +288,57 @@ public static class QueryExtensions
     /// <param name="elements">The elements to take as source.</param>
     /// <param name="selector">A selector object.</param>
     /// <param name="result">A reference to the list where to store the results.</param>
-    public static void QuerySelectorAll<T>(this T elements, ISelector selector, List<IElement> result) where T : class, INodeList
+    public static void QuerySelectorAll<T>(this T elements, ISelector selector, List<IElement> result) where T : class, INodeList =>
+        elements.QuerySelectorAll(selector, null, result);
+
+    /// <summary>
+    /// Returns a list of the elements within the document (using depth-first pre-order traversal
+    /// of the document's nodes) that match the specified group of selectors.
+    /// </summary>
+    /// <param name="elements">The elements to take as source.</param>
+    /// <param name="selector">A selector object.</param>
+    /// <param name="scope">The optional scope element.</param>
+    /// <param name="result">A reference to the list where to store the results.</param>
+    public static void QuerySelectorAll<T>(this T elements, ISelector selector, IElement? scope, List<IElement> result) where T : class, INodeList
     {
+        var stack = new Stack<Element>();
+
         for (var i = 0; i < elements.Length; i++)
         {
-            if (elements[i] is IElement element)
+            if (elements[i] is Element rootElement)
             {
-                foreach (var descendantAndSelf in element.DescendantsAndSelf<IElement>())
+                stack.Push(rootElement);
+
+                while (stack.Count > 0)
                 {
-                    if (selector.Match(descendantAndSelf))
+                    var element = stack.Pop();
+
+                    if (selector.Match(element, scope))
                     {
-                        result.Add(descendantAndSelf);
+                        result.Add(element);
                     }
+
+#if NET5_0_OR_GREATER
+                    var entries = CollectionsMarshal.AsSpan(element.ChildNodes._entries);
+
+                    for (var j = entries.Length - 1; j >= 0; j--)
+                    {
+                        if (entries[j] is Element child)
+                        {
+                            stack.Push(child);
+                        }
+                    }
+#else
+                    var childNodes = element.ChildNodes;
+
+                    for (var j = childNodes.Length - 1; j >= 0; j--)
+                    {
+                        if (childNodes[j] is Element child)
+                        {
+                            stack.Push(child);
+                        }
+                    }
+#endif
                 }
             }
         }

--- a/src/AngleSharp/Html/HtmlElementFactory.cs
+++ b/src/AngleSharp/Html/HtmlElementFactory.cs
@@ -5,6 +5,9 @@ using AngleSharp.Html.Dom;
 using AngleSharp.Text;
 using System;
 using System.Collections.Generic;
+#if NET8_0_OR_GREATER
+using System.Collections.Frozen;
+#endif
 
 /// <summary>
 /// Provides string to HTMLElement instance creation mappings.
@@ -15,7 +18,7 @@ sealed class HtmlElementFactory : IElementFactory<Document, HtmlElement>
 
     private delegate HtmlElement Creator(Document owner, String? prefix);
 
-    private readonly Dictionary<String, Creator> creators = new(StringComparer.OrdinalIgnoreCase)
+    private static readonly Dictionary<String, Creator> _creatorsDict = new(StringComparer.OrdinalIgnoreCase)
     {
         { TagNames.Div, (document, prefix) => new HtmlDivElement(document, prefix) },
         { TagNames.A, (document, prefix) => new HtmlAnchorElement(document, prefix) },
@@ -156,6 +159,12 @@ sealed class HtmlElementFactory : IElementFactory<Document, HtmlElement>
         { TagNames.SelectedContent, (document, prefix) => new HtmlSelectedContentElement(document, prefix) },
     };
 
+#if NET8_0_OR_GREATER
+    private static readonly FrozenDictionary<String, Creator> creators = _creatorsDict.ToFrozenDictionary(StringComparer.OrdinalIgnoreCase);
+#else
+    private static readonly Dictionary<String, Creator> creators = _creatorsDict;
+#endif
+
     /// <summary>
     /// Returns a specialized HTMLElement instance for the given tag name.
     /// </summary>
@@ -166,6 +175,41 @@ sealed class HtmlElementFactory : IElementFactory<Document, HtmlElement>
     /// <returns>The specialized HTMLElement instance.</returns>
     public HtmlElement Create(Document document, String localName, String? prefix = null, NodeFlags flags = NodeFlags.None)
     {
+        // Fast path for the most common tags — avoids dictionary hash + delegate invoke
+        if (localName.Length > 0)
+        {
+            // Tag names from the tokenizer are interned strings (reference-equal to TagNames constants)
+            // so we can use ReferenceEquals for zero-cost dispatch on the hottest tags
+            if (ReferenceEquals(localName, TagNames.Div)) return new HtmlDivElement(document, prefix);
+            if (ReferenceEquals(localName, TagNames.Span)) return new HtmlSpanElement(document, prefix);
+            if (ReferenceEquals(localName, TagNames.P)) return new HtmlParagraphElement(document, prefix);
+            if (ReferenceEquals(localName, TagNames.A)) return new HtmlAnchorElement(document, prefix);
+            if (ReferenceEquals(localName, TagNames.Li)) return new HtmlListItemElement(document, TagNames.Li, prefix);
+            if (ReferenceEquals(localName, TagNames.Td)) return new HtmlTableDataCellElement(document, prefix);
+            if (ReferenceEquals(localName, TagNames.Tr)) return new HtmlTableRowElement(document, prefix);
+            if (ReferenceEquals(localName, TagNames.Th)) return new HtmlTableHeaderCellElement(document, prefix);
+            if (ReferenceEquals(localName, TagNames.Img)) return new HtmlImageElement(document, prefix);
+            if (ReferenceEquals(localName, TagNames.Input)) return new HtmlInputElement(document, prefix);
+            if (ReferenceEquals(localName, TagNames.Br)) return new HtmlBreakRowElement(document, prefix);
+            if (ReferenceEquals(localName, TagNames.Code)) return new HtmlCodeElement(document, prefix);
+            if (ReferenceEquals(localName, TagNames.Pre)) return new HtmlPreElement(document, prefix);
+            if (ReferenceEquals(localName, TagNames.Ul)) return new HtmlUnorderedListElement(document, prefix);
+            if (ReferenceEquals(localName, TagNames.Ol)) return new HtmlOrderedListElement(document, prefix);
+            if (ReferenceEquals(localName, TagNames.Dl)) return new HtmlDefinitionListElement(document, prefix);
+            if (ReferenceEquals(localName, TagNames.Dd)) return new HtmlListItemElement(document, TagNames.Dd, prefix);
+            if (ReferenceEquals(localName, TagNames.Dt)) return new HtmlListItemElement(document, TagNames.Dt, prefix);
+            if (ReferenceEquals(localName, TagNames.H1)) return new HtmlHeadingElement(document, TagNames.H1, prefix);
+            if (ReferenceEquals(localName, TagNames.H2)) return new HtmlHeadingElement(document, TagNames.H2, prefix);
+            if (ReferenceEquals(localName, TagNames.H3)) return new HtmlHeadingElement(document, TagNames.H3, prefix);
+            if (ReferenceEquals(localName, TagNames.H4)) return new HtmlHeadingElement(document, TagNames.H4, prefix);
+            if (ReferenceEquals(localName, TagNames.H5)) return new HtmlHeadingElement(document, TagNames.H5, prefix);
+            if (ReferenceEquals(localName, TagNames.H6)) return new HtmlHeadingElement(document, TagNames.H6, prefix);
+            if (ReferenceEquals(localName, TagNames.Table)) return new HtmlTableElement(document, prefix);
+            if (ReferenceEquals(localName, TagNames.Tbody)) return new HtmlTableSectionElement(document, TagNames.Tbody, prefix);
+            if (ReferenceEquals(localName, TagNames.Thead)) return new HtmlTableSectionElement(document, TagNames.Thead, prefix);
+            if (ReferenceEquals(localName, TagNames.Tfoot)) return new HtmlTableSectionElement(document, TagNames.Tfoot, prefix);
+        }
+
         if (creators.TryGetValue(localName, out var creator))
         {
             return creator.Invoke(document, prefix);

--- a/src/AngleSharp/Html/Parser/HtmlForeignExtensions.cs
+++ b/src/AngleSharp/Html/Parser/HtmlForeignExtensions.cs
@@ -4,6 +4,9 @@ namespace AngleSharp.Html.Parser
     using AngleSharp.Text;
     using System;
     using System.Collections.Generic;
+#if NET8_0_OR_GREATER
+    using System.Collections.Frozen;
+#endif
     using Common;
     using Construction;
     using Tokens.Struct;
@@ -14,7 +17,7 @@ namespace AngleSharp.Html.Parser
     static class HtmlForeignExtensions
     {
         #region Fields
-        private static readonly Dictionary<StringOrMemory, String> svgAttributeNames =
+        private static readonly Dictionary<StringOrMemory, String> _svgAttributeNamesDict =
             new(OrdinalStringOrMemoryComparer.Instance)
         {
             { "attributename", "attributeName" },
@@ -81,7 +84,7 @@ namespace AngleSharp.Html.Parser
             { "zoomandpan", "zoomAndPan" },
         };
 
-        private static readonly Dictionary<StringOrMemory, String> svgAdjustedTagNames =
+        private static readonly Dictionary<StringOrMemory, String> _svgAdjustedTagNamesDict =
             new(OrdinalStringOrMemoryComparer.Instance)
         {
              { "altglyph", "altGlyph" },
@@ -121,6 +124,14 @@ namespace AngleSharp.Html.Parser
              { "radialgradient", "radialGradient" },
              { "textpath", "textPath" }
         };
+
+#if NET8_0_OR_GREATER
+        private static readonly FrozenDictionary<StringOrMemory, String> svgAttributeNames = _svgAttributeNamesDict.ToFrozenDictionary(OrdinalStringOrMemoryComparer.Instance);
+        private static readonly FrozenDictionary<StringOrMemory, String> svgAdjustedTagNames = _svgAdjustedTagNamesDict.ToFrozenDictionary(OrdinalStringOrMemoryComparer.Instance);
+#else
+        private static readonly Dictionary<StringOrMemory, String> svgAttributeNames = _svgAttributeNamesDict;
+        private static readonly Dictionary<StringOrMemory, String> svgAdjustedTagNames = _svgAdjustedTagNamesDict;
+#endif
 
         #endregion
 

--- a/src/AngleSharp/Html/Parser/HtmlParser.cs
+++ b/src/AngleSharp/Html/Parser/HtmlParser.cs
@@ -275,8 +275,16 @@ namespace AngleSharp.Html.Parser
 
         private HtmlDocument CreateDocument(String source)
         {
-            var textSource = new TextSource(source);
-            return CreateDocument(textSource);
+            if (_options.IsScripting)
+            {
+                var textSource = new TextSource(source);
+                return CreateDocument(textSource);
+            }
+            else
+            {
+                var memSource = new ReadOnlyMemoryTextSource(source);
+                return CreateDocument(new TextSource(memSource));
+            }
         }
 
         private HtmlDocument CreateDocument(Stream source)

--- a/src/AngleSharp/Html/Parser/HtmlTokenizer.cs
+++ b/src/AngleSharp/Html/Parser/HtmlTokenizer.cs
@@ -295,7 +295,9 @@ namespace AngleSharp.Html.Parser
 
                     default:
                         Append(c);
-                        break;
+                        // Try to scan ahead and bulk-append plain text
+                        c = ScanDataText();
+                        continue;
                 }
 
                 c = GetNext();

--- a/src/AngleSharp/Text/CharArrayTextSource.cs
+++ b/src/AngleSharp/Text/CharArrayTextSource.cs
@@ -41,6 +41,11 @@ public sealed class CharArrayTextSource : IReadOnlyTextSource
         }
     }
 
+    /// <summary>
+    /// Gets the underlying character array.
+    /// </summary>
+    internal Char[] Array => _array;
+
     /// <ihneritdoc />
     public Char this[Int32 index] => _array[index];
 

--- a/src/AngleSharp/Text/ReadOnlyMemoryTextSource.cs
+++ b/src/AngleSharp/Text/ReadOnlyMemoryTextSource.cs
@@ -53,6 +53,11 @@ public sealed class ReadOnlyMemoryTextSource : IReadOnlyTextSource
         }
     }
 
+    /// <summary>
+    /// Gets the underlying memory buffer.
+    /// </summary>
+    internal ReadOnlyMemory<Char> Memory => _memory;
+
     /// <ihneritdoc />
     public Char this[Int32 index] => _content != null ? _content[index] : _memory.Span[index];
 


### PR DESCRIPTION
## Prerequisites

Please make sure you can check the following two boxes:

- [x] I have read the **CONTRIBUTING** document
- [x] My code follows the code style of this project

## Contribution Type

What types of changes does your code introduce? Put an `x` in all the boxes that apply:

- [x] Bug fix (non-breaking change which fixes an issue, please reference the issue id)
- [ ] New feature (non-breaking change which adds functionality, make sure to open an associated issue first)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] My change requires a change to the documentation
- [ ] I have updated the documentation accordingly
- [ ] I have added tests to cover my changes
- [x] All new and existing tests passed

## Description

Performance optimizations for the HTML parser, CSS selector engine, and URL parser to reduce allocations.
  
---

1. Bulk text scanning in tokenizer (BaseTokenizer.cs, HtmlTokenizer.cs)
  
2. FrozenDictionary for static lookup tables (.NET 8+)
  
3. ReferenceEquals fast-path in HtmlElementFactory
  
4. URL parsing allocation reduction (Url.cs)
  
5. Selector engine: lazy descendant traversal (CssCombinator.cs)
  
6. QuerySelectorAll stack-based traversal (QueryExtensions.cs) Replaces LINQ DescendantsAndSelf with an explicit Stack<Element> + CollectionsMarshal.AsSpan for child iteration,  avoiding enumerator allocations
  7. HashSet for protocol lookups (ProtocolNames.cs) RelativeProtocols and OriginalableProtocols changed from String[] (linear scan) to HashSet<String> (O(1) lookup)
  8. ReadOnlyMemoryTextSource for non-scripting parse (HtmlParser.cs)

Relates to #97 

<img width="1196" height="1658" alt="image" src="https://github.com/user-attachments/assets/9291edc8-6207-4960-94e9-aab947467b44" />

# AngleSharp Selector Benchmark: Optimized vs Baseline
 
| Selector | Baseline Mean (µs) | Optimized Mean (µs) | Speedup | Baseline Alloc | Optimized Alloc | Alloc Reduction |
|---|---:|---:|---:|---:|---:|---:|
| .note | 46.88 | 28.30 | 1.66× | 17.04 KB | 8.80 KB | 48% |
| #title | 49.36 | 28.43 | 1.74× | 16.80 KB | 8.57 KB | 49% |
| a[href] | 52.40 | 34.03 | 1.54× | 21.05 KB | 12.82 KB | 39% |
| a[href][lang][class] | 54.99 | 36.10 | 1.52× | 17.12 KB | 8.88 KB | 48% |
| body | 46.32 | 26.52 | 1.75× | 16.80 KB | 8.57 KB | 49% |
| body div | 49.32 | 28.96 | 1.70× | 24.50 KB | 12.68 KB | 48% |
| div | 46.12 | 28.32 | 1.63× | 17.84 KB | 9.60 KB | 46% |
| div #title | 47.34 | 29.91 | 1.58× | 17.22 KB | 8.91 KB | 48% |
| div + p | 75.84 | 60.55 | 1.25× | 32.80 KB | 24.57 KB | 25% |
| div > p | 51.16 | 33.83 | 1.51× | 36.38 KB | 28.14 KB | 23% |
| div > p > a | 51.14 | 33.97 | 1.50× | 34.85 KB | 26.62 KB | 24% |
| div ~ p | 352.05 | 355.93 | 0.99× | 729.55 KB | 721.32 KB | 1% |
| div p | 59.81 | 37.89 | 1.58× | 62.18 KB | 30.65 KB | 51% |
| div p a | 70.60 | 45.19 | 1.56× | 78.78 KB | 29.91 KB | 62% |
| div, p, a | 60.95 | 41.28 | 1.48× | 33.19 KB | 24.95 KB | 25% |
| div:not(.example) | 48.61 | 29.13 | 1.67× | 17.52 KB | 9.29 KB | 47% |
| div.example | 48.55 | 29.37 | 1.65× | 18.01 KB | 9.77 KB | 46% |
| div.example.note | 54.77 | 37.47 | 1.46× | 18.39 KB | 10.16 KB | 45% |
| div[class!=made_up] | 47.67 | 29.89 | 1.59× | 18.07 KB | 9.84 KB | 46% |
| div[class] | 47.50 | 29.67 | 1.60× | 18.02 KB | 9.78 KB | 46% |
| div[class*=e] | 48.19 | 29.92 | 1.61× | 18.05 KB | 9.82 KB | 46% |
| div[class^=exa] | 48.21 | 29.53 | 1.63× | 18.06 KB | 9.83 KB | 46% |
| div[class~=example] | 50.57 | 31.97 | 1.58× | 26.02 KB | 17.79 KB | 32% |
| div[class=example] | 48.06 | 29.38 | 1.64× | 18.09 KB | 9.86 KB | 45% |
| div[class\|=dialog] | 49.26 | 28.47 | 1.73× | 16.98 KB | 8.75 KB | 48% |
| div[class$=mple] | 47.91 | 29.29 | 1.64× | 18.06 KB | 9.83 KB | 46% |
| div[class (full)] | 49.53 | 31.04 | 1.60× | 18.18 KB | 9.95 KB | 45% |
| h1[id (full)] | 49.37 | 27.31 | 1.81× | 17.59 KB | 9.36 KB | 47% |
| h1#title | 45.91 | 27.43 | 1.67× | 16.97 KB | 8.73 KB | 49% |
| h1#title + div > p | 70.24 | 50.94 | 1.38× | 38.77 KB | 30.53 KB | 21% |
| p:contains (full) | 113.98 | 89.52 | 1.27× | 247.16 KB | 238.93 KB | 3% |
| p:first-child | 49.25 | 30.33 | 1.62× | 17.98 KB | 9.75 KB | 46% |
| p:last-child | 48.39 | 30.48 | 1.59× | 17.46 KB | 9.23 KB | 47% |
| p:nth-child(2n) | 177.36 | 155.15 | 1.14× | 21.17 KB | 12.94 KB | 39% |
| p:nth-child(2n+1) | 178.14 | 157.39 | 1.13× | 21.20 KB | 12.97 KB | 39% |
| p:nth-child(even) | 177.22 | 156.46 | 1.13× | 21.15 KB | 12.91 KB | 39% |
| p:nth-child(n) | 177.52 | 157.75 | 1.13× | 25.16 KB | 16.93 KB | 33% |
| p:nth-child(odd) | 176.25 | 158.09 | 1.11× | 21.15 KB | 12.91 KB | 39% |
| p:only-child | 96.02 | 82.93 | 1.16× | 16.95 KB | 8.72 KB | 49% |
| ul .tocline2 | 48.36 | 29.21 | 1.66× | 18.84 KB | 9.76 KB | 48% |
| ul.toc > li.tocline2 | 49.07 | 30.40 | 1.61× | 18.25 KB | 10.02 KB | 45% |
| ul.toc li.tocline2 | 47.72 | 29.93 | 1.59× | 19.16 KB | 10.09 KB | 47% |

data was from benchmark tests, warmup 2, iterations 8
