### PR TITLE
Fix O(n^2) regression for .net full framework

### DIFF
--- a/src/AngleSharp.Benchmarks/ParserBenchmark.cs
+++ b/src/AngleSharp.Benchmarks/ParserBenchmark.cs
@@ -14,9 +14,6 @@ using HtmlAgilityPack;
 namespace AngleSharp.Benchmarks
 {
     using System;
-    using System.Linq;
-    using Html;
-    using Text;
 
     [MemoryDiagnoser, GroupBenchmarksBy(BenchmarkLogicalGroupRule.ByParams), ShortRunJob]
     public class ParserBenchmark
@@ -111,52 +108,5 @@ namespace AngleSharp.Benchmarks
         {
             using var _ = angleSharpParser.ParseDocument(UrlTest.Source.AsMemory());
         }
-    }
-
-    [MemoryDiagnoser, ShortRunJob]
-    public class ScanDataTextBenchmark
-    {
-        [Params(100, 1_000, 10_000)]
-        public Int32 Repeats { get; set; }
-        private String html;
-        private Char[] chars;
-
-        [GlobalSetup]
-        public void Setup()
-        {
-            html = String.Concat(Enumerable.Repeat("<p>Hello World.<br>How are you?<br/>All good<br /> Ok, bye.</p>", Repeats));
-            chars = html.ToCharArray();
-        }
-
-        [Benchmark]
-        public Int32 StringSource() => Go(new TextSource(html));
-
-        [Benchmark]
-        public Int32 CharSource() => Go(new TextSource(new CharArrayTextSource(chars, chars.Length)));
-
-        [Benchmark]
-        public Int32 MemSource() => Go(new TextSource(new ReadOnlyMemoryTextSource(html.AsMemory())));
-
-        private static Int32 Go(TextSource source)
-        {
-            var tokenizer = new HtmlTokenizer(source, HtmlEntityProvider.Resolver)
-            {
-                DisableElementPositionTracking = true
-            };
-
-            var tokens = 0;
-            while (true)
-            {
-                ref var token = ref tokenizer.GetStructToken();
-                if (token.Type == HtmlTokenType.EndOfFile)
-                {
-                    break;
-                }
-                tokens++;
-            }
-
-            return tokens;
-        }
-
     }
 }

--- a/src/AngleSharp.Benchmarks/ParserBenchmark.cs
+++ b/src/AngleSharp.Benchmarks/ParserBenchmark.cs
@@ -14,6 +14,9 @@ using HtmlAgilityPack;
 namespace AngleSharp.Benchmarks
 {
     using System;
+    using System.Linq;
+    using Html;
+    using Text;
 
     [MemoryDiagnoser, GroupBenchmarksBy(BenchmarkLogicalGroupRule.ByParams), ShortRunJob]
     public class ParserBenchmark
@@ -108,5 +111,52 @@ namespace AngleSharp.Benchmarks
         {
             using var _ = angleSharpParser.ParseDocument(UrlTest.Source.AsMemory());
         }
+    }
+
+    [MemoryDiagnoser, ShortRunJob]
+    public class ScanDataTextBenchmark
+    {
+        [Params(100, 1_000, 10_000)]
+        public Int32 Repeats { get; set; }
+        private String html;
+        private Char[] chars;
+
+        [GlobalSetup]
+        public void Setup()
+        {
+            html = String.Concat(Enumerable.Repeat("<p>Hello World.<br>How are you?<br/>All good<br /> Ok, bye.</p>", Repeats));
+            chars = html.ToCharArray();
+        }
+
+        [Benchmark]
+        public Int32 StringSource() => Go(new TextSource(html));
+
+        [Benchmark]
+        public Int32 CharSource() => Go(new TextSource(new CharArrayTextSource(chars, chars.Length)));
+
+        [Benchmark]
+        public Int32 MemSource() => Go(new TextSource(new ReadOnlyMemoryTextSource(html.AsMemory())));
+
+        private static Int32 Go(TextSource source)
+        {
+            var tokenizer = new HtmlTokenizer(source, HtmlEntityProvider.Resolver)
+            {
+                DisableElementPositionTracking = true
+            };
+
+            var tokens = 0;
+            while (true)
+            {
+                ref var token = ref tokenizer.GetStructToken();
+                if (token.Type == HtmlTokenType.EndOfFile)
+                {
+                    break;
+                }
+                tokens++;
+            }
+
+            return tokens;
+        }
+
     }
 }

--- a/src/AngleSharp.Benchmarks/ScanDataTextBenchmark.cs
+++ b/src/AngleSharp.Benchmarks/ScanDataTextBenchmark.cs
@@ -1,0 +1,54 @@
+﻿namespace AngleSharp.Benchmarks;
+
+using System;
+using System.Linq;
+using BenchmarkDotNet.Attributes;
+using Html;
+using Html.Parser;
+using Text;
+
+[MemoryDiagnoser, ShortRunJob]
+public class ScanDataTextBenchmark
+{
+    [Params(100, 1_000, 10_000)]
+    public Int32 Repeats { get; set; }
+    private String _html;
+    private Char[] _chars;
+
+    [GlobalSetup]
+    public void Setup()
+    {
+        _html = String.Concat(Enumerable.Repeat("<p>Hello World.<br>How are you?<br/>All good<br /> Ok, bye.</p>", Repeats));
+        _chars = _html.ToCharArray();
+    }
+
+    [Benchmark]
+    public Int32 StringSource() => Go(new TextSource(_html));
+
+    [Benchmark]
+    public Int32 CharSource() => Go(new TextSource(new CharArrayTextSource(_chars, _chars.Length)));
+
+    [Benchmark]
+    public Int32 MemSource() => Go(new TextSource(new ReadOnlyMemoryTextSource(_html.AsMemory())));
+
+    private static Int32 Go(TextSource source)
+    {
+        var tokenizer = new HtmlTokenizer(source, HtmlEntityProvider.Resolver)
+        {
+            DisableElementPositionTracking = true
+        };
+
+        var tokens = 0;
+        while (true)
+        {
+            ref var token = ref tokenizer.GetStructToken();
+            if (token.Type == HtmlTokenType.EndOfFile)
+            {
+                break;
+            }
+            tokens++;
+        }
+
+        return tokens;
+    }
+}

