### PR TITLE
Consolidate #if defs to use NET8_0_OR_GREATER consistently

### DIFF
--- a/src/AngleSharp/Common/BaseTokenizer.cs
+++ b/src/AngleSharp/Common/BaseTokenizer.cs
@@ -447,13 +447,13 @@ namespace AngleSharp.Common
                 }
                 else
                 {
-#if NETSTANDARD2_0 || NET462 || NET472
+#if NET8_0_OR_GREATER
+                    _sbb!._sb.Append(run);
+#else
                     for (var i = 0; i < run.Length; i++)
                     {
                         _sbb!._sb.Append(run[i]);
                     }
-#else
-                    _sbb!._sb.Append(run);
 #endif
                 }
 

--- a/src/AngleSharp/Common/ObjectExtensions.cs
+++ b/src/AngleSharp/Common/ObjectExtensions.cs
@@ -166,7 +166,7 @@ namespace AngleSharp.Common
         /// </summary>
         /// <param name="code">A specific error code.</param>
         /// <returns>The description of the error.</returns>
-#if NET6_0_OR_GREATER
+#if NET8_0_OR_GREATER
         public static String GetMessage<[DynamicallyAccessedMembers(DynamicallyAccessedMemberTypes.PublicFields)] T>(this T code)
 #else
         public static String GetMessage<T>(this T code)

--- a/src/AngleSharp/Common/StringBuilderBuffer.cs
+++ b/src/AngleSharp/Common/StringBuilderBuffer.cs
@@ -56,7 +56,7 @@ internal sealed class StringBuilderBuffer : IMutableCharBuffer
 
     public IMutableCharBuffer Append(ReadOnlySpan<Char> str)
     {
-#if NETSTANDARD2_1_OR_GREATER || NETCOREAPP2_1_OR_GREATER
+#if NET8_0_OR_GREATER
         _sb.Append(str);
 #else
         foreach (var c in str)

--- a/src/AngleSharp/Dom/QueryExtensions.cs
+++ b/src/AngleSharp/Dom/QueryExtensions.cs
@@ -6,7 +6,7 @@ using AngleSharp.Text;
 using System;
 using System.Collections.Generic;
 using System.Linq;
-#if NET5_0_OR_GREATER
+#if NET8_0_OR_GREATER
 using System.Runtime.InteropServices;
 #endif
 
@@ -318,7 +318,7 @@ public static class QueryExtensions
                         result.Add(element);
                     }
 
-#if NET5_0_OR_GREATER
+#if NET8_0_OR_GREATER
                     var entries = CollectionsMarshal.AsSpan(element.ChildNodes._entries);
 
                     for (var j = entries.Length - 1; j >= 0; j--)

--- a/src/AngleSharp/Html/Parser/Tokens/Struct/StructHtmlToken.cs
+++ b/src/AngleSharp/Html/Parser/Tokens/Struct/StructHtmlToken.cs
@@ -414,7 +414,7 @@ public struct StructHtmlToken
     /// <returns>The trimmed characters.</returns>
     public void CleanStart()
     {
-#if NETSTANDARD2_1_OR_GREATER || NETCOREAPP2_1_OR_GREATER
+#if NET8_0_OR_GREATER
         var newData = _name.Memory.TrimStart(Spaces);
         if (newData.Length != _name.Length)
         {


### PR DESCRIPTION
# Types of Changes

## Prerequisites

Please ensure the following two boxes are checked:

- [x] I have read the **CONTRIBUTING** document  
- [x] My code follows the code style of this project

## Contribution Type

What types of changes does your code introduce? Put an `x` in all the boxes that apply:

- [ ] Bug fix (non-breaking change which fixes an issue, please reference the issue id)  
- [ ] New feature (non-breaking change which adds functionality, make sure to open an associated issue first)  
- [ ] Breaking change (fix or feature that would cause existing functionality to change)  
- [ ] My change requires a change to the documentation  
- [ ] I have updated the documentation accordingly  
- [ ] I have added tests to cover my changes  
- [ ] All new and existing tests passed

(Note: this change is primarily a consolidation/refactor introducing .NET 8-optimized code paths; it is not a feature, bugfix, or breaking change.)

## Description

- Consolidate preprocessor conditionals to use NET8_0_OR_GREATER consistently. 