### PR TITLE
Add MemoryCookieProvider(CookieContainer) constructor and tests

### DIFF
--- a/src/AngleSharp.Core.Tests/Library/CookieHandling.cs
+++ b/src/AngleSharp.Core.Tests/Library/CookieHandling.cs
@@ -483,6 +483,36 @@ namespace AngleSharp.Core.Tests.Library
             Assert.AreEqual(mcp.GetCookie(url), cookie);
         }
 
+        [Test]
+        public void ImportedCookieContainerReadsCorrectly_Issue1249()
+        {
+            var mcp = new MemoryCookieProvider();
+            var url = Url.Create("http://www.example.com");
+            var cookie = "A=A";
+            mcp.SetCookie(url,
+                $"{cookie}; expires={DateTime.UtcNow.AddHours(1):R}");
+            Assert.AreEqual(mcp.GetCookie(url), cookie);
+            var initialContainer = mcp.Container;
+            var manualMcp = new MemoryCookieProvider(initialContainer);
+            Assert.AreSame(initialContainer, manualMcp.Container);
+            Assert.AreEqual(manualMcp.GetCookie(url), cookie);
+        }
+
+        [Test]
+        public void ImportedCookieContainerWritesCorrectly_Issue1249()
+        {
+            var mcp = new MemoryCookieProvider();
+            var url = Url.Create("http://www.example.com");
+            var cookie = "A=A";
+            var initialContainer = mcp.Container;
+            var manualMcp = new MemoryCookieProvider(initialContainer);
+            Assert.AreSame(initialContainer, manualMcp.Container);
+            manualMcp.SetCookie(url,
+                $"{cookie}; expires={DateTime.UtcNow.AddHours(1):R}");
+            Assert.AreEqual(mcp.GetCookie(url), cookie);
+            Assert.AreEqual(manualMcp.GetCookie(url), cookie);
+        }
+
         private static Task<IDocument> LoadDocumentWithFakeRequesterAndCookie(IResponse initialResponse,
             Func<Request, IResponse> onRequest)
         {

--- a/src/AngleSharp/Io/MemoryCookieProvider.cs
+++ b/src/AngleSharp/Io/MemoryCookieProvider.cs
@@ -22,6 +22,15 @@ namespace AngleSharp.Io
         }
 
         /// <summary>
+        /// Creates a new cookie service with a specific <see cref="CookieContainer"/>.
+        /// </summary>
+        /// <param name="container">The cookie container to associate with this cookie service.</param>
+        public MemoryCookieProvider(CookieContainer container)
+        {
+            _container = container ?? throw new ArgumentNullException(nameof(container));
+        }
+
+        /// <summary>
         /// Gets the associated cookie container.
         /// </summary>
         public CookieContainer Container => _container;


### PR DESCRIPTION
Closes #1249

# Types of Changes

This PR adds an additional constructor to `MemoryCookieProvider` with the signature `public MemoryCookieProvider(CookieContainer container)`. The CookieContainer is used as the storage of cookies for that MemoryCookieProvider instance, instead of the CookieContainer that would be created by the no-parameter constructor.

## Prerequisites

Please make sure you can check the following two boxes:

- [x] I have read the **CONTRIBUTING** document
- [x] My code follows the code style of this project

## Contribution Type

What types of changes does your code introduce? Put an `x` in all the boxes that apply:

- [ ] Bug fix (non-breaking change which fixes an issue, please reference the issue id)
- [x] New feature (non-breaking change which adds functionality, make sure to open an associated issue first)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] My change requires a change to the documentation
- [ ] I have updated the documentation accordingly
- [ ] I have added tests to cover my changes
- [ ] All new and existing tests passed

## Description

Adding a new constructor to MemoryCookieProvider allows one to specify a CookieContainer that should be used by the instance of MemoryCookieProvider while otherwise maintaining the behaviour of the provider. Tests to verify that the behaviour remains the same between instances created by the no-parameter constructor and those created with the CookieContainer-receiving constructor have been added (`ImportedCookieContainerReadsCorrectly_Issue1249`, `ImportedCookieContainerWritesCorrectly_Issue1249`).