--- a/src/AngleSharp/Common/BaseTokenizer.cs
+++ b/src/AngleSharp/Common/BaseTokenizer.cs
@@ -428,7 +428,8 @@ namespace AngleSharp.Common
             var found = remaining.IndexOfAny(DataTextTerminators);
 #else
             var found = remaining.IndexOfAny('<', '&', '\0');
-            var nlIdx = remaining.IndexOfAny('\r', '\n');
+            var nlSearchSpace = found < 0 ? remaining : remaining.Slice(0, found);
+            var nlIdx = nlSearchSpace.IndexOfAny('\r', '\n');
             if (nlIdx >= 0 && (found < 0 || nlIdx < found))
             {
                 found = nlIdx;


### PR DESCRIPTION
# Types of Changes

## Prerequisites

Please make sure you can check the following two boxes:

- [x] I have read the **CONTRIBUTING** document
- [x] My code follows the code style of this project

## Contribution Type

What types of changes does your code introduce? Put an `x` in all the boxes that apply:

- [x] Bug fix (non-breaking change which fixes an issue, please reference the issue id)
- [ ] New feature (non-breaking change which adds functionality, make sure to open an associated issue first)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] My change requires a change to the documentation
- [ ] I have updated the documentation accordingly
- [x] I have added tests to cover my changes
- [x] All new and existing tests passed

## Description

Fixes quadratic time for minified html parsing on full framework.

Before

| Method       | Repeats | Mean           | Error           | StdDev       | Gen0     | Gen1     | Gen2     | Allocated  |
|------------- |-------- |---------------:|----------------:|-------------:|---------:|---------:|---------:|-----------:|
| StringSource | 100     |       216.0 us |         8.98 us |      0.49 us |   6.1035 |   0.2441 |        - |   37.73 KB |
| CharSource   | 100     |       950.1 us |        23.44 us |      1.28 us |   2.9297 |        - |        - |   18.68 KB |
| MemSource    | 100     |       988.1 us |       115.57 us |      6.34 us |   1.9531 |        - |        - |   18.67 KB |
| StringSource | 1000    |     2,227.5 us |       218.01 us |     11.95 us |  35.1563 |  35.1563 |  35.1563 |  331.85 KB |
| CharSource   | 1000    |    81,464.2 us |     3,795.32 us |    208.03 us |        - |        - |        - |  258.31 KB |
| MemSource    | 1000    |    81,837.3 us |     1,721.96 us |     94.39 us |        - |        - |        - |  258.31 KB |
| StringSource | 10000   |    21,850.3 us |     3,424.26 us |    187.70 us | 562.5000 | 250.0000 | 250.0000 | 3273.25 KB |
| CharSource   | 10000   | 8,011,800.5 us |   795,739.74 us | 43,617.18 us |        - |        - |        - | 2048.02 KB |
| MemSource    | 10000   | 8,063,873.5 us | 1,607,227.96 us | 88,097.59 us |        - |        - |        - | 2048.02 KB |

After

| Method       | Repeats | Mean        | Error       | StdDev    | Gen0     | Gen1     | Gen2     | Allocated  |
|------------- |-------- |------------:|------------:|----------:|---------:|---------:|---------:|-----------:|
| StringSource | 100     |    230.6 us |    28.29 us |   1.55 us |   6.1035 |   0.2441 |        - |   37.73 KB |
| CharSource   | 100     |    152.5 us |    17.93 us |   0.98 us |   2.9297 |        - |        - |   18.68 KB |
| MemSource    | 100     |    186.6 us |     8.71 us |   0.48 us |   2.9297 |        - |        - |   18.67 KB |
| StringSource | 1000    |  2,250.4 us |   243.83 us |  13.37 us |  35.1563 |  35.1563 |  35.1563 |  331.85 KB |
| CharSource   | 1000    |  1,546.3 us |   154.11 us |   8.45 us |  41.0156 |  41.0156 |  41.0156 |   130.7 KB |
| MemSource    | 1000    |  1,883.6 us |   146.66 us |   8.04 us |  41.0156 |  41.0156 |  41.0156 |   130.7 KB |
| StringSource | 10000   | 22,421.8 us | 6,478.61 us | 355.11 us | 562.5000 | 250.0000 | 250.0000 | 3273.34 KB |
| CharSource   | 10000   | 15,212.2 us |   400.16 us |  21.93 us | 281.2500 | 281.2500 | 281.2500 | 2053.63 KB |
| MemSource    | 10000   | 18,749.1 us | 1,044.97 us |  57.28 us | 281.2500 | 281.2500 | 281.2500 | 2053.55 KB |