### PR TITLE
Fix Range.ExtractContent to follow the DOM Standard

### DIFF
--- a/src/AngleSharp.Core.Tests/Library/Range.cs
+++ b/src/AngleSharp.Core.Tests/Library/Range.cs
@@ -193,5 +193,61 @@ namespace AngleSharp.Core.Tests.Library
             Assert.IsFalse(htmlRaw.Contains("This should be deleted too"));
             Assert.IsFalse(document.Contains(toDelete));
         }
+
+        [Test]
+        public void CanExtractContentWithPartiallyContainedTextNodes()
+        {
+            var document = "<p>abc<b>def</b>ghi</p>".ToHtmlDocument();
+            var p = document.QuerySelector("p");
+            var range = document.CreateRange();
+            range.StartWith(p.ChildNodes[0], 1);
+            range.EndWith(p.ChildNodes[2], 2);
+
+            var fragment = range.ExtractContent();
+            var div = document.CreateElement("div");
+            div.AppendChild(fragment);
+
+            Assert.AreEqual("bc<b>def</b>gh", div.InnerHtml);
+            Assert.AreEqual("ai", p.InnerHtml);
+            Assert.AreEqual(p, range.Head);
+            Assert.AreEqual(1, range.Start);
+            Assert.AreEqual(p, range.Tail);
+            Assert.AreEqual(1, range.End);
+        }
+
+        [Test]
+        public void CanExtractContentWithPartiallyContainedElements()
+        {
+            var document = "<div id=host><a>abc</a><b>def</b></div>".ToHtmlDocument();
+            var host = document.QuerySelector("#host");
+            var range = document.CreateRange();
+            range.StartWith(document.QuerySelector("a").FirstChild, 1);
+            range.EndWith(document.QuerySelector("b").FirstChild, 1);
+
+            var fragment = range.ExtractContent();
+            var div = document.CreateElement("div");
+            div.AppendChild(fragment);
+
+            Assert.AreEqual("<a>bc</a><b>d</b>", div.InnerHtml);
+            Assert.AreEqual("<a>a</a><b>ef</b>", host.InnerHtml);
+        }
+
+        [Test]
+        public void CanExtractContentFromDetachedSubtree()
+        {
+            var document = "<body></body>".ToHtmlDocument();
+            var detached = document.CreateElement("div");
+            detached.InnerHtml = "<a>abc</a><b>def</b>";
+            var range = document.CreateRange();
+            range.StartWith(detached.QuerySelector("a").FirstChild, 1);
+            range.EndWith(detached.QuerySelector("b").FirstChild, 1);
+
+            var fragment = range.ExtractContent();
+            var div = document.CreateElement("div");
+            div.AppendChild(fragment);
+
+            Assert.AreEqual("<a>bc</a><b>d</b>", div.InnerHtml);
+            Assert.AreEqual("<a>a</a><b>ef</b>", detached.InnerHtml);
+        }
     }
 }

--- a/src/AngleSharp/Dom/Internal/Range.cs
+++ b/src/AngleSharp/Dom/Internal/Range.cs
@@ -402,10 +402,12 @@ namespace AngleSharp.Dom
                     }
 
                     var firstPartiallyContainedChild = !originalStart.Node.IsInclusiveAncestorOf(originalEnd.Node) ?
-                        commonAncestor.GetNodes<INode>(predicate: IsPartiallyContained).FirstOrDefault() : null;
+                        commonAncestor.ChildNodes.FirstOrDefault(IsPartiallyContained) : null;
                     var lastPartiallyContainedchild = !originalEnd.Node.IsInclusiveAncestorOf(originalStart.Node) ?
