### PR TITLE
Observe media attribute changes on SVG style elements

### DIFF
--- a/src/AngleSharp.Core.Tests/Css/StyleExtensions.cs
+++ b/src/AngleSharp.Core.Tests/Css/StyleExtensions.cs
@@ -115,6 +115,23 @@ namespace AngleSharp.Core.Tests.Css
             Assert.IsNotNull(style);
             Assert.AreEqual(style.Sheet.OwnerNode.TextContent, "circle { fill: gold; }");
         }
+
+        [Test]
+        public async Task SvgStyleMediaAttributeShouldUpdateStyleSheetMedia()
+        {
+            var stylingService = new MockStylingService();
+            var cfg = Configuration.Default.WithOnly<IStylingService>(stylingService);
+            var svg = @"<svg><style>circle { fill: gold; }</style></svg>";
+            var document = await BrowsingContext.New(cfg).OpenAsync(m => m.Content(svg));
+
+            var style = document.QuerySelector("svg > style");
+            var sheet = ((ILinkStyle)style).Sheet;
+            Assert.IsNotNull(sheet);
+
+            style.SetAttribute(AttributeNames.Media, "print");
+
+            Assert.AreEqual("print", sheet.Media.MediaText);
+        }
     }
 
     internal class MockStylingService : IStylingService

--- a/src/AngleSharp/Dom/Internal/DefaultAttributeObserver.cs
+++ b/src/AngleSharp/Dom/Internal/DefaultAttributeObserver.cs
@@ -1,6 +1,7 @@
 namespace AngleSharp.Dom
 {
     using AngleSharp.Html.Dom;
+    using AngleSharp.Svg.Dom;
     using AngleSharp.Text;
     using System;
     using System.Collections.Generic;
@@ -40,6 +41,7 @@ namespace AngleSharp.Dom
             RegisterObserver<HtmlUrlBaseElement>(AttributeNames.Ping, (element, value) => element.UpdatePing(value));
             RegisterObserver<HtmlTableCellElement>(AttributeNames.Headers, (element, value) => element.UpdateHeaders(value));
             RegisterObserver<HtmlStyleElement>(AttributeNames.Media, (element, value) => element.UpdateMedia(value));
+            RegisterObserver<SvgStyleElement>(AttributeNames.Media, (element, value) => element.UpdateMedia(value));
             RegisterObserver<HtmlSelectElement>(AttributeNames.Value, (element, value) => element.UpdateValue(value));
             RegisterObserver<HtmlOutputElement>(AttributeNames.For, (element, value) => element.UpdateFor(value));
             RegisterObserver<HtmlObjectElement>(AttributeNames.Data, (element, value) => element.UpdateSource(value));


### PR DESCRIPTION
## Description

`DefaultAttributeObserver` registers the `media` → `UpdateMedia` observer for `HtmlStyleElement` only. The SVG `<style>` element added in #1233 has the same `UpdateMedia` plumbing but no registration, so changing the `media` attribute on an SVG style element never updated its stylesheet's `MediaList` (observable with a styling service such as AngleSharp.Css installed).

This mirrors the existing HTML registration for `SvgStyleElement` and adds a test using the existing `MockStylingService`.

## Types of changes

- [x] Bug fix (non-breaking change which fixes an issue)

## Checklist

- [x] My code follows the code style of this project.
- [x] I have added tests to cover my changes.
- [x] All new and existing tests passed.

🤖 Generated with [Claude Code](https://claude.com/claude-code)