### PR TITLE
Expose asynchronous HTML token source seam

### DIFF
--- a/src/AngleSharp.Core.Tests/Html/AsyncTokenSource.cs
+++ b/src/AngleSharp.Core.Tests/Html/AsyncTokenSource.cs
@@ -1,0 +1,91 @@
+namespace AngleSharp.Core.Tests.Html
+{
+    using System;
+    using System.Collections.Generic;
+    using System.Threading;
+    using System.Threading.Tasks;
+    using AngleSharp.Html.Dom.Events;
+    using AngleSharp.Html.Parser;
+    using AngleSharp.Html.Parser.Tokens;
+    using AngleSharp.Html.Parser.Tokens.Struct;
+    using AngleSharp.Text;
+    using NUnit.Framework;
+
+    [TestFixture]
+    public class AsyncTokenSourceTests
+    {
+        [Test]
+        public async Task TreeBuilderWaitsWheneverSegmentedTokenSourceNeedsInput()
+        {
+            using var source = new SegmentedTokenSource(
+                StructHtmlToken.Open("pre"),
+                StructHtmlToken.Character("\nhello", default),
+                StructHtmlToken.Close("pre"),
+                StructHtmlToken.EndOfFile(default));
+
+            var parse = new HtmlParser().ParseDocumentAsync(source);
+            Assert.IsFalse(parse.IsCompleted);
+            var document = await parse;
+
+            Assert.AreEqual("hello", document.Body.TextContent);
+            Assert.AreEqual(3, source.WaitCount);
+        }
+
+        private sealed class SegmentedTokenSource : IHtmlTokenSource
+        {
+            private readonly Queue<StructHtmlToken> _tokens;
+            private Boolean _available = true;
+
+            public SegmentedTokenSource(params StructHtmlToken[] tokens) => _tokens = new(tokens);
+
+            public Int32 WaitCount { get; private set; }
+
+            public event EventHandler<HtmlErrorEvent> Error;
+
+            public HtmlParseMode State { get; set; }
+            public Boolean IsAcceptingCharacterData { get; set; }
+            public Boolean IsStrictMode { get; set; }
+            public Boolean IsSupportingProcessingInstructions { get; set; }
+            public Boolean IsNotConsumingCharacterReferences { get; set; }
+            public Boolean IsPreservingAttributeNames { get; set; }
+            public Boolean SkipRawText { get; set; }
+            public Boolean SkipScriptText { get; set; }
+            public Boolean SkipDataText { get; set; }
+            public Boolean SkipComments { get; set; }
+            public Boolean SkipPlaintext { get; set; }
+            public Boolean SkipRCDataText { get; set; }
+            public Boolean SkipCDATA { get; set; }
+            public Boolean SkipProcessingInstructions { get; set; }
+            public Boolean DisableElementPositionTracking { get; set; }
+            public ShouldEmitAttribute ShouldEmitAttribute { get; set; } =
+                static (ref StructHtmlToken _, ReadOnlyMemory<Char> _) => true;
+            public Action<HtmlToken, TextRange> OnToken { get; set; }
+
+            public Boolean TryGetStructToken(out StructHtmlToken token)
+            {
+                if (!_available)
+                {
+                    token = default;
+                    return false;
+                }
+                token = _tokens.Dequeue();
+                _available = _tokens.Count == 0;
+                return true;
+            }
+
+            public async Task WaitForInputAsync(CancellationToken cancellationToken)
+            {
+                cancellationToken.ThrowIfCancellationRequested();
+                WaitCount++;
+                await Task.Yield();
+                cancellationToken.ThrowIfCancellationRequested();
+                _available = true;
+            }
+
+            public void RaiseErrorOccurred(HtmlParseError code, TextPosition position) =>
+                Error?.Invoke(this, new HtmlErrorEvent(code, position));
+
+            public void Dispose() { }
+        }
+    }
+}

--- a/src/AngleSharp.Core.Tests/Html/AsyncTokenSource.cs
+++ b/src/AngleSharp.Core.Tests/Html/AsyncTokenSource.cs
@@ -4,7 +4,6 @@ namespace AngleSharp.Core.Tests.Html
     using System.Collections.Generic;
     using System.Threading;
     using System.Threading.Tasks;
-    using AngleSharp.Html.Dom.Events;
     using AngleSharp.Html.Parser;
     using AngleSharp.Html.Parser.Tokens;
     using AngleSharp.Html.Parser.Tokens.Struct;
@@ -31,7 +30,20 @@ namespace AngleSharp.Core.Tests.Html
             Assert.AreEqual(3, source.WaitCount);
         }
 