-                        commonAncestor.GetNodes<INode>(predicate: IsPartiallyContained).LastOrDefault() : null;
-                    var containedChildren = commonAncestor.GetNodes<INode>(predicate: Intersects).ToList();
+                        commonAncestor.ChildNodes.LastOrDefault(IsPartiallyContained) : null;
+                    var containedChildren = commonAncestor.ChildNodes
+                        .Where(m => new Boundary(m, 0) > originalStart && new Boundary(m, GetNodeLength(m)) < originalEnd)
+                        .ToList();
 
                     if (containedChildren.OfType<IDocumentType>().Any())
                     {
@@ -416,12 +418,12 @@ namespace AngleSharp.Dom
                     {
                         var referenceNode = originalStart.Node;
 
-                        while (referenceNode.Parent != null && !referenceNode.IsInclusiveAncestorOf(originalEnd.Node))
+                        while (referenceNode.Parent != null && !referenceNode.Parent.IsInclusiveAncestorOf(originalEnd.Node))
                         {
                             referenceNode = referenceNode.Parent;
                         }
 
-                        newBoundary = new Boundary(referenceNode, referenceNode.Parent!.ChildNodes.Index(referenceNode) + 1);
+                        newBoundary = new Boundary(referenceNode.Parent!, referenceNode.Index() + 1);
                     }
 
                     if (firstPartiallyContainedChild is ICharacterData)
@@ -436,11 +438,11 @@ namespace AngleSharp.Dom
                     }
                     else if (firstPartiallyContainedChild != null)
                     {
-                        var clone = firstPartiallyContainedChild.Clone();
+                        var clone = firstPartiallyContainedChild.Clone(false);
                         fragment.AppendChild(clone);
                         var subrange = new Range(originalStart, new Boundary(firstPartiallyContainedChild, firstPartiallyContainedChild.ChildNodes.Length));
                         var subfragment = subrange.ExtractContent();
-                        fragment.AppendChild(subfragment);
+                        clone.AppendChild(subfragment);
                     }
 
                     foreach (var child in containedChildren)
@@ -458,11 +460,11 @@ namespace AngleSharp.Dom
                     }
                     else if (lastPartiallyContainedchild != null)
                     {
-                        var clone = lastPartiallyContainedchild.Clone();
+                        var clone = lastPartiallyContainedchild.Clone(false);
                         fragment.AppendChild(clone);
                         var subrange = new Range(new Boundary(lastPartiallyContainedchild, 0), originalEnd);
                         var subfragment = subrange.ExtractContent();
-                        fragment.AppendChild(subfragment);
+                        clone.AppendChild(subfragment);
                     }
 
                     _start = newBoundary;


### PR DESCRIPTION
## Description

`Range.ExtractContent()` (`extractContents()`) deviated from the [DOM Standard algorithm](https://dom.spec.whatwg.org/#dom-range-extractcontents) in several ways and corrupted the document:

- **Contained children** were computed as *all descendants* of the common ancestor that *intersect* the range, instead of the *direct children* that are *contained* in it. Partially contained nodes and nested descendants were therefore moved into the fragment a second time, corrupting both the fragment and the source tree.
- The **first/last partially contained child** was searched among all descendants instead of the direct children of the common ancestor, so nested boundaries picked the wrong node.
- Partially contained elements were **cloned deeply** (spec requires a shallow clone) and their subrange fragment was appended to the outer fragment instead of the clone, flattening and duplicating content.
- The **new boundary** computation climbed one level too far and passed node/offset to the wrong `Boundary` arguments, throwing `NullReferenceException` when the common ancestor has no parent (detached subtrees) and collapsing the range to a wrong position otherwise. It now mirrors the correct logic already used by `ClearContent`.

### Example

```csharp
// <p>abc<b>def</b>ghi</p>, range from 'abc'@1 to 'ghi'@2
var fragment = range.ExtractContent();
// Before: fragment = bca<b></b>defigh, <p> left empty
// After (matches browsers): fragment = bc<b>def</b>gh, <p> = ai
```

Extracting inside a detached subtree (e.g. a `<div>` created via `CreateElement`) previously threw `NullReferenceException`.

`ClearContent`/`deleteContents()` was already correct and is untouched.

## Types of changes

- [x] Bug fix (non-breaking change which fixes an issue)

## Checklist

- [x] My code follows the code style of this project.
- [x] I have added tests to cover my changes.
- [x] All new and existing tests passed.

🤖 Generated with [Claude Code](https://claude.com/claude-code)