### PR TITLE
Fix Range.CopyContent to follow the DOM Standard

### DIFF
--- a/src/AngleSharp.Core.Tests/Library/Range.cs
+++ b/src/AngleSharp.Core.Tests/Library/Range.cs
@@ -163,6 +163,40 @@ namespace AngleSharp.Core.Tests.Library
         }
 
         [Test]
+        public void CanCopyContentWithPartiallyContainedTextNodes()
+        {
+            var document = "<p>abc<b>def</b>ghi</p>".ToHtmlDocument();
+            var p = document.QuerySelector("p");
+            var range = document.CreateRange();
+            range.StartWith(p.ChildNodes[0], 1);
+            range.EndWith(p.ChildNodes[2], 2);
+
+            var fragment = range.CopyContent();
+            var div = document.CreateElement("div");
+            div.AppendChild(fragment);
+
+            Assert.AreEqual("bc<b>def</b>gh", div.InnerHtml);
+            Assert.AreEqual("abc<b>def</b>ghi", p.InnerHtml);
+        }
+
+        [Test]
+        public void CanCopyContentWithPartiallyContainedElements()
+        {
+            var document = "<div id=host><a>abc</a><b>def</b></div>".ToHtmlDocument();
+            var host = document.QuerySelector("#host");
+            var range = document.CreateRange();
+            range.StartWith(document.QuerySelector("a").FirstChild, 1);
+            range.EndWith(document.QuerySelector("b").FirstChild, 1);
+
+            var fragment = range.CopyContent();
+            var div = document.CreateElement("div");
+            div.AppendChild(fragment);
+
+            Assert.AreEqual("<a>bc</a><b>d</b>", div.InnerHtml);
+            Assert.AreEqual("<a>abc</a><b>def</b>", host.InnerHtml);
+        }
+
+        [Test]
         public void CanClearContent()
         {
             var document = @"

--- a/src/AngleSharp/Dom/Internal/Range.cs
+++ b/src/AngleSharp/Dom/Internal/Range.cs
@@ -502,10 +502,12 @@ namespace AngleSharp.Dom
                     }
 
                     var firstPartiallyContainedChild = !originalStart.Node.IsInclusiveAncestorOf(originalEnd.Node) ?
-                        commonAncestor.GetNodes<INode>(predicate: IsPartiallyContained).FirstOrDefault() : null;
+                        commonAncestor.ChildNodes.FirstOrDefault(IsPartiallyContained) : null;
                     var lastPartiallyContainedchild = !originalEnd.Node.IsInclusiveAncestorOf(originalStart.Node) ?
-                        commonAncestor.GetNodes<INode>(predicate: IsPartiallyContained).LastOrDefault() : null;
-                    var containedChildren = commonAncestor.GetNodes<INode>(predicate: Intersects).ToList();
+                        commonAncestor.ChildNodes.LastOrDefault(IsPartiallyContained) : null;
+                    var containedChildren = commonAncestor.ChildNodes
+                        .Where(m => new Boundary(m, 0) > originalStart && new Boundary(m, GetNodeLength(m)) < originalEnd)
+                        .ToList();
 
                     if (containedChildren.OfType<IDocumentType>().Any())
                     {
@@ -523,11 +525,11 @@ namespace AngleSharp.Dom
                     }
                     else if (firstPartiallyContainedChild != null)
                     {
-                        var clone = firstPartiallyContainedChild.Clone();
+                        var clone = firstPartiallyContainedChild.Clone(false);
                         fragment.AppendChild(clone);
                         var subrange = new Range(originalStart, new Boundary(firstPartiallyContainedChild, firstPartiallyContainedChild.ChildNodes.Length));
                         var subfragment = subrange.CopyContent();
-                        fragment.AppendChild(subfragment);
+                        clone.AppendChild(subfragment);
                     }
 
                     foreach (var child in containedChildren)
@@ -544,11 +546,11 @@ namespace AngleSharp.Dom
                     }
                     else if (lastPartiallyContainedchild != null)
                     {
-                        var clone = lastPartiallyContainedchild.Clone();
+                        var clone = lastPartiallyContainedchild.Clone(false);
                         fragment.AppendChild(clone);
                         var subrange = new Range(new Boundary(lastPartiallyContainedchild, 0), originalEnd);
                         var subfragment = subrange.CopyContent();
-                        fragment.AppendChild(subfragment);
+                        clone.AppendChild(subfragment);
                     }
                 }
             }


### PR DESCRIPTION
## Description

`Range.CopyContent()` (`cloneContents()`) deviated from the [DOM Standard algorithm](https://dom.spec.whatwg.org/#dom-range-clonecontents) and duplicated content:

- **Contained children** were computed as *all descendants* of the common ancestor that *intersect* the range, instead of the *direct children* that are *contained* in it, so partially contained nodes and nested descendants were cloned into the fragment multiple times.
- The **first/last partially contained child** was searched among all descendants instead of the direct children of the common ancestor.
- Partially contained elements were **cloned deeply** (spec requires a shallow clone) and their subrange fragment was appended to the outer fragment instead of the clone, flattening and duplicating content.

### Example

```csharp
// <p>abc<b>def</b>ghi</p>, range from 'abc'@1 to 'ghi'@2
var fragment = range.CopyContent();
// Before: fragment = bcabc<b>def</b>defghigh
// After (matches browsers): fragment = bc<b>def</b>gh
```

Same root cause as the `ExtractContent` fix in #1256, applied to the clone-only path.

## Types of changes

- [x] Bug fix (non-breaking change which fixes an issue)

## Checklist

- [x] My code follows the code style of this project.
- [x] I have added tests to cover my changes.
- [x] All new and existing tests passed.

🤖 Generated with [Claude Code](https://claude.com/claude-code)