-        private sealed class SegmentedTokenSource : IHtmlTokenSource
+        [Test]
+        public async Task CallerRetainsOwnershipOfAlternativeTokenSource()
+        {
+            var source = new SegmentedTokenSource(StructHtmlToken.EndOfFile(default));
+            var document = await new HtmlParser().ParseDocumentAsync(source);
+
+            document.Dispose();
+
+            Assert.IsFalse(source.IsDisposed);
+            source.Dispose();
+            Assert.IsTrue(source.IsDisposed);
+        }
+
+        private sealed class SegmentedTokenSource : IHtmlTokenSource, IDisposable
         {
             private readonly Queue<StructHtmlToken> _tokens;
             private Boolean _available = true;
@@ -39,27 +51,22 @@ namespace AngleSharp.Core.Tests.Html
             public SegmentedTokenSource(params StructHtmlToken[] tokens) => _tokens = new(tokens);
 
             public Int32 WaitCount { get; private set; }
+            public Boolean IsDisposed { get; private set; }
 
-            public event EventHandler<HtmlErrorEvent> Error;
+            public void Configure(
+                HtmlTokenizerOptions options,
+                Action<HtmlToken, TextRange> onToken,
+                Action<HtmlParseError, TextPosition> reportError)
+            {
+            }
 
-            public HtmlParseMode State { get; set; }
-            public Boolean IsAcceptingCharacterData { get; set; }
-            public Boolean IsStrictMode { get; set; }
-            public Boolean IsSupportingProcessingInstructions { get; set; }
-            public Boolean IsNotConsumingCharacterReferences { get; set; }
-            public Boolean IsPreservingAttributeNames { get; set; }
-            public Boolean SkipRawText { get; set; }
-            public Boolean SkipScriptText { get; set; }
-            public Boolean SkipDataText { get; set; }
-            public Boolean SkipComments { get; set; }
-            public Boolean SkipPlaintext { get; set; }
-            public Boolean SkipRCDataText { get; set; }
-            public Boolean SkipCDATA { get; set; }
-            public Boolean SkipProcessingInstructions { get; set; }
-            public Boolean DisableElementPositionTracking { get; set; }
-            public ShouldEmitAttribute ShouldEmitAttribute { get; set; } =
-                static (ref StructHtmlToken _, ReadOnlyMemory<Char> _) => true;
-            public Action<HtmlToken, TextRange> OnToken { get; set; }
+            public void SetState(HtmlParseMode state)
+            {
+            }
+
+            public void SetAcceptingCharacterData(Boolean value)
+            {
+            }
 
             public Boolean TryGetStructToken(out StructHtmlToken token)
             {
@@ -82,10 +89,7 @@ namespace AngleSharp.Core.Tests.Html
                 _available = true;
             }
 
-            public void RaiseErrorOccurred(HtmlParseError code, TextPosition position) =>
-                Error?.Invoke(this, new HtmlErrorEvent(code, position));
-
-            public void Dispose() { }
+            public void Dispose() => IsDisposed = true;
         }
     }
 }

--- a/src/AngleSharp/Html/Parser/HtmlDomBuilder.cs
+++ b/src/AngleSharp/Html/Parser/HtmlDomBuilder.cs
@@ -25,7 +25,8 @@ namespace AngleSharp.Html.Parser
         #region Fields
 
         private readonly TokenConsumer _consumeAsDelegate;
-        private readonly HtmlTokenizer _tokenizer;
+        private readonly IHtmlTokenSource _tokenizer;
+        private readonly HtmlTokenizer? _synchronousTokenizer;
         private readonly TDocument _document;
         private readonly List<IConstructableElement> _openElements;
         private readonly List<IConstructableElement> _formattingElements;
@@ -43,11 +44,13 @@ namespace AngleSharp.Html.Parser
         private Boolean _foster;
         private Boolean _frameset;
         private Boolean _ended;
+        private Boolean _shouldPreventNewLine;
 
         private Func<IConstructableElement, Boolean>? _shouldEnd;
         private readonly IDomConstructionElementFactory<TDocument, TElement> _elementFactory;
         private Task? _waiting;
         private readonly Boolean _emitWhitespaceTextNodes;
+        private readonly Boolean _usesDocumentSource;
 
         #endregion
 
@@ -68,11 +71,16 @@ namespace AngleSharp.Html.Parser
             TDocument document,
             HtmlTokenizerOptions? maybeOptions = null,
             Boolean emitWhitespaceTextNodes = false,
