### PR TITLE
Fix Range.IsCollapsed to also compare offsets

### DIFF
--- a/src/AngleSharp.Core.Tests/Library/Range.cs
+++ b/src/AngleSharp.Core.Tests/Library/Range.cs
@@ -36,6 +36,25 @@ namespace AngleSharp.Core.Tests.Library
         }
 
         [Test]
+        public void RangeWithDifferentOffsetsInSameNodeIsNotCollapsed()
+        {
+            var document = "<p>abc<b>def</b>ghi</p>".ToHtmlDocument();
+            var p = document.QuerySelector("p");
+            var range = document.CreateRange();
+            range.Select(p.QuerySelector("b"));
+
+            Assert.AreEqual(p, range.Head);
+            Assert.AreEqual(1, range.Start);
+            Assert.AreEqual(p, range.Tail);
+            Assert.AreEqual(2, range.End);
+            Assert.IsFalse(range.IsCollapsed);
+
+            range.Collapse(true);
+
+            Assert.IsTrue(range.IsCollapsed);
+        }
+
+        [Test]
         public void CanSelectSomeRange_Issue1119()
         {
             var document = "<body><p><em>Text1</em>Text2</p></body>".ToHtmlDocument();

--- a/src/AngleSharp/Dom/Internal/Range.cs
+++ b/src/AngleSharp/Dom/Internal/Range.cs
@@ -48,7 +48,7 @@ namespace AngleSharp.Dom
 
         public Int32 End => _end.Offset;
 
-        public Boolean IsCollapsed => _start.Node == _end.Node;
+        public Boolean IsCollapsed => _start.Node == _end.Node && _start.Offset == _end.Offset;
 
         public INode CommonAncestor
         {


### PR DESCRIPTION
## Description

Per the [DOM Standard](https://dom.spec.whatwg.org/#range-collapsed), a range is collapsed only if its start and end are the **same boundary point** (same node *and* same offset). `Range.IsCollapsed` only compared the nodes:

```csharp
public Boolean IsCollapsed => _start.Node == _end.Node;
```

so any range whose boundaries live in the same container — e.g. after `Select(node)` (`selectNode()`), which sets `(parent, i)` .. `(parent, i + 1)` — was wrongly reported as collapsed.

## Types of changes

- [x] Bug fix (non-breaking change which fixes an issue)

## Checklist

- [x] My code follows the code style of this project.
- [x] I have added tests to cover my changes.
- [x] All new and existing tests passed.

🤖 Generated with [Claude Code](https://claude.com/claude-code)