### PR TITLE
Fix swapped END_TO_END and END_TO_START in Range.CompareBoundaryTo

### DIFF
--- a/src/AngleSharp.Core.Tests/Library/Range.cs
+++ b/src/AngleSharp.Core.Tests/Library/Range.cs
@@ -1,5 +1,6 @@
 namespace AngleSharp.Core.Tests.Library
 {
+    using AngleSharp.Dom;
     using NUnit.Framework;
 
     [TestFixture]
@@ -99,6 +100,33 @@ namespace AngleSharp.Core.Tests.Library
 
             Assert.AreEqual(p1, range1.CommonAncestor);
             Assert.AreEqual(document.Body, range2.CommonAncestor);
+        }
+
+        [Test]
+        public void CanCompareBoundaryPointsOfOverlappingRanges()
+        {
+            var document = "<p>abc<b>def</b>ghi</p>".ToHtmlDocument();
+            var p = document.QuerySelector("p");
+            var outer = document.CreateRange();
+            outer.StartWith(p, 0);
+            outer.EndWith(p, 3);
+            var inner = document.CreateRange();
+            inner.StartWith(p, 1);
+            inner.EndWith(p, 2);
+
+            // START_TO_START compares this start (p,0) to source start (p,1)
+            Assert.AreEqual(RangePosition.Before, outer.CompareBoundaryTo(RangeType.StartToStart, inner));
+            // START_TO_END compares this end (p,3) to source start (p,1)
+            Assert.AreEqual(RangePosition.After, outer.CompareBoundaryTo(RangeType.StartToEnd, inner));
+            // END_TO_END compares this end (p,3) to source end (p,2)
+            Assert.AreEqual(RangePosition.After, outer.CompareBoundaryTo(RangeType.EndToEnd, inner));
+            // END_TO_START compares this start (p,0) to source end (p,2)
+            Assert.AreEqual(RangePosition.Before, outer.CompareBoundaryTo(RangeType.EndToStart, inner));
+
+            Assert.AreEqual(RangePosition.After, inner.CompareBoundaryTo(RangeType.StartToStart, outer));
+            Assert.AreEqual(RangePosition.After, inner.CompareBoundaryTo(RangeType.StartToEnd, outer));
+            Assert.AreEqual(RangePosition.Before, inner.CompareBoundaryTo(RangeType.EndToEnd, outer));
+            Assert.AreEqual(RangePosition.Before, inner.CompareBoundaryTo(RangeType.EndToStart, outer));
         }
 
         [Test]

--- a/src/AngleSharp/Dom/Internal/Range.cs
+++ b/src/AngleSharp/Dom/Internal/Range.cs
@@ -692,12 +692,12 @@ namespace AngleSharp.Dom
                     break;
 
                 case RangeType.EndToEnd:
-                    thisPoint = _start;
+                    thisPoint = _end;
                     otherPoint = new Boundary(sourceRange.Tail, sourceRange.End);
                     break;
 
                 case RangeType.EndToStart:
-                    thisPoint = _end;
+                    thisPoint = _start;
                     otherPoint = new Boundary(sourceRange.Tail, sourceRange.End);
                     break;
 


### PR DESCRIPTION
## Description

Per the [DOM Standard](https://dom.spec.whatwg.org/#dom-range-compareboundarypoints), `compareBoundaryPoints(how, sourceRange)` maps:

- `END_TO_END` → compare **this end** to source end
- `END_TO_START` → compare **this start** to source end

`Range.CompareBoundaryTo` used the opposite boundary of this range for those two cases (this start for `EndToEnd`, this end for `EndToStart`). The bug only surfaces with **overlapping** ranges — for disjoint ranges both mappings happen to produce the same result, which is presumably why it went unnoticed.

```csharp
// outer = (p,0)..(p,3), inner = (p,1)..(p,2)
outer.CompareBoundaryTo(RangeType.EndToEnd, inner);
// Before: RangePosition.Before (compared outer start (p,0) to inner end (p,2))
// After:  RangePosition.After  (compares outer end (p,3) to inner end (p,2)) — matches browsers
```

## Types of changes

- [x] Bug fix (non-breaking change which fixes an issue)

## Checklist

- [x] My code follows the code style of this project.
- [x] I have added tests to cover my changes.
- [x] All new and existing tests passed.

🤖 Generated with [Claude Code](https://claude.com/claude-code)