-            Func<IConstructableElement, Boolean>? shouldEnd = null)
+            Func<IConstructableElement, Boolean>? shouldEnd = null,
+            IHtmlTokenSource? tokenSource = null)
         {
             _shouldEnd = shouldEnd;
             _elementFactory = elementFactory;
-            _tokenizer = new HtmlTokenizer(document.Source, HtmlEntityProvider.ResolverExtended);
+            _usesDocumentSource = tokenSource is null;
+            _synchronousTokenizer = tokenSource is null
+                ? new HtmlTokenizer(document.Source, HtmlEntityProvider.ResolverExtended)
+                : null;
+            _tokenizer = tokenSource ?? _synchronousTokenizer!;
             _document = document;
             _openElements = [];
             _templateModes = new Stack<HtmlTreeMode>();
@@ -143,7 +151,7 @@ namespace AngleSharp.Html.Parser
 
             do
             {
-                ref var token = ref _tokenizer.GetStructToken();
+                ref var token = ref _synchronousTokenizer!.GetStructToken();
                 if (token.Type == HtmlTokenType.EndOfFile)
                 {
                     Consume(ref token);
@@ -190,13 +198,25 @@ namespace AngleSharp.Html.Parser
 
             do
             {
-                if (source.Length - source.Index < 1024)
+                if (_usesDocumentSource && source.Length - source.Index < 1024)
                 {
                     await source.PrefetchAsync(8192, cancelToken).ConfigureAwait(false);
                 }
                 cancelToken.ThrowIfCancellationRequested();
 
-                var @break = Worker(middleware);
+                StructHtmlToken token;
+                if (_synchronousTokenizer is not null)
+                {
+                    token = _synchronousTokenizer.GetStructToken();
+                }
+                else if (!_tokenizer.TryGetStructToken(out token))
+                {
+                    await _tokenizer.WaitForInputAsync(cancelToken).ConfigureAwait(false);
+                    continue;
+                }
+                PreventNewLineIfNeeded(ref token);
+
+                var @break = Worker(middleware, ref token);
                 if (@break) { break; }
 
                 if (_waiting is not null)
@@ -214,9 +234,8 @@ namespace AngleSharp.Html.Parser
 
             return _document;
 
-            Boolean Worker(TokenizerMiddleware middleware)
+            Boolean Worker(TokenizerMiddleware middleware, ref StructHtmlToken token)
             {
-                var token = _tokenizer.GetStructToken();
                 if (token.Type == HtmlTokenType.EndOfFile)
                 {
                     Consume(ref token);
@@ -4074,14 +4093,31 @@ namespace AngleSharp.Html.Parser
         /// </summary>
         private void PreventNewLine()
         {
-            var temp = _tokenizer.GetStructToken();
+            if (_synchronousTokenizer is null)
+            {
+                _shouldPreventNewLine = true;
+                return;
+            }
 
+            var temp = _synchronousTokenizer.GetStructToken();
             if (temp.Type == HtmlTokenType.Character)
             {
                 temp.RemoveNewLine();
             }
 
             Home(ref temp);
+        }
+
+        private void PreventNewLineIfNeeded(ref StructHtmlToken token)
+        {
+            if (_shouldPreventNewLine)
+            {
+                _shouldPreventNewLine = false;
+                if (token.Type == HtmlTokenType.Character)
+                {
+                    token.RemoveNewLine();
+                }
+            }
         }
 
         /// <summary>
@@ -4489,13 +4525,15 @@ namespace AngleSharp.Html.Parser
             IHtmlElementConstructionFactory elementFactory,
             HtmlDocument document,
             HtmlTokenizerOptions? maybeOptions = null,
-            String? stopAt = null)
+            String? stopAt = null,
+            IHtmlTokenSource? tokenSource = null)
             : base(
                 elementFactory: elementFactory,
                 document: document,
                 maybeOptions: maybeOptions,
                 emitWhitespaceTextNodes: true,
-                shouldEnd: stopAt is not null ? e => e.Prefix.Length == 0 && e.LocalName.Is(stopAt) : null)
+                shouldEnd: stopAt is not null ? e => e.Prefix.Length == 0 && e.LocalName.Is(stopAt) : null,
+                tokenSource: tokenSource)
         {
         }
     }

--- a/src/AngleSharp/Html/Parser/HtmlDomBuilder.cs
+++ b/src/AngleSharp/Html/Parser/HtmlDomBuilder.cs
@@ -56,11 +56,7 @@ namespace AngleSharp.Html.Parser
 
         #region Events
 
-        public event EventHandler<HtmlErrorEvent> Error
-        {
-            add { _tokenizer.Error += value; }
-            remove { _tokenizer.Error -= value; }
-        }
+        public event EventHandler<HtmlErrorEvent>? Error;
 
         #endregion
 
@@ -80,7 +76,7 @@ namespace AngleSharp.Html.Parser
             _synchronousTokenizer = tokenSource is null
                 ? new HtmlTokenizer(document.Source, HtmlEntityProvider.ResolverExtended)
                 : null;
-            _tokenizer = tokenSource ?? _synchronousTokenizer!;
+            _tokenizer = tokenSource ?? new HtmlTokenizerTokenSource(_synchronousTokenizer!);
             _document = document;
             _openElements = [];
             _templateModes = new Stack<HtmlTreeMode>();
@@ -94,25 +90,7 @@ namespace AngleSharp.Html.Parser
 
             if (maybeOptions.HasValue)
             {
-                var options = maybeOptions.Value;
-
-                _tokenizer.IsStrictMode = options.IsStrictMode;
-                _tokenizer.IsSupportingProcessingInstructions = options.IsSupportingProcessingInstructions;
-                _tokenizer.IsNotConsumingCharacterReferences = options.IsNotConsumingCharacterReferences;
-                _tokenizer.IsPreservingAttributeNames = options.IsPreservingAttributeNames;
-                _tokenizer.SkipRawText = options.SkipRawText;
-                _tokenizer.SkipScriptText = options.SkipScriptText;
-                _tokenizer.SkipDataText = options.SkipDataText;
-                _tokenizer.ShouldEmitAttribute = options.ShouldEmitAttribute;
-                _tokenizer.SkipDataText = options.SkipDataText;
-                _tokenizer.SkipScriptText = options.SkipScriptText;
-                _tokenizer.SkipRawText = options.SkipRawText;
-                _tokenizer.SkipComments = options.SkipComments;
-                _tokenizer.SkipPlaintext = options.SkipPlaintext;
-                _tokenizer.SkipRCDataText = options.SkipRCDataText;
-                _tokenizer.SkipCDATA = options.SkipCDATA;
-                _tokenizer.SkipProcessingInstructions = options.SkipProcessingInstructions;
-                _tokenizer.DisableElementPositionTracking = options.DisableElementPositionTracking;
+                _tokenizer.Configure(maybeOptions.Value, onToken: null, ReportError);
             }
         }
 
@@ -259,7 +237,7 @@ namespace AngleSharp.Html.Parser
         private void Restart()
         {
             _currentMode = HtmlTreeMode.Initial;
-            _tokenizer.State = HtmlParseMode.PCData;
+            _tokenizer.SetState(HtmlParseMode.PCData);
             _document.Clear();
             _ended = false;
             _frameset = true;
@@ -313,28 +291,28 @@ namespace AngleSharp.Html.Parser
 
             if (tagName.IsOneOf(TagNames.Title, TagNames.Textarea))
             {
-                _tokenizer.State = HtmlParseMode.RCData;
+                _tokenizer.SetState(HtmlParseMode.RCData);
             }
             else if (tagName.IsOneOf(TagNames.Style, TagNames.Xmp, TagNames.Iframe, TagNames.NoEmbed))
             {
-                _tokenizer.State = HtmlParseMode.Rawtext;
+                _tokenizer.SetState(HtmlParseMode.Rawtext);
             }
             else if (tagName.Is(TagNames.Script))
             {
-                _tokenizer.State = HtmlParseMode.Script;
+                _tokenizer.SetState(HtmlParseMode.Script);
             }
             else if (tagName.Is(TagNames.Plaintext))
             {
-                _tokenizer.State = HtmlParseMode.Plaintext;
+                _tokenizer.SetState(HtmlParseMode.Plaintext);
             }
             else if (tagName.Is(TagNames.NoScript) &&
                      (options.IsScripting || context.Flags.HasFlag(NodeFlags.LiteralText)))
             {
-                _tokenizer.State = HtmlParseMode.Rawtext;
+                _tokenizer.SetState(HtmlParseMode.Rawtext);
             }
             else if (tagName.Is(TagNames.NoFrames) && !options.IsNotSupportingFrames)
             {
-                _tokenizer.State = HtmlParseMode.Rawtext;
+                _tokenizer.SetState(HtmlParseMode.Rawtext);
             }
 
             var root = _elementFactory.Create(_document, TagNames.Html);
@@ -349,7 +327,7 @@ namespace AngleSharp.Html.Parser
 
             Reset();
 
-            _tokenizer.IsAcceptingCharacterData = !AdjustedCurrentNode!.Flags.HasFlag(NodeFlags.HtmlMember);
+            _tokenizer.SetAcceptingCharacterData(!AdjustedCurrentNode!.Flags.HasFlag(NodeFlags.HtmlMember));
 
             IConstructableNode? contextNode = context;
 
@@ -393,24 +371,8 @@ namespace AngleSharp.Html.Parser
 
         private void SetOptions(HtmlParserOptions options)
         {
-            _tokenizer.IsStrictMode = options.IsStrictMode;
-            _tokenizer.IsSupportingProcessingInstructions = options.IsSupportingProcessingInstructions;
-            _tokenizer.IsNotConsumingCharacterReferences = options.IsNotConsumingCharacterReferences;
-            _tokenizer.IsPreservingAttributeNames = options.IsPreservingAttributeNames;
-            _tokenizer.SkipRawText = options.SkipRawText;
-            _tokenizer.SkipScriptText = options.SkipScriptText;
-            _tokenizer.SkipDataText = options.SkipDataText;
-            _tokenizer.SkipScriptText = options.SkipScriptText;
-            _tokenizer.SkipRawText = options.SkipRawText;
-            _tokenizer.SkipComments = options.SkipComments;
-            _tokenizer.SkipPlaintext = options.SkipPlaintext;
-            _tokenizer.SkipRCDataText = options.SkipRCDataText;
-            _tokenizer.SkipCDATA = options.SkipCDATA;
-            _tokenizer.SkipProcessingInstructions = options.SkipProcessingInstructions;
-            _tokenizer.ShouldEmitAttribute = options.ShouldEmitAttribute!;
-            _tokenizer.DisableElementPositionTracking = options.DisableElementPositionTracking;
-            _tokenizer.OnToken = options.OnToken;
             _options = options;
+            _tokenizer.Configure(new HtmlTokenizerOptions(options), options.OnToken, ReportError);
         }
 
         #endregion
@@ -797,7 +759,7 @@ namespace AngleSharp.Html.Parser
                     {
                         var script = _elementFactory.CreateScript(_document, parserInserted: true, started: IsFragmentCase);
                         AddElement(script, ref token);
-                        _tokenizer.State = HtmlParseMode.Script;
+                        _tokenizer.SetState(HtmlParseMode.Script);
                         _previousMode = _currentMode;
                         _currentMode = HtmlTreeMode.Text;
                         return;
@@ -1229,7 +1191,7 @@ namespace AngleSharp.Html.Parser
             {
                 var textarea = _elementFactory.Create(_document, TagNames.Textarea);
                 AddElement(textarea, ref tag);
-                _tokenizer.State = HtmlParseMode.RCData;
+                _tokenizer.SetState(HtmlParseMode.RCData);
                 _previousMode = _currentMode;
                 _frameset = false;
                 _currentMode = HtmlTreeMode.Text;
@@ -1382,7 +1344,7 @@ namespace AngleSharp.Html.Parser
                 }
 
                 AddElement(ref tag);
-                _tokenizer.State = HtmlParseMode.Plaintext;
+                _tokenizer.SetState(HtmlParseMode.Plaintext);
             }
             else if (tagName.Is(TagNames.Frameset))
             {
@@ -3122,7 +3084,7 @@ namespace AngleSharp.Html.Parser
         {
             _previousMode = _currentMode;
             _currentMode = HtmlTreeMode.Text;
-            _tokenizer.State = HtmlParseMode.Rawtext;
+            _tokenizer.SetState(HtmlParseMode.Rawtext);
         }
 
         /// <summary>
@@ -3134,7 +3096,7 @@ namespace AngleSharp.Html.Parser
             AddElement(ref tag);
             _previousMode = _currentMode;
             _currentMode = HtmlTreeMode.Text;
-            _tokenizer.State = HtmlParseMode.RCData;
+            _tokenizer.SetState(HtmlParseMode.RCData);
         }
 
         /// <summary>
@@ -3739,7 +3701,7 @@ namespace AngleSharp.Html.Parser
                 if (!selfClosing)
                 {
                     _openElements.Add(node);
-                    _tokenizer.IsAcceptingCharacterData = true;
+                    _tokenizer.SetAcceptingCharacterData(true);
                 }
                 else if (tag.Name.Is(TagNames.Script))
                 {
@@ -4150,7 +4112,7 @@ namespace AngleSharp.Html.Parser
             _document.AddNode(element);
             SetupElement(element, ref tag, false);
             _openElements.Add(element);
-            _tokenizer.IsAcceptingCharacterData = false;
+            _tokenizer.SetAcceptingCharacterData(false);
             _document.ApplyManifest();
         }
 
@@ -4196,7 +4158,7 @@ namespace AngleSharp.Html.Parser
             {
                 CloseNodeAt(_openElements.Count - 1);
                 var node = AdjustedCurrentNode;
-                _tokenizer.IsAcceptingCharacterData = node is not null && !node.Flags.HasFlag(NodeFlags.HtmlMember);
+                _tokenizer.SetAcceptingCharacterData(node is not null && !node.Flags.HasFlag(NodeFlags.HtmlMember));
             }
         }
 
@@ -4279,7 +4241,7 @@ namespace AngleSharp.Html.Parser
             }
 
             _openElements.Add(element);
