### PR TITLE
Fix O(n^2) regression when tokenizing large plain-text runs

### DIFF
--- a/src/AngleSharp.Core.Tests/Html/HtmlTokenization.cs
+++ b/src/AngleSharp.Core.Tests/Html/HtmlTokenization.cs
@@ -6,6 +6,7 @@ namespace AngleSharp.Core.Tests.Html
     using AngleSharp.Text;
     using NUnit.Framework;
     using System;
+    using System.Diagnostics;
     using System.IO;
     using System.Linq;
     using System.Text;
@@ -69,6 +70,43 @@ namespace AngleSharp.Core.Tests.Html
             Assert.AreEqual(HtmlTokenType.EndOfFile, eof.Type);
             Assert.AreEqual("\nThis is test 1", tokenP1data.Data);
             Assert.AreEqual(" \nThis is test 2", tokenP2data.Data);
+        }
+
+        [Test]
+        public void TokenizationLargePlainTextRunReadOnlyMemoryIsLinear()
+            => AssertLargePlainTextRunIsLinear(text => new TextSource(new ReadOnlyMemoryTextSource(text)));
+
+        [Test]
+        public void TokenizationLargePlainTextRunCharArrayIsLinear()
+            => AssertLargePlainTextRunIsLinear(text => new TextSource(new CharArrayTextSource(text.ToCharArray(), text.Length)));
+
+        private static void AssertLargePlainTextRunIsLinear(Func<String, TextSource> sourceFactory)
+        {
+            // Regression test for the O(n^2) ScanDataText bug.
+            // A long plain-text run with no DataText terminators ('<', '&', '\0', '\r', '\n')
+            // must be bulk-appended in a single pass. BaseTokenizer.ScanDataText folded the
+            // "no terminator found" result (IndexOfAny returns -1) into a zero-length run, so
+            // the tokenizer re-scanned the entire remaining buffer for every character.
+            // 2 MB of plain text took ~70 s before the fix and a few ms after.
+            const Int32 length = 2 * 1024 * 1024;
+            var text = new String('a', length);
+            var source = sourceFactory(text);
+            var tokenizer = CreateTokenizer(source);
+
+            var stopwatch = Stopwatch.StartNew();
+            var token = tokenizer.Get();
+            stopwatch.Stop();
+
+            // Correctness: the whole run is emitted as a single, complete Character token.
+            Assert.AreEqual(HtmlTokenType.Character, token.Type);
+            Assert.AreEqual(length, token.Data.Length);
+            Assert.AreEqual(text, token.Data);
+            Assert.AreEqual(HtmlTokenType.EndOfFile, tokenizer.Get().Type);
+
+            // Performance guard: a quadratic regression turns this into tens of seconds.
+            // The bound is deliberately generous (linear parse is a few ms) to avoid flakiness.
+            Assert.That(stopwatch.Elapsed, Is.LessThan(TimeSpan.FromSeconds(10)),
+                $"Tokenizing a {length / (1024 * 1024)} MB plain-text run took {stopwatch.Elapsed.TotalSeconds:F1}s; the O(n^2) ScanDataText regression has likely returned.");
         }
 
         [Test]

--- a/src/AngleSharp/Common/BaseTokenizer.cs
+++ b/src/AngleSharp/Common/BaseTokenizer.cs
@@ -435,7 +435,7 @@ namespace AngleSharp.Common
             }
 #endif
 
-            var runLength = found <= 0 ? 0 : found;
+            var runLength = found < 0 ? remaining.Length : found;
 
             if (runLength > 0)
             {


### PR DESCRIPTION
The ScanDataText bulk-append optimization (added in 1.5.0) scanned the remaining buffer with IndexOfAny on every character. When no DataText terminator ('<', '&', '\0', '\r', '\n') was present before EOF, IndexOfAny returned -1, which `found <= 0 ? 0 : found` collapsed to a zero-length run. The tokenizer then advanced a single character and re-scanned the entire remaining buffer again, making tag-less text O(n^2): a 2 MB plain-text body took ~70s to parse (vs a few ms in 1.4.0).

Treat the "no terminator" result as a run extending to the end of the buffer so the whole remainder is appended in one pass. Parsing is now linear (and faster than 1.4.0, since the run is appended via a single span).

Add a regression test covering both ReadOnlyMemoryTextSource and CharArrayTextSource that asserts correct token output and guards against the quadratic behaviour returning.

# Types of Changes

## Prerequisites

Please make sure you can check the following two boxes:

- [x] I have read the **CONTRIBUTING** document
- [x] My code follows the code style of this project

## Contribution Type

What types of changes does your code introduce? Put an `x` in all the boxes that apply:

- [x] Bug fix (non-breaking change which fixes an issue, please reference the issue id)
- [ ] New feature (non-breaking change which adds functionality, make sure to open an associated issue first)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] My change requires a change to the documentation
- [ ] I have updated the documentation accordingly
- [x] I have added tests to cover my changes
- [x] All new and existing tests passed

## Description

[Place a meaningful description here.]
