### PR TITLE
Improve attribute observer dispatch during HTML parsing

### DIFF
--- a/src/AngleSharp/Dom/Internal/DefaultAttributeObserver.cs
+++ b/src/AngleSharp/Dom/Internal/DefaultAttributeObserver.cs
@@ -12,14 +12,14 @@ namespace AngleSharp.Dom
     /// </summary>
     public class DefaultAttributeObserver : IAttributeObserver
     {
-        private readonly List<AttributeObserver> _actions;
+        private readonly Dictionary<String, List<AttributeObserver>> _actions;
 
         /// <summary>
         /// Creates a new instance.
         /// </summary>
         public DefaultAttributeObserver()
         {
-            _actions = [];
+            _actions = new Dictionary<String, List<AttributeObserver>>(StringComparer.Ordinal);
             RegisterStandardObservers();
         }
 
@@ -66,9 +66,15 @@ namespace AngleSharp.Dom
         public void RegisterObserver<TElement>(String expectedName, Action<TElement, String> callback)
             where TElement : IElement
         {
-            _actions.Add((element, actualName, value) =>
+            if (!_actions.TryGetValue(expectedName, out var actions))
             {
-                if (element is TElement tEl && actualName.Is(expectedName))
+                actions = [];
+                _actions.Add(expectedName, actions);
+            }
+
+            actions.Add((element, _, value) =>
+            {
+                if (element is TElement tEl)
                 {
                     callback.Invoke(tEl, value);
                 }
@@ -77,7 +83,12 @@ namespace AngleSharp.Dom
 
         void IAttributeObserver.NotifyChange(IElement host, String name, String? value)
         {
-            foreach (var action in _actions)
+            if (!_actions.TryGetValue(name, out var actions))
+            {
+                return;
+            }
+
+            foreach (var action in actions)
             {
                 action.Invoke(host, name, value!);
             }

--- a/src/AngleSharp/Dom/Internal/Document.cs
+++ b/src/AngleSharp/Dom/Internal/Document.cs
@@ -36,6 +36,7 @@ namespace AngleSharp.Dom
         private readonly Location _location;
         private readonly TextSource _source;
         private readonly Object _importedUrisLock = new();
+        private IAttributeObserver[]? _attributeObservers;
 
         private QuirksMode _quirksMode;
         private Sandboxes _sandbox;
@@ -772,6 +773,9 @@ namespace AngleSharp.Dom
 
         /// <inheritdoc />
         public IBrowsingContext Context => _context;
+
+        internal IReadOnlyList<IAttributeObserver> AttributeObservers =>
+            _attributeObservers ??= _context.GetServices<IAttributeObserver>().ToArray();
 
         /// <inheritdoc />
         public HttpStatusCode StatusCode

--- a/src/AngleSharp/Dom/Internal/Element.cs
+++ b/src/AngleSharp/Dom/Internal/Element.cs
@@ -598,7 +598,7 @@ namespace AngleSharp.Dom
 
             if (attrs.Length > 0)
             {
-                var observers = Context.GetServices<IAttributeObserver>();
+                var observers = Owner.AttributeObservers;
 
                 foreach (var attr in attrs)
                 {
@@ -617,7 +617,7 @@ namespace AngleSharp.Dom
         {
             if (namespaceUri is null)
             {
-                var observers = Context.GetServices<IAttributeObserver>();
+                var observers = Owner.AttributeObservers;
 
                 foreach (var observer in observers)
                 {

--- a/src/AngleSharp/Html/Dom/Internal/HtmlImageElement.cs
+++ b/src/AngleSharp/Html/Dom/Internal/HtmlImageElement.cs
@@ -14,6 +14,7 @@ namespace AngleSharp.Html.Dom
         #region Fields
 
         private readonly ImageRequestProcessor _request;
+        private Boolean _isSettingUp;
 
         #endregion
 
@@ -99,11 +100,30 @@ namespace AngleSharp.Html.Dom
 
         internal override void SetupElement()
         {
-            base.SetupElement();
-            UpdateSource();
+            _isSettingUp = true;
+            try
+            {
+                base.SetupElement();
+            }
+            finally
+            {
+                _isSettingUp = false;
+            }
+
+            UpdateSourceCore();
         }
 
         internal void UpdateSource()
+        {
+            if (_isSettingUp)
+            {
+                return;
+            }
+
+            UpdateSourceCore();
+        }
+
+        private void UpdateSourceCore()
         {
             var url = this.GetImageCandidate();
 


### PR DESCRIPTION
# Types of Changes

## Prerequisites

Please make sure you can check the following two boxes:

- [x] I have read the **CONTRIBUTING** document
- [x] My code follows the code style of this project

## Contribution Type

What types of changes does your code introduce? Put an `x` in all the boxes that apply:

- [ ] Bug fix (non-breaking change which fixes an issue, please reference the issue id)
- [ ] New feature (non-breaking change which adds functionality, make sure to open an associated issue first)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] My change requires a change to the documentation
- [ ] I have updated the documentation accordingly
- [ ] I have added tests to cover my changes
- [x] All new and existing tests passed

## Description

This is a non-breaking performance improvement for HTML parsing and mutable DOM construction.

- Index attribute observers by attribute name instead of scanning every registered callback.
- Cache the configured attribute observer collection per document.
- Defer image source selection while `SetupElement` applies attributes, then update it once.

### Benchmark

| Revision | Mean | StdDev |
|---|---:|---:|
| `origin/devel` | 3.948 ms | 0.113 ms |
| this branch | 3.688 ms | 0.088 ms |

| Method | devel | candidate | Change |
|---|---:|---:|---:|
| AccumulatingSource | 4.634 ms | 3.718 ms | -19.8% |
| BoundedSource | 4.095 ms | 3.348 ms | -18.2% |
| AutomaticBoundedSource | 4.259 ms | 3.463 ms | -18.7% |