-            _tokenizer.IsAcceptingCharacterData = !element.Flags.HasFlag(NodeFlags.HtmlMember);
+            _tokenizer.SetAcceptingCharacterData(!element.Flags.HasFlag(NodeFlags.HtmlMember));
         }
 
         /// <summary>
@@ -4509,13 +4471,25 @@ namespace AngleSharp.Html.Parser
 
         #region Handlers
 
-        private void RaiseErrorOccurred(HtmlParseError code, ref StructHtmlToken token) => _tokenizer.RaiseErrorOccurred(code, token.Position);
+        private void RaiseErrorOccurred(HtmlParseError code, ref StructHtmlToken token) =>
+            ReportError(code, token.Position);
+
+        private void ReportError(HtmlParseError code, TextPosition position)
+        {
+            if (_options.IsStrictMode)
+            {
+                const String message = "Error while parsing the provided HTML document.";
+                throw new HtmlParseException(code.GetCode(), message, position);
+            }
+
+            Error?.Invoke(this, new HtmlErrorEvent(code, position));
+        }
 
         #endregion
 
         public void Dispose()
         {
-            _tokenizer.Dispose();
+            _synchronousTokenizer?.Dispose();
         }
     }
 

--- a/src/AngleSharp/Html/Parser/HtmlParser.cs
+++ b/src/AngleSharp/Html/Parser/HtmlParser.cs
@@ -265,17 +265,6 @@ namespace AngleSharp.Html.Parser
         }
 
         /// <summary>
