### PR TITLE
Fix NodeIterator pre-removing steps to use the first following node

### DIFF
--- a/src/AngleSharp.Core.Tests/Library/NodeIterator.cs
+++ b/src/AngleSharp.Core.Tests/Library/NodeIterator.cs
@@ -237,5 +237,53 @@
             Assert.AreEqual(inner1, node2);
             Assert.AreEqual(inner2, node3);
         }
+
+        [Test]
+        public void NodeIteratorShouldMoveReferenceToFollowingNodeOnRemoval()
+        {
+            var doc = "<div id='root'><div id='a'></div><div id='b'><div id='c'></div></div><div id='d'></div></div>".ToHtmlDocument();
+            var root = doc.GetElementById("root");
+            var b = doc.GetElementById("b");
+            var c = doc.GetElementById("c");
+            var d = doc.GetElementById("d");
+            var iterator = doc.CreateNodeIterator(root, FilterSettings.Element);
+
+            iterator.Next(); // root
+            iterator.Next(); // a
+            iterator.Next(); // b
+            iterator.Next(); // c
+            Assert.AreEqual(c, iterator.Previous());
+            Assert.IsTrue(iterator.IsBeforeReference);
+
+            b.Parent.RemoveChild(b);
+
+            Assert.AreEqual(d, iterator.Reference);
+            Assert.AreEqual(d, iterator.Next());
+        }
+
+        [Test]
+        public void NodeIteratorShouldNotRevisitNodesWhenReferenceParentIsRemoved()
+        {
+            var doc = "<div id='root'><div id='first'></div><div id='second'><div id='third'></div></div></div>".ToHtmlDocument();
+            var root = doc.GetElementById("root");
+            var first = doc.GetElementById("first");
+            var second = doc.GetElementById("second");
+            var third = doc.GetElementById("third");
+            var iterator = doc.CreateNodeIterator(root, FilterSettings.Element);
+
+            Assert.AreEqual(root, iterator.Next());
+            Assert.AreEqual(first, iterator.Next());
+            Assert.AreEqual(second, iterator.Next());
+            Assert.AreEqual(third, iterator.Next());
+            Assert.AreEqual(third, iterator.Previous());
+
+            second.Parent.RemoveChild(second);
+
+            Assert.AreEqual(first, iterator.Reference);
+            Assert.IsFalse(iterator.IsBeforeReference);
+            Assert.AreEqual(null, iterator.Next());
+            Assert.AreEqual(first, iterator.Previous());
+            Assert.AreEqual(root, iterator.Previous());
+        }
     }
 }

--- a/src/AngleSharp/Dom/Internal/NodeIterator.cs
+++ b/src/AngleSharp/Dom/Internal/NodeIterator.cs
@@ -59,7 +59,9 @@ namespace AngleSharp.Dom
             {
                 if (IsBeforeReference)
                 {
-                    var next = Root.GetDescendants().FirstOrDefault(m => !m.IsInclusiveDescendantOf(node));
+                    var next = Root.GetDescendants()
+                        .SkipWhile(m => !Object.ReferenceEquals(m, node))
+                        .FirstOrDefault(m => !m.IsInclusiveDescendantOf(node));
 
                     if (next is not null)
                     {


### PR DESCRIPTION
## Description

Per the [DOM Standard pre-removing steps](https://dom.spec.whatwg.org/#nodeiterator-pre-removing-steps), when a node containing the iterator's reference is removed while the pointer is *before* the reference, the new reference must be the removed node's first **following** node (within the root, not a descendant of the removed node). If there is none, the pointer flips to *after* and the reference becomes the deepest last descendant of the previous sibling.

The implementation searched `Root.GetDescendants()` **from the beginning of the tree**, so it always found the first node of the root's subtree outside the removed branch — which can be *before* the removed node. This moved the reference backwards, made `NextNode()` re-return already visited nodes instead of `null`, and made `PreviousNode()` return the wrong node; the pointer-before/previous-sibling fallback was effectively unreachable.

The fix skips ahead to the removed node in tree order before searching, matching the spec (follow-up to the pre-remove handling introduced for #1222).

```csharp
// <div id=root><a></a><b><i></i></b></div>, iterator at <i> (pointer before), remove <b>
iterator.Next();
// Before: <a> (already visited!)   After: null — matches browsers
```

## Types of changes

- [x] Bug fix (non-breaking change which fixes an issue)

## Checklist

- [x] My code follows the code style of this project.
- [x] I have added tests to cover my changes.
- [x] All new and existing tests passed.

🤖 Generated with [Claude Code](https://claude.com/claude-code)