-        /// Parses the supplied text source asynchronously with option to cancel.
-        /// </summary>
-        /// <param name="source">The source to parse.</param>
-        /// <param name="cancel">The cancellation token.</param>
-        public Task<IHtmlDocument> ParseDocumentAsync(TextSource source, CancellationToken cancel)
-        {
-            var document = CreateDocument(source);
-            return ParseAsync(document, cancel);
-        }
-
-        /// <summary>
         /// Parses tokens supplied by an alternative token source asynchronously.
         /// </summary>
         /// <param name="tokenSource">The token source to consume. The caller retains ownership of the source.</param>

--- a/src/AngleSharp/Html/Parser/HtmlParser.cs
+++ b/src/AngleSharp/Html/Parser/HtmlParser.cs
@@ -265,6 +265,35 @@ namespace AngleSharp.Html.Parser
         }
 
         /// <summary>
+        /// Parses the supplied text source asynchronously with option to cancel.
+        /// </summary>
+        /// <param name="source">The source to parse.</param>
+        /// <param name="cancel">The cancellation token.</param>
+        public Task<IHtmlDocument> ParseDocumentAsync(TextSource source, CancellationToken cancel)
+        {
+            var document = CreateDocument(source);
+            return ParseAsync(document, cancel);
+        }
+
+        /// <summary>
+        /// Parses tokens supplied by an alternative token source asynchronously.
+        /// </summary>
+        /// <param name="tokenSource">The token source to consume. The caller retains ownership of the source.</param>
+        /// <param name="cancel">The cancellation token.</param>
+        public Task<IHtmlDocument> ParseDocumentAsync(
+            IHtmlTokenSource tokenSource,
+            CancellationToken cancel = default)
+        {
+            if (tokenSource is null)
+            {
+                throw new ArgumentNullException(nameof(tokenSource));
+            }
+
+            var document = CreateDocument(String.Empty);
+            return ParseAsync(document, cancel, tokenSource: tokenSource);
+        }
+
+        /// <summary>
         /// Parses the string asynchronously with option to cancel.
         /// </summary>
         public async Task<IHtmlHeadElement?> ParseHeadAsync(String source, CancellationToken cancel)
@@ -353,11 +382,14 @@ namespace AngleSharp.Html.Parser
             return document;
         }
 
-        private HtmlDomBuilder CreateBuilder(HtmlDocument document, String? stopAt)
+        private HtmlDomBuilder CreateBuilder(
+            HtmlDocument document,
+            String? stopAt,
+            IHtmlTokenSource? tokenSource = null)
         {
             var options = new HtmlTokenizerOptions(_options);
             var factory = _context.GetService<IHtmlElementConstructionFactory>() ?? HtmlDomConstructionFactory.Instance;
-            var parser = new HtmlDomBuilder(factory, document, options, stopAt);
+            var parser = new HtmlDomBuilder(factory, document, options, stopAt, tokenSource);
             if (HasEventListener(EventNames.Error))
             {
                 parser.Error += (_, ev) => InvokeEventListener(ev);
@@ -374,9 +406,13 @@ namespace AngleSharp.Html.Parser
             return document;
         }
 
-        private async Task<IHtmlDocument> ParseAsync(HtmlDocument document, CancellationToken cancel, String? stopAt = null)
+        private async Task<IHtmlDocument> ParseAsync(
+            HtmlDocument document,
+            CancellationToken cancel,
+            String? stopAt = null,
+            IHtmlTokenSource? tokenSource = null)
         {
-            var parser = CreateBuilder(document, stopAt);
+            var parser = CreateBuilder(document, stopAt, tokenSource);
             InvokeHtmlParseEvent(document, completed: false);
             await parser.ParseAsync(_options, null, cancel).ConfigureAwait(false);
             InvokeHtmlParseEvent(document, completed: true);

--- a/src/AngleSharp/Html/Parser/HtmlTokenizer.cs
+++ b/src/AngleSharp/Html/Parser/HtmlTokenizer.cs
@@ -7,6 +7,8 @@ namespace AngleSharp.Html.Parser
     using Text;
     using System;
     using System.Collections.Generic;
+    using System.Threading;
+    using System.Threading.Tasks;
     using Tokens;
     using Tokens.Struct;
     using AttributeName = System.ReadOnlyMemory<System.Char>;
@@ -46,7 +48,7 @@ namespace AngleSharp.Html.Parser
     /// Performs the tokenization of the source code. Follows the tokenization algorithm at:
     /// http://www.w3.org/html/wg/drafts/html/master/syntax.html
     /// </summary>
-    public sealed class HtmlTokenizer : BaseTokenizer
+    public sealed class HtmlTokenizer : BaseTokenizer, IHtmlTokenSource
     {
         #region Fields
 
@@ -240,6 +242,14 @@ namespace AngleSharp.Html.Parser
             return ref token;
         }
 
+        Boolean IHtmlTokenSource.TryGetStructToken(out StructHtmlToken token)
+        {
+            token = GetStructToken();
+            return true;
+        }
+
+        Task IHtmlTokenSource.WaitForInputAsync(CancellationToken cancellationToken) => Task.CompletedTask;
+
         internal void RaiseErrorOccurred(HtmlParseError code, TextPosition position)
         {
             var handler = Error;
@@ -255,6 +265,9 @@ namespace AngleSharp.Html.Parser
                 handler.Invoke(this, errorEvent);
             }
         }
+
+        void IHtmlTokenSource.RaiseErrorOccurred(HtmlParseError code, TextPosition position) =>
+            RaiseErrorOccurred(code, position);
 
         #endregion
 

--- a/src/AngleSharp/Html/Parser/HtmlTokenizer.cs
+++ b/src/AngleSharp/Html/Parser/HtmlTokenizer.cs
@@ -7,8 +7,6 @@ namespace AngleSharp.Html.Parser
     using Text;
     using System;
     using System.Collections.Generic;
-    using System.Threading;
-    using System.Threading.Tasks;
     using Tokens;
     using Tokens.Struct;
     using AttributeName = System.ReadOnlyMemory<System.Char>;
@@ -48,7 +46,7 @@ namespace AngleSharp.Html.Parser
     /// Performs the tokenization of the source code. Follows the tokenization algorithm at:
     /// http://www.w3.org/html/wg/drafts/html/master/syntax.html
     /// </summary>
-    public sealed class HtmlTokenizer : BaseTokenizer, IHtmlTokenSource
+    public sealed class HtmlTokenizer : BaseTokenizer
     {
         #region Fields
 
@@ -56,6 +54,7 @@ namespace AngleSharp.Html.Parser
         private StringOrMemory _lastStartTag;
         private TextPosition _position;
         private StructHtmlToken _token;
+        private Action<HtmlParseError, TextPosition>? _errorSink;
         private ShouldEmitAttribute _shouldEmitAttribute = static Boolean (ref StructHtmlToken _, AttributeName _) => true;
         private Char[]? _characterReferenceBuffer;
 
@@ -242,13 +241,11 @@ namespace AngleSharp.Html.Parser
             return ref token;
         }
 
-        Boolean IHtmlTokenSource.TryGetStructToken(out StructHtmlToken token)
+        internal Action<HtmlParseError, TextPosition>? ErrorSink
         {
-            token = GetStructToken();
-            return true;
+            get => _errorSink;
+            set => _errorSink = value;
         }
-
-        Task IHtmlTokenSource.WaitForInputAsync(CancellationToken cancellationToken) => Task.CompletedTask;
 
         internal void RaiseErrorOccurred(HtmlParseError code, TextPosition position)
         {
@@ -264,10 +261,8 @@ namespace AngleSharp.Html.Parser
                 var errorEvent = new HtmlErrorEvent(code, position);
                 handler.Invoke(this, errorEvent);
             }
+            _errorSink?.Invoke(code, position);
         }
-
-        void IHtmlTokenSource.RaiseErrorOccurred(HtmlParseError code, TextPosition position) =>
-            RaiseErrorOccurred(code, position);
 
         #endregion
 

--- a/src/AngleSharp/Html/Parser/HtmlTokenizerTokenSource.cs
+++ b/src/AngleSharp/Html/Parser/HtmlTokenizerTokenSource.cs
@@ -1,0 +1,46 @@
+namespace AngleSharp.Html.Parser;
+
+using System;
+using System.Threading;
+using System.Threading.Tasks;
+using AngleSharp.Html.Parser.Tokens;
+using AngleSharp.Html.Parser.Tokens.Struct;
+using AngleSharp.Text;
+
+internal sealed class HtmlTokenizerTokenSource(HtmlTokenizer tokenizer) : IHtmlTokenSource
+{
+    public void Configure(
+        HtmlTokenizerOptions options,
+        Action<HtmlToken, TextRange>? onToken,
+        Action<HtmlParseError, TextPosition> reportError)
+    {
+        tokenizer.IsStrictMode = options.IsStrictMode;
+        tokenizer.IsSupportingProcessingInstructions = options.IsSupportingProcessingInstructions;
+        tokenizer.IsNotConsumingCharacterReferences = options.IsNotConsumingCharacterReferences;
+        tokenizer.IsPreservingAttributeNames = options.IsPreservingAttributeNames;
+        tokenizer.SkipRawText = options.SkipRawText;
+        tokenizer.SkipScriptText = options.SkipScriptText;
+        tokenizer.SkipDataText = options.SkipDataText;
+        tokenizer.ShouldEmitAttribute = options.ShouldEmitAttribute;
+        tokenizer.SkipComments = options.SkipComments;
+        tokenizer.SkipPlaintext = options.SkipPlaintext;
+        tokenizer.SkipRCDataText = options.SkipRCDataText;
+        tokenizer.SkipCDATA = options.SkipCDATA;
+        tokenizer.SkipProcessingInstructions = options.SkipProcessingInstructions;
+        tokenizer.DisableElementPositionTracking = options.DisableElementPositionTracking;
+        tokenizer.OnToken = onToken;
+        tokenizer.ErrorSink = reportError;
+    }
+
+    public void SetState(HtmlParseMode state) => tokenizer.State = state;
+
+    public void SetAcceptingCharacterData(Boolean value) => tokenizer.IsAcceptingCharacterData = value;
+
+    public Boolean TryGetStructToken(out StructHtmlToken token)
+    {
+        token = tokenizer.GetStructToken();
+        return true;
+    }
+
+    public Task WaitForInputAsync(CancellationToken cancellationToken) => Task.CompletedTask;
+}

--- a/src/AngleSharp/Html/Parser/IHtmlTokenSource.cs
+++ b/src/AngleSharp/Html/Parser/IHtmlTokenSource.cs
@@ -3,7 +3,6 @@ namespace AngleSharp.Html.Parser;
 using System;
 using System.Threading;
 using System.Threading.Tasks;
-using AngleSharp.Html.Dom.Events;
 using AngleSharp.Html.Parser.Tokens;
 using AngleSharp.Html.Parser.Tokens.Struct;
 using AngleSharp.Text;
@@ -15,68 +14,23 @@ using AngleSharp.Text;
 /// Implement this contract to feed an alternative tokenizer into
 /// <see cref="HtmlParser.ParseDocumentAsync(IHtmlTokenSource, CancellationToken)"/>.
 /// </remarks>
-public interface IHtmlTokenSource : IDisposable
+public interface IHtmlTokenSource
 {
-    /// <summary>Raised when a parse error is encountered.</summary>
-    event EventHandler<HtmlErrorEvent>? Error;
+    /// <summary>Configures tokenization before input is consumed.</summary>
+    void Configure(
+        HtmlTokenizerOptions options,
+        Action<HtmlToken, TextRange>? onToken,
+        Action<HtmlParseError, TextPosition> reportError);
 
-    /// <summary>Gets or sets the tokenizer state requested by tree construction.</summary>
-    HtmlParseMode State { get; set; }
+    /// <summary>Changes the tokenizer state requested by tree construction.</summary>
+    void SetState(HtmlParseMode state);
 
-    /// <summary>Gets or sets whether character data tokens are currently accepted.</summary>
-    Boolean IsAcceptingCharacterData { get; set; }
-
-    /// <summary>Gets or sets whether parse errors should be treated strictly.</summary>
-    Boolean IsStrictMode { get; set; }
-
-    /// <summary>Gets or sets whether processing instructions are supported.</summary>
-    Boolean IsSupportingProcessingInstructions { get; set; }
-
-    /// <summary>Gets or sets whether character references should remain unconsumed.</summary>
-    Boolean IsNotConsumingCharacterReferences { get; set; }
-
-    /// <summary>Gets or sets whether attribute-name casing should be preserved.</summary>
-    Boolean IsPreservingAttributeNames { get; set; }
-
-    /// <summary>Gets or sets whether raw-text tokens should be skipped.</summary>
-    Boolean SkipRawText { get; set; }
-
-    /// <summary>Gets or sets whether script-text tokens should be skipped.</summary>
-    Boolean SkipScriptText { get; set; }
-
-    /// <summary>Gets or sets whether data-text tokens should be skipped.</summary>
-    Boolean SkipDataText { get; set; }
-
-    /// <summary>Gets or sets whether comment tokens should be skipped.</summary>
-    Boolean SkipComments { get; set; }
-
-    /// <summary>Gets or sets whether plaintext tokens should be skipped.</summary>
-    Boolean SkipPlaintext { get; set; }
-
-    /// <summary>Gets or sets whether RCDATA tokens should be skipped.</summary>
-    Boolean SkipRCDataText { get; set; }
-
-    /// <summary>Gets or sets whether CDATA tokens should be skipped.</summary>
-    Boolean SkipCDATA { get; set; }
-
-    /// <summary>Gets or sets whether processing-instruction tokens should be skipped.</summary>
-    Boolean SkipProcessingInstructions { get; set; }
-
-    /// <summary>Gets or sets whether element position tracking is disabled.</summary>
-    Boolean DisableElementPositionTracking { get; set; }
-
-    /// <summary>Gets or sets the predicate controlling attribute emission.</summary>
-    ShouldEmitAttribute ShouldEmitAttribute { get; set; }
-
-    /// <summary>Gets or sets a callback invoked for emitted tokens.</summary>
-    Action<HtmlToken, TextRange>? OnToken { get; set; }
+    /// <summary>Changes whether character data tokens are currently accepted.</summary>
+    void SetAcceptingCharacterData(Boolean value);
 
     /// <summary>Attempts to get the next currently available token.</summary>
     Boolean TryGetStructToken(out StructHtmlToken token);
 
     /// <summary>Waits until more input may be available.</summary>
     Task WaitForInputAsync(CancellationToken cancellationToken);
-
-    /// <summary>Reports a parse error discovered by tree construction.</summary>
-    void RaiseErrorOccurred(HtmlParseError code, TextPosition position);
 }

--- a/src/AngleSharp/Html/Parser/IHtmlTokenSource.cs
+++ b/src/AngleSharp/Html/Parser/IHtmlTokenSource.cs
@@ -1,0 +1,82 @@
+namespace AngleSharp.Html.Parser;
+
+using System;
+using System.Threading;
+using System.Threading.Tasks;
+using AngleSharp.Html.Dom.Events;
+using AngleSharp.Html.Parser.Tokens;
+using AngleSharp.Html.Parser.Tokens.Struct;
+using AngleSharp.Text;
+
+/// <summary>
+/// Represents a token source consumed by the HTML tree constructor.
+/// </summary>
+/// <remarks>
+/// Implement this contract to feed an alternative tokenizer into
+/// <see cref="HtmlParser.ParseDocumentAsync(IHtmlTokenSource, CancellationToken)"/>.
+/// </remarks>
+public interface IHtmlTokenSource : IDisposable
+{
+    /// <summary>Raised when a parse error is encountered.</summary>
+    event EventHandler<HtmlErrorEvent>? Error;
+
+    /// <summary>Gets or sets the tokenizer state requested by tree construction.</summary>
+    HtmlParseMode State { get; set; }
+
+    /// <summary>Gets or sets whether character data tokens are currently accepted.</summary>
+    Boolean IsAcceptingCharacterData { get; set; }
+
+    /// <summary>Gets or sets whether parse errors should be treated strictly.</summary>
+    Boolean IsStrictMode { get; set; }
+
+    /// <summary>Gets or sets whether processing instructions are supported.</summary>
+    Boolean IsSupportingProcessingInstructions { get; set; }
+
+    /// <summary>Gets or sets whether character references should remain unconsumed.</summary>
+    Boolean IsNotConsumingCharacterReferences { get; set; }
+
+    /// <summary>Gets or sets whether attribute-name casing should be preserved.</summary>
+    Boolean IsPreservingAttributeNames { get; set; }
+
+    /// <summary>Gets or sets whether raw-text tokens should be skipped.</summary>
+    Boolean SkipRawText { get; set; }
+
+    /// <summary>Gets or sets whether script-text tokens should be skipped.</summary>
+    Boolean SkipScriptText { get; set; }
+
+    /// <summary>Gets or sets whether data-text tokens should be skipped.</summary>
+    Boolean SkipDataText { get; set; }
+
+    /// <summary>Gets or sets whether comment tokens should be skipped.</summary>
+    Boolean SkipComments { get; set; }
+
+    /// <summary>Gets or sets whether plaintext tokens should be skipped.</summary>
+    Boolean SkipPlaintext { get; set; }
+
+    /// <summary>Gets or sets whether RCDATA tokens should be skipped.</summary>
+    Boolean SkipRCDataText { get; set; }
+
+    /// <summary>Gets or sets whether CDATA tokens should be skipped.</summary>
+    Boolean SkipCDATA { get; set; }
+
+    /// <summary>Gets or sets whether processing-instruction tokens should be skipped.</summary>
+    Boolean SkipProcessingInstructions { get; set; }
+
+    /// <summary>Gets or sets whether element position tracking is disabled.</summary>
+    Boolean DisableElementPositionTracking { get; set; }
+
+    /// <summary>Gets or sets the predicate controlling attribute emission.</summary>
+    ShouldEmitAttribute ShouldEmitAttribute { get; set; }
+
+    /// <summary>Gets or sets a callback invoked for emitted tokens.</summary>
+    Action<HtmlToken, TextRange>? OnToken { get; set; }
+
+    /// <summary>Attempts to get the next currently available token.</summary>
+    Boolean TryGetStructToken(out StructHtmlToken token);
+
+    /// <summary>Waits until more input may be available.</summary>
+    Task WaitForInputAsync(CancellationToken cancellationToken);
+
+    /// <summary>Reports a parse error discovered by tree construction.</summary>
+    void RaiseErrorOccurred(HtmlParseError code, TextPosition position);
+}

--- a/src/AngleSharp/Html/Parser/Tokens/Struct/StructHtmlToken.cs
+++ b/src/AngleSharp/Html/Parser/Tokens/Struct/StructHtmlToken.cs
@@ -56,7 +56,8 @@ public struct StructHtmlToken
     internal static StructHtmlToken Skipped(HtmlTokenType htmlTokenType, TextPosition position) =>
         new(htmlTokenType, position);
 
-    internal static StructHtmlToken Doctype(Boolean quirksForced, TextPosition position) =>
+    /// <summary>Creates a document type token.</summary>
+    public static StructHtmlToken Doctype(Boolean quirksForced, TextPosition position) =>
         new(HtmlTokenType.Doctype, position)
         {
             _structTokenDoctypeData = new StructTokenDoctypeData()
@@ -68,19 +69,23 @@ public struct StructHtmlToken
     internal static StructHtmlToken TagOpen(TextPosition position) =>
         new(HtmlTokenType.StartTag, position);
 
-    internal static StructHtmlToken Open(StringOrMemory name) =>
+    /// <summary>Creates a start-tag token.</summary>
+    public static StructHtmlToken Open(StringOrMemory name) =>
         new(HtmlTokenType.StartTag, TextPosition.Empty, name);
 
     internal static StructHtmlToken TagClose(TextPosition position) =>
         new(HtmlTokenType.EndTag, position);
 
-    internal static StructHtmlToken Close(StringOrMemory s) =>
+    /// <summary>Creates an end-tag token.</summary>
+    public static StructHtmlToken Close(StringOrMemory s) =>
         new(HtmlTokenType.EndTag, TextPosition.Empty, s);
 
-    internal static StructHtmlToken Character(StringOrMemory name, TextPosition position) =>
+    /// <summary>Creates a character token.</summary>
+    public static StructHtmlToken Character(StringOrMemory name, TextPosition position) =>
         new(HtmlTokenType.Character, position, name);
 
-    internal static StructHtmlToken Comment(StringOrMemory name, TextPosition position) =>
+    /// <summary>Creates a comment token.</summary>
+    public static StructHtmlToken Comment(StringOrMemory name, TextPosition position) =>
         new(HtmlTokenType.Comment, position, name);
 
     internal static StructHtmlToken ProcessingInstruction(StringOrMemory name, TextPosition position) =>
@@ -89,7 +94,8 @@ public struct StructHtmlToken
             IsProcessingInstruction = true
         };
 
-    internal static StructHtmlToken EndOfFile(TextPosition position) =>
+    /// <summary>Creates an end-of-file token.</summary>
+    public static StructHtmlToken EndOfFile(TextPosition position) =>
         new(HtmlTokenType.EndOfFile, position);
 
     #endregion


### PR DESCRIPTION
# Types of Changes

## Prerequisites

- [x] I have read the **CONTRIBUTING** document
- [x] My code follows the code style of this project

## Contribution Type

- [ ] Bug fix
- [x] New feature
- [ ] Breaking change
- [x] My change requires documentation
- [x] I have added tests to cover my changes
- [x] All new and existing tests passed

## Description

Closes #1264.

Adds a minimal asynchronous token-source seam between tokenization and HTML tree construction:

- `IHtmlTokenSource` exposes five operations: configure, change tokenizer state, change character-data acceptance, try-read, and wait for input;
- `HtmlParser.ParseDocumentAsync(IHtmlTokenSource, CancellationToken)` feeds alternative tokenizers into the existing tree builder;
- the built-in `HtmlTokenizer` keeps its existing public shape and is connected through an internal adapter;
- the parser does not dispose caller-owned token sources;
- the required `StructHtmlToken` factories remain public.

The motivating consumer is a segmented UTF-8 tokenizer reusing AngleSharp tree correction without retokenizing decoded text or materializing an intermediate DOM.

Naming and public-surface suggestions are very welcome.