### PR TITLE
Improve selector matching performance (fixes #929)

### DIFF
--- a/src/AngleSharp.Benchmarks/AngleSharp.Benchmarks.csproj
+++ b/src/AngleSharp.Benchmarks/AngleSharp.Benchmarks.csproj
@@ -1,7 +1,7 @@
 <Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
     <OutputType>Exe</OutputType>
-    <TargetFrameworks>net472;net8.0</TargetFrameworks>
+    <TargetFrameworks>net472;net8.0;net10.0</TargetFrameworks>
     <SignAssembly>false</SignAssembly>
     <IsPackable>false</IsPackable>
   </PropertyGroup>

--- a/src/AngleSharp.Benchmarks/Issue929Benchmark.cs
+++ b/src/AngleSharp.Benchmarks/Issue929Benchmark.cs
@@ -1,0 +1,44 @@
+using System.IO;
+using System.Linq;
+using AngleSharp.Dom;
+using AngleSharp.Html.Parser;
+using BenchmarkDotNet.Attributes;
+using BenchmarkDotNet.Configs;
+
+namespace AngleSharp.Benchmarks
+{
+    /// <summary>
+    /// Reproduces https://github.com/AngleSharp/AngleSharp/issues/929 - looking up a single
+    /// element by tag name plus text content. The hand-rolled variant is the baseline the
+    /// issue reports as being dramatically faster than the equivalent CSS selector.
+    /// </summary>
+    [MemoryDiagnoser, GroupBenchmarksBy(BenchmarkLogicalGroupRule.ByCategory), CategoriesColumn]
+    public class Issue929Benchmark
+    {
+        private const string Present = "Selectors";
+        private const string Absent = "NoSuchTextAnywhereInThisDocument";
+
+        private static readonly HtmlParser parser = new HtmlParser();
+        private IDocument document;
+
+        [GlobalSetup]
+        public void GlobalSetup()
+        {
+            document = parser.ParseDocument(File.ReadAllText("page.html"));
+        }
+
+        [BenchmarkCategory("Found"), Benchmark(Baseline = true)]
+        public IElement HandRolled() =>
+            document.GetElementsByTagName("h2").FirstOrDefault(x => x.TextContent.Contains(Present));
+
+        [BenchmarkCategory("Found"), Benchmark]
+        public IElement Selector() => document.QuerySelector("h2:contains(" + Present + ")");
+
+        [BenchmarkCategory("NotFound"), Benchmark(Baseline = true)]
+        public IElement HandRolledMiss() =>
+            document.GetElementsByTagName("h2").FirstOrDefault(x => x.TextContent.Contains(Absent));
+
+        [BenchmarkCategory("NotFound"), Benchmark]
+        public IElement SelectorMiss() => document.QuerySelector("h2:contains(" + Absent + ")");
+    }
+}

--- a/src/AngleSharp.Benchmarks/QuerySelectorBenchmark.cs
+++ b/src/AngleSharp.Benchmarks/QuerySelectorBenchmark.cs
@@ -1,0 +1,58 @@
+using System.Collections.Generic;
+using System.IO;
+using AngleSharp.Dom;
+using AngleSharp.Html.Parser;
+using BenchmarkDotNet.Attributes;
+using BenchmarkDotNet.Configs;
+
+namespace AngleSharp.Benchmarks
+{
+    /// <summary>
+    /// Focused gate for selector matching performance. Unlike <see cref="SelectorBenchmark"/>
+    /// - which is a broad short-run sweep - this uses the default job for low noise and covers
+    /// both the "all matches" and the "first match" traversal, which are separate code paths.
+    /// </summary>
+    [MemoryDiagnoser, GroupBenchmarksBy(BenchmarkLogicalGroupRule.ByParams)]
+    public class QuerySelectorBenchmark
+    {
+        private static readonly HtmlParser parser = new HtmlParser();
+        private IDocument document;
+
+        [GlobalSetup]
+        public void GlobalSetup()
+        {
+            document = parser.ParseDocument(File.ReadAllText("page.html"));
+        }
+
+        [ParamsSource(nameof(GetSelectors))]
+        public string Selector { get; set; }
+
+        public IEnumerable<string> GetSelectors => new[]
+        {
+            // Baseline traversal cost: every element is visited, matching is trivial.
+            "div",
+            // Descendant and child combinators.
+            "div p",
+            "ul.toc li.tocline2",
+            // Sibling combinators - these walk siblings per candidate.
+            "div + p",
+            "div ~ p",
+            // Structural pseudo classes - these walk the parent's child list per candidate.
+            "p:nth-child(2n+1)",
+            "p:only-child",
+            // Text matching - this materializes text content per candidate.
+            "p:contains(selectors)",
+            // Single-hit selectors: the first match is found without visiting the whole tree.
+            "#title",
+            ".note",
+            // No match at all: forces a complete traversal even for QuerySelector.
+            "div.no-such-class-anywhere"
+        };
+
+        [Benchmark]
+        public IElement QuerySelector() => document.QuerySelector(Selector);
+
+        [Benchmark]
+        public IHtmlCollection<IElement> QuerySelectorAll() => document.QuerySelectorAll(Selector);
+    }
+}

--- a/src/AngleSharp.Core.Tests/Css/CssSelector.cs
+++ b/src/AngleSharp.Core.Tests/Css/CssSelector.cs
@@ -1608,5 +1608,85 @@ nav h1, nav h2, nav h3, nav h4, nav h5, nav h6";
             // Should match cells from both tables
             Assert.GreaterOrEqual(result.Length, 2);
         }
+
+        [Test]
+        public void ContainsMatchesTextInASingleTextNode()
+        {
+            var document = "<p id='a'>Climbing Directory</p><p id='b'>Something else</p>".ToHtmlDocument();
+            var result = RunQuery(document, "p:contains(Climbing Directory)");
+
+            Assert.AreEqual(1, result.Length);
+            Assert.AreEqual("a", result[0].Id);
+        }
+
+        [Test]
+        public void ContainsMatchesTextSpanningChildElements()
+        {
+            // TextContent concatenates descendants, so the match has to be found even
+            // though no single text node contains it.
+            var document = "<p id='a'>Climb<b>ing</b> Directory</p>".ToHtmlDocument();
+            var result = RunQuery(document, "p:contains(Climbing Directory)");
+
+            Assert.AreEqual(1, result.Length);
+            Assert.AreEqual("a", result[0].Id);
+        }
+
+        [Test]
+        public void ContainsMatchesTextSpanningDeeplyNestedElements()
+        {
+            var document = "<div id='a'>A<span>B<em>C</em></span><i>D</i>E</div>".ToHtmlDocument();
+
+            Assert.AreEqual(1, RunQuery(document, "div:contains(ABCDE)").Length);
+            Assert.AreEqual(0, RunQuery(document, "div:contains(ABCED)").Length);
+        }
+
+        [Test]
+        public void ContainsRestartsCorrectlyOnPartialMatch()
+        {
+            // A naive streaming matcher that resets on mismatch would miss the overlap.
+            var document = "<p id='a'>aaab</p>".ToHtmlDocument();
+
+            Assert.AreEqual(1, RunQuery(document, "p:contains(aab)").Length);
+            Assert.AreEqual(0, RunQuery(document, "p:contains(aabb)").Length);
+        }
+
+        [Test]
+        public void ContainsRestartsCorrectlyAcrossNodeBoundary()
+        {
+            var document = "<p id='a'>aa<b>a</b>b</p>".ToHtmlDocument();
+
+            Assert.AreEqual(1, RunQuery(document, "p:contains(aaab)").Length);
+            Assert.AreEqual(1, RunQuery(document, "p:contains(aab)").Length);
+        }
+
+        [Test]
+        public void ContainsIsCaseSensitiveAndMatchesNothingWhenAbsent()
+        {
+            var document = "<p id='a'>Climbing Directory</p>".ToHtmlDocument();
+
+            Assert.AreEqual(0, RunQuery(document, "p:contains(climbing)").Length);
+            Assert.AreEqual(0, RunQuery(document, "p:contains(Nowhere)").Length);
+        }
+
+        [Test]
+        public void QuerySelectorFindsSameElementAsQuerySelectorAllFirst()
+        {
+            var document = Assets.selectors.ToHtmlDocument();
+
+            foreach (var query in new[] { "div", "div p", "div ~ p", "p:nth-child(2n+1)", "p:only-child", ".note", "#title" })
+            {
+                var all = document.QuerySelectorAll(query);
+                var first = document.QuerySelector(query);
+
+                if (all.Length == 0)
+                {
+                    Assert.IsNull(first, query);
+                }
+                else
+                {
+                    Assert.AreSame(all[0], first, query);
+                }
+            }
+        }
     }
 }

--- a/src/AngleSharp/Css/Dom/Internal/FirstChildSelector.cs
+++ b/src/AngleSharp/Css/Dom/Internal/FirstChildSelector.cs
@@ -45,7 +45,7 @@ namespace AngleSharp.Css.Dom
 
             for (var i = 0; i < length; i++)
             {
-                if (nodes[i] is IElement child && (matchAll || kind.Match(child, scope)))
+                if (nodes.TryGetElement(i, out var child) && (matchAll || kind.Match(child, scope)))
                 {
                     k += 1;
 

--- a/src/AngleSharp/Css/Dom/Internal/FirstTypeSelector.cs
+++ b/src/AngleSharp/Css/Dom/Internal/FirstTypeSelector.cs
@@ -43,7 +43,7 @@ namespace AngleSharp.Css.Dom
 
             for (var i = 0; i < length; i++)
             {
-                if (nodes[i] is IElement child && child.NodeName.Is(nodeName))
+                if (nodes.TryGetElement(i, out var child) && child.NodeName.Is(nodeName))
                 {
                     k += 1;
 

--- a/src/AngleSharp/Css/Dom/Internal/LastChildSelector.cs
+++ b/src/AngleSharp/Css/Dom/Internal/LastChildSelector.cs
@@ -44,7 +44,7 @@ namespace AngleSharp.Css.Dom
 
             for (var i = nodes.Length - 1; i >= 0; i--)
             {
-                if (nodes[i] is IElement child && (matchAll || kind.Match(child, scope)))
+                if (nodes.TryGetElement(i, out var child) && (matchAll || kind.Match(child, scope)))
                 {
                     k += 1;
 

--- a/src/AngleSharp/Css/Dom/Internal/LastTypeSelector.cs
+++ b/src/AngleSharp/Css/Dom/Internal/LastTypeSelector.cs
@@ -42,7 +42,7 @@ namespace AngleSharp.Css.Dom
 
             for (var i = nodes.Length - 1; i >= 0; i--)
             {
-                if (nodes[i] is IElement child && child.NodeName.Is(nodeName))
+                if (nodes.TryGetElement(i, out var child) && child.NodeName.Is(nodeName))
                 {
                     k += 1;
 

--- a/src/AngleSharp/Css/Dom/Internal/TextContainsMatcher.cs
+++ b/src/AngleSharp/Css/Dom/Internal/TextContainsMatcher.cs
@@ -1,0 +1,119 @@
+namespace AngleSharp.Css.Dom
+{
+    using AngleSharp.Dom;
+    using System;
+
+    /// <summary>
+    /// Tests whether the text content of an element contains a fixed string, without
+    /// materializing that text content.
+    /// </summary>
+    /// <remarks>
+    /// The naive implementation is <c>element.TextContent.Contains(value)</c>, which
+    /// concatenates every descendant text node into a fresh string for every candidate
+    /// element. This streams the text nodes instead and runs Knuth-Morris-Pratt over them,
+    /// so a match spanning a node boundary is still found while nothing is allocated. The
+    /// prefix table is built once, when the selector is parsed.
+    /// </remarks>
+    sealed class TextContainsMatcher
+    {
+        private readonly String _value;
+        private readonly Int32[] _prefixes;
+
+        public TextContainsMatcher(String value)
+        {
+            _value = value;
+            _prefixes = BuildPrefixes(value);
+        }
+
+        public Boolean Matches(IElement element)
+        {
+            if (_value.Length == 0)
+            {
+                return true;
+            }
+
+            var matched = 0;
+            return Scan(element, ref matched);
+        }
+
+        private Boolean Scan(INode node, ref Int32 matched)
+        {
+            var children = node.ChildNodes;
+            var n = children.Length;
+
+            for (var i = 0; i < n; i++)
+            {
+                var child = children[i];
+
+                if (child is IText text)
+                {
+                    if (Feed(text.Data, ref matched))
+                    {
+                        return true;
+                    }
+                }
+                else if (child.HasChildNodes && Scan(child, ref matched))
+                {
+                    return true;
+                }
+            }
+
+            return false;
+        }
+
+        private Boolean Feed(String data, ref Int32 matched)
+        {
+            var value = _value;
+            var prefixes = _prefixes;
+            var length = value.Length;
+            var k = matched;
+
+            for (var i = 0; i < data.Length; i++)
+            {
+                var current = data[i];
+
+                while (k > 0 && current != value[k])
+                {
+                    k = prefixes[k - 1];
+                }
+
+                if (current == value[k])
+                {
+                    k++;
+
+                    if (k == length)
+                    {
+                        matched = k;
+                        return true;
+                    }
+                }
+            }
+
+            matched = k;
+            return false;
+        }
+
+        private static Int32[] BuildPrefixes(String value)
+        {
+            var prefixes = new Int32[value.Length];
+            var k = 0;
+
+            for (var i = 1; i < value.Length; i++)
+            {
+                while (k > 0 && value[i] != value[k])
+                {
+                    k = prefixes[k - 1];
+                }
+
+                if (value[i] == value[k])
+                {
+                    k++;
+                }
+
+                prefixes[i] = k;
+            }
+
+            return prefixes;
+        }
+    }
+}

--- a/src/AngleSharp/Css/Dom/SelectorExtensions.cs
+++ b/src/AngleSharp/Css/Dom/SelectorExtensions.cs
@@ -19,19 +19,30 @@ namespace AngleSharp.Css.Dom
         /// <returns>The resulting element or null.</returns>
         public static IElement? MatchAny(this ISelector selector, IEnumerable<IElement> elements, IElement? scope)
         {
-            var stack = new Stack<INode>();
             foreach (var element in elements)
             {
-                stack.Clear();
-                var nodes = element.GetDescendantsAndSelf(
-                    stack,
-                    filter: static (node, state) => node is IElement e && state.Selector.Match(e, state.Scope),
-                    state: new SelectorState(selector, scope));
-
-                var enumerator = nodes.GetEnumerator();
-                if (enumerator.MoveNext())
+                if (element is Element root)
                 {
-                    return (IElement?) enumerator.Current;
+                    var walker = new ElementTreeEnumerator(root);
+
+                    while (walker.MoveNext())
+                    {
+                        var current = walker.Current;
+
+                        if (selector.Match(current, scope))
+                        {
+                            return current;
+                        }
+                    }
+                }
+                else
+                {
+                    var match = MatchAnyCore(selector, element, scope);
+
+                    if (match is not null)
+                    {
+                        return match;
+                    }
                 }
             }
 
@@ -64,31 +75,73 @@ namespace AngleSharp.Css.Dom
 
         private static void MatchAll(this ISelector selector, IEnumerable<IElement> elements, IElement? scope, List<IElement> result)
         {
-            var stack = new Stack<INode>();
             foreach (var element in elements)
             {
-                stack.Clear();
-                var nodes = element.GetDescendantsAndSelf(
-                    stack,
-                    filter: static (node, state) => node is IElement e && state.Selector.Match(e, state.Scope),
-                    state: new SelectorState(selector, scope));
-
-                foreach (var descendantAndSelf in nodes)
+                if (element is Element root)
                 {
-                    result.Add((IElement) descendantAndSelf);
+                    var walker = new ElementTreeEnumerator(root);
+
+                    while (walker.MoveNext())
+                    {
+                        var current = walker.Current;
+
+                        if (selector.Match(current, scope))
+                        {
+                            result.Add(current);
+                        }
+                    }
+                }
+                else
+                {
+                    MatchAllCore(selector, element, scope, result);
                 }
             }
         }
 
-        private readonly struct SelectorState
+        /// <summary>
+        /// Fallback for <see cref="IElement"/> implementations that do not derive from
+        /// <see cref="Element"/>, where the concrete node list is not available.
+        /// </summary>
+        private static IElement? MatchAnyCore(ISelector selector, IElement element, IElement? scope)
         {
-            public readonly ISelector Selector;
-            public readonly IElement? Scope;
-
-            public SelectorState(ISelector selector, IElement? scope)
+            if (selector.Match(element, scope))
             {
-                Selector = selector;
-                Scope = scope;
+                return element;
+            }
+
+            var children = element.ChildNodes;
+
+            for (var i = 0; i < children.Length; i++)
+            {
+                if (children[i] is IElement child)
+                {
+                    var match = MatchAnyCore(selector, child, scope);
+
+                    if (match is not null)
+                    {
+                        return match;
+                    }
+                }
+            }
+
+            return null;
+        }
+
+        private static void MatchAllCore(ISelector selector, IElement element, IElement? scope, List<IElement> result)
+        {
+            if (selector.Match(element, scope))
+            {
+                result.Add(element);
+            }
+
+            var children = element.ChildNodes;
+
+            for (var i = 0; i < children.Length; i++)
+            {
+                if (children[i] is IElement child)
+                {
+                    MatchAllCore(selector, child, scope, result);
+                }
             }
         }
     }

--- a/src/AngleSharp/Css/Parser/CssCombinator.cs
+++ b/src/AngleSharp/Css/Parser/CssCombinator.cs
@@ -154,12 +154,41 @@ namespace AngleSharp.Css.Parser
 
             private static IEnumerable<IElement> GetPreviousSiblings(IElement element)
             {
-                var sibling = element.PreviousElementSibling;
-
-                while (sibling != null)
+                // Walking PreviousElementSibling repeatedly is quadratic, since each step
+                // has to locate the element in its parent again. Scan the child list once.
+                if (element is Node node && node.Parent is Node parent)
                 {
-                    yield return sibling;
-                    sibling = sibling.PreviousElementSibling;
+                    var children = parent.ChildNodes;
+                    var index = -1;
+
+                    for (var i = 0; i < children.Length; i++)
+                    {
+                        if (Object.ReferenceEquals(children[i], node))
+                        {
+                            index = i;
+                            break;
+                        }
+                    }
+
+                    for (var i = index - 1; i >= 0; i--)
+                    {
+                        var child = children[i];
+
+                        if (child.NodeType == NodeType.Element)
+                        {
+                            yield return (Element)child;
+                        }
+                    }
+                }
+                else
+                {
+                    var sibling = element.PreviousElementSibling;
+
+                    while (sibling != null)
+                    {
+                        yield return sibling;
+                        sibling = sibling.PreviousElementSibling;
+                    }
                 }
             }
         }

--- a/src/AngleSharp/Css/Parser/CssSelectorConstructor.cs
+++ b/src/AngleSharp/Css/Parser/CssSelectorConstructor.cs
@@ -957,7 +957,8 @@ namespace AngleSharp.Css.Parser
                 if (_valid && _value is not null)
                 {
                     var code = PseudoClassNames.Contains.CssFunction(_value);
-                    return new PseudoClassSelector(el => el.TextContent.Contains(_value), code);
+                    var matcher = new TextContainsMatcher(_value);
+                    return new PseudoClassSelector(matcher.Matches, code);
                 }
 
                 return null;

--- a/src/AngleSharp/Dom/Internal/Element.cs
+++ b/src/AngleSharp/Dom/Internal/Element.cs
@@ -89,12 +89,7 @@ namespace AngleSharp.Dom
             get
             {
                 var sb = StringBuilderPool.Obtain();
-
-                foreach (var child in this.GetDescendants().OfType<IText>())
-                {
-                    sb.Append(child.Data);
-                }
-
+                AppendText(this, sb);
                 return sb.ToPool();
             }
             set
@@ -150,19 +145,28 @@ namespace AngleSharp.Dom
             {
                 var parent = Parent;
 
-                if (parent != null)
+                if (parent is not null)
                 {
+                    var children = parent.ChildNodes;
                     var found = false;
 
-                    for (var i = parent.ChildNodes.Length - 1; i >= 0; i--)
+                    // Scanning backwards matters: the preceding element sibling is usually
+                    // right next to this node, so the loop normally ends shortly after the
+                    // node is located. A forward scan would always pay the full prefix.
+                    for (var i = children.Length - 1; i >= 0; i--)
                     {
-                        if (Object.ReferenceEquals(parent.ChildNodes[i], this))
+                        var node = children[i];
+
+                        if (found)
+                        {
+                            if (node.NodeType == NodeType.Element)
+                            {
+                                return (Element)node;
+                            }
+                        }
+                        else if (Object.ReferenceEquals(node, this))
                         {
                             found = true;
-                        }
-                        else if (found && parent.ChildNodes[i] is IElement previousElementSibling)
-                        {
-                            return previousElementSibling;
                         }
                     }
                 }
@@ -178,20 +182,26 @@ namespace AngleSharp.Dom
             {
                 var parent = Parent;
 
-                if (parent != null)
+                if (parent is not null)
                 {
-                    var n = parent.ChildNodes.Length;
+                    var children = parent.ChildNodes;
+                    var n = children.Length;
                     var found = false;
 
                     for (var i = 0; i < n; i++)
                     {
-                        if (Object.ReferenceEquals(parent.ChildNodes[i], this))
+                        var node = children[i];
+
+                        if (found)
+                        {
+                            if (node.NodeType == NodeType.Element)
+                            {
+                                return (Element)node;
+                            }
+                        }
+                        else if (Object.ReferenceEquals(node, this))
                         {
                             found = true;
-                        }
-                        else if (found && parent.ChildNodes[i] is IElement childEl)
-                        {
-                            return childEl;
                         }
                     }
                 }
@@ -642,6 +652,30 @@ namespace AngleSharp.Dom
         #endregion
 
         #region Helpers
+
+        /// <summary>
+        /// Appends the data of every descendant text node, in tree order. Equivalent to
+        /// iterating GetDescendants().OfType&lt;IText&gt;(), without the nested iterators.
+        /// </summary>
+        private static void AppendText(Node parent, System.Text.StringBuilder sb)
+        {
+            var children = parent.ChildNodes;
+            var n = children.Length;
+
+            for (var i = 0; i < n; i++)
+            {
+                var child = children[i];
+
+                if (child is IText text)
+                {
+                    sb.Append(text.Data);
+                }
+                else if (child.HasChildNodes)
+                {
+                    AppendText(child, sb);
+                }
+            }
+        }
 
         /// <inheritdoc />
         protected void UpdateAttribute(String name, String value) => this.SetOwnAttribute(name, value, suppressCallbacks: true);

--- a/src/AngleSharp/Dom/Internal/ElementTreeEnumerator.cs
+++ b/src/AngleSharp/Dom/Internal/ElementTreeEnumerator.cs
@@ -1,0 +1,118 @@
+namespace AngleSharp.Dom
+{
+    using System;
+
+    /// <summary>
+    /// Depth-first pre-order enumerator over an element and all of its element
+    /// descendants.
+    /// </summary>
+    /// <remarks>
+    /// The obvious implementation pushes every element child onto a stack, but a
+    /// <see cref="System.Collections.Generic.Stack{T}"/> of a reference type pays an array
+    /// covariance check on every push, and the stack grows to the width of the tree even
+    /// when the very first element matches. This walks parent links instead and only keeps
+    /// a stack of child indices, which stores value types and is bounded by the depth of
+    /// the tree rather than its width.
+    /// </remarks>
+    internal struct ElementTreeEnumerator
+    {
+        private const Int32 InitialDepth = 16;
+
+        private Element _current;
+        private Int32[]? _indices;
+        private Int32 _depth;
+        private Boolean _started;
+        private Boolean _finished;
+
+        public ElementTreeEnumerator(Element root)
+        {
+            _current = root;
+            _indices = null;
+            _depth = 0;
+            _started = false;
+            _finished = false;
+        }
+
+        public readonly Element Current => _current;
+
+        public Boolean MoveNext()
+        {
+            if (_finished)
+            {
+                return false;
+            }
+
+            if (!_started)
+            {
+                _started = true;
+                return true;
+            }
+
+            var child = GetElementAtOrAfter(_current, 0, out var childIndex);
+
+            if (child is not null)
+            {
+                Push(childIndex);
+                _current = child;
+                return true;
+            }
+
+            while (_depth > 0)
+            {
+                // Only elements are ever descended into, so the parent is always an element.
+                var parent = (Element)_current.Parent!;
+                var sibling = GetElementAtOrAfter(parent, _indices![_depth - 1] + 1, out var siblingIndex);
+
+                if (sibling is not null)
+                {
+                    _indices[_depth - 1] = siblingIndex;
+                    _current = sibling;
+                    return true;
+                }
+
+                _depth--;
+                _current = parent;
+            }
+
+            _finished = true;
+            return false;
+        }
+
+        private void Push(Int32 index)
+        {
+            var indices = _indices;
+
+            if (indices is null)
+            {
+                indices = _indices = new Int32[InitialDepth];
+            }
+            else if (_depth == indices.Length)
+            {
+                Array.Resize(ref indices, indices.Length * 2);
+                _indices = indices;
+            }
+
+            indices[_depth++] = index;
+        }
+
+        private static Element? GetElementAtOrAfter(Element element, Int32 start, out Int32 index)
+        {
+            var children = element.ChildNodes;
+            var n = children.Length;
+
+            for (var i = start; i < n; i++)
+            {
+                var node = children[i];
+
+                if (node.NodeType == NodeType.Element)
+                {
+                    index = i;
+                    return (Element)node;
+                }
+            }
+
+            index = -1;
+            return null;
+        }
+    }
+}

--- a/src/AngleSharp/Dom/Internal/Node.cs
+++ b/src/AngleSharp/Dom/Internal/Node.cs
@@ -116,7 +116,16 @@ namespace AngleSharp.Dom
         INode? INode.Parent => _parent;
 
         /// <inheritdoc />
-        public IElement? ParentElement => _parent as IElement;
+        public IElement? ParentElement
+        {
+            get
+            {
+                // Avoids the interface cast helper, which is hot for descendant and
+                // child combinators walking the ancestor chain of every candidate.
+                var parent = _parent;
+                return parent is not null && parent.NodeType == NodeType.Element ? (Element)parent : null;
+            }
+        }
 
         INodeList INode.ChildNodes => _children;
 

--- a/src/AngleSharp/Dom/Internal/NodeList.cs
+++ b/src/AngleSharp/Dom/Internal/NodeList.cs
@@ -116,6 +116,13 @@ namespace AngleSharp.Dom
     {
         Int32 Length { get; }
         INode this[Int32 index] { get; }
+
+        /// <summary>
+        /// Gets the node at the given index if it is an element. Preferred over an
+        /// "is IElement" test on the indexer, which goes through the interface cast
+        /// helper on every child of every candidate.
+        /// </summary>
+        Boolean TryGetElement(Int32 index, out IElement element);
     }
 
     internal readonly struct ConcreteNodeListAccessor : INodeListAccessor
@@ -138,6 +145,21 @@ namespace AngleSharp.Dom
             [MethodImpl(MethodImplOptions.AggressiveInlining)]
             get => _nodeList[index];
         }
+
+        [MethodImpl(MethodImplOptions.AggressiveInlining)]
+        public Boolean TryGetElement(Int32 index, out IElement element)
+        {
+            var node = _nodeList[index];
+
+            if (node.NodeType == NodeType.Element)
+            {
+                element = (Element)node;
+                return true;
+            }
+
+            element = null!;
+            return false;
+        }
     }
 
     internal readonly struct InterfaceNodeListAccessor : INodeListAccessor
@@ -159,6 +181,19 @@ namespace AngleSharp.Dom
         {
             [MethodImpl(MethodImplOptions.AggressiveInlining)]
             get => _nodeList[index];
+        }
+
+        [MethodImpl(MethodImplOptions.AggressiveInlining)]
+        public Boolean TryGetElement(Int32 index, out IElement element)
+        {
+            if (_nodeList[index] is IElement child)
+            {
+                element = child;
+                return true;
+            }
+
+            element = null!;
+            return false;
         }
     }
 }

--- a/src/AngleSharp/Dom/QueryExtensions.cs
+++ b/src/AngleSharp/Dom/QueryExtensions.cs
@@ -6,9 +6,6 @@ using AngleSharp.Text;
 using System;
 using System.Collections.Generic;
 using System.Linq;
-#if NET5_0_OR_GREATER
-using System.Runtime.InteropServices;
-#endif
 
 /// <summary>
 /// Extensions for performing QuerySelector operations.
@@ -301,44 +298,20 @@ public static class QueryExtensions
     /// <param name="result">A reference to the list where to store the results.</param>
     public static void QuerySelectorAll<T>(this T elements, ISelector selector, IElement? scope, List<IElement> result) where T : class, INodeList
     {
-        var stack = new Stack<Element>();
-
         for (var i = 0; i < elements.Length; i++)
         {
             if (elements[i] is Element rootElement)
             {
-                stack.Push(rootElement);
+                var walker = new ElementTreeEnumerator(rootElement);
 
-                while (stack.Count > 0)
+                while (walker.MoveNext())
                 {
-                    var element = stack.Pop();
+                    var element = walker.Current;
 
                     if (selector.Match(element, scope))
                     {
                         result.Add(element);
                     }
-
-#if NET5_0_OR_GREATER
-                    var entries = CollectionsMarshal.AsSpan(element.ChildNodes._entries);
-
-                    for (var j = entries.Length - 1; j >= 0; j--)
-                    {
-                        if (entries[j] is Element child)
-                        {
-                            stack.Push(child);
-                        }
-                    }
-#else
-                    var childNodes = element.ChildNodes;
-
-                    for (var j = childNodes.Length - 1; j >= 0; j--)
-                    {
-                        if (childNodes[j] is Element child)
-                        {
-                            stack.Push(child);
-                        }
-                    }
-#endif
                 }
             }
         }


### PR DESCRIPTION
# Improve selector matching performance (fixes #929)

Issue #929 reported that `doc.QuerySelector("h2:contains('...')")` was dramatically slower
than the hand-rolled `GetElementsByTagName("h2").FirstOrDefault(x => x.TextContent.Contains(...))`.

Profiling the current `devel` (ultra/ETW sampling at 8190 Hz, 127 KB W3C Selectors spec page,
1781 elements) showed the gap is **not** in `:contains` — it is in the traversal machinery
behind `QuerySelector`, plus a handful of per-candidate interface casts and a quadratic
sibling walk. Where the time went on the unmodified code:

| cost | share | cause |
|---|---|---|
| `CastHelpers.StelemRef` / `StelemRef_Helper` | 33.8% of the `QuerySelector` path | array covariance checks pushing onto `Stack<INode>` |
| `NodeExtensions.GetDescendantsAndSelf.MoveNext` | 36.8% of the `QuerySelector` path | iterator state machine + `Func<>` filter per query |
| `CastHelpers.IsInstanceOfInterface` | 9.9% of the `QuerySelectorAll` sweep | `nodes[i] is IElement` in the nth-child family (96.8% from one method) |
| `Element.get_PreviousElementSibling` | 10.0% of the `QuerySelectorAll` sweep | re-reads `parent.ChildNodes` twice per loop iteration |
| `StelemRef` | 11.4% of the `QuerySelectorAll` sweep | `Stack<Element>` pushes |

## Changes

1. **`SelectorExtensions.MatchAny`/`MatchAll`** no longer route through the
   `GetDescendantsAndSelf` iterator with a `Stack<INode>` and a delegate filter.
   `QuerySelector` was measurably slower than `QuerySelectorAll` for strictly less work.
2. **`INodeListAccessor.TryGetElement`** tests `NodeType` instead of casting to `IElement`,
   used by `First`/`LastChildSelector` and `First`/`LastTypeSelector`.
3. **Sibling access**: `Previous`/`NextElementSibling` hoist the child list out of the loop
   and drop the interface casts; `Node.ParentElement` avoids the interface cast helper
   (it is on the ancestor walk of every descendant/child combinator candidate);
   `SiblingCombinator` scans the parent's child list once instead of re-locating the element
   for every sibling, which was quadratic.
4. **New `ElementTreeEnumerator`** — depth-first pre-order walk over parent links with a
   stack of child *indices* rather than nodes. No covariance checks, and the working set is
   bounded by tree depth instead of tree width. Used by `QuerySelectorAll`, `MatchAny` and
   `MatchAll`.
5. **New `TextContainsMatcher`** — `:contains` streams descendant text nodes through
   Knuth-Morris-Pratt (prefix table built once, at selector parse time) instead of
   materializing `TextContent` for every candidate. Matches spanning a node boundary are
   still found. `Element.TextContent` itself also drops its nested LINQ iterators.

## Results

BenchmarkDotNet 0.15.8, AMD Ryzen 9 5950X, Windows 11. Default job (not ShortRun), machine
idle for both runs. StdDev under 1% throughout.

### Issue #929 — the reported scenario

Hand-rolled `GetElementsByTagName` + `TextContent.Contains` is the baseline (ratio 1.00).

**net10.0**

| | before | after |
|---|---|---|
| found — `h2:contains(...)` | 9.997 μs (0.29×) | **2.873 μs (0.10×)** |
| not found — `h2:contains(...)` | 63.182 μs (**1.93× slower**) | **26.902 μs (0.78×)** |
| not found — allocated | 23.14 KB (3.13×) | **176 B (0.09×)** |

**net8.0**

| | before | after |
|---|---|---|
| found — `h2:contains(...)` | 12.85 μs (0.34×) | **3.277 μs (0.09×)** |
| not found — `h2:contains(...)` | 100.43 μs (**2.49× slower**) | **29.451 μs (0.77×)** |
| not found — allocated | 23.3 KB (3.09×) | **184 B (0.10×)** |

The full-scan case went from ~2× slower than the hand-rolled loop to faster than it, on both
runtimes. The selector form now wins in both directions.

### `QuerySelector` (net10.0)

| selector | before | after | speedup |
|---|---:|---:|---:|
| `div` | 3,998 ns | 145 ns | 27.6× |
| `p:nth-child(2n+1)` | 4,418 ns | 160 ns | 27.6× |
| `div p` | 4,085 ns | 179 ns | 22.8× |
| `#title` | 3,571 ns | 185 ns | 19.3× |
| `div ~ p` | 6,658 ns | 818 ns | 8.1× |
| `ul.toc li.tocline2` | 7,175 ns | 1,377 ns | 5.2× |
| `p:contains(selectors)` | 6,093 ns | 1,273 ns | 4.8× |
| `.note` | 23,932 ns | 8,330 ns | 2.9× |
| `div.no-such-class` (full scan) | 61,804 ns | 27,255 ns | 2.3× |
| `div + p` | 33,785 ns | 16,903 ns | 2.0× |
| `p:only-child` | 111,092 ns | 80,451 ns | 1.4× |

Allocation is now a flat **176 B** per call. It was a flat **16,808 B** — paid even when the
match was the first element visited, because the node stack grew to the width of the document
regardless of when the search stopped.

### `QuerySelectorAll` (net10.0)

| selector | before | after | speedup |
|---|---:|---:|---:|
| `div ~ p` | 339,976 ns | 75,601 ns | 4.5× |
| `p:nth-child(2n+1)` | 158,150 ns | 94,504 ns | 1.7× |
| `p:contains(selectors)` | 116,171 ns | 75,399 ns | 1.5× |
| `ul.toc li.tocline2` | 40,464 ns | 30,192 ns | 1.3× |
| `#title` | 31,450 ns | 24,819 ns | 1.3× |
| `div` | 32,681 ns | 26,300 ns | 1.2× |
| `div + p` | 80,632 ns | 68,402 ns | 1.2× |
| `div p` | 45,044 ns | 40,038 ns | 1.1× |
| `p:only-child` | 110,207 ns | 109,585 ns | 1.0× |

`p:contains(selectors)` allocation: **235.75 KB → 1,256 B (192× less)**.

### Broad sweep — existing `SelectorBenchmark`, all 42 selectors

| | net10.0 | net8.0 |
|---|---|---|
| regressions over 3% | **0** | **0** |
| smallest gain | 1.13× | 1.14× |
| largest gain | 4.52× (`div ~ p`) | 4.04× (`div ~ p`) |

## Benchmark additions

`SelectorBenchmark` only ever covered `QuerySelectorAll`, so the slowest path had no coverage.
Added:

- `QuerySelectorBenchmark` — 11 selectors against **both** `QuerySelector` and
  `QuerySelectorAll`, default job for low noise; includes a deliberate no-match selector to
  force a complete traversal.
- `Issue929Benchmark` — the head-to-head from the issue, in found and not-found variants.
- `net10.0` added to the benchmark project's target frameworks.

## Tests

All existing tests pass on net10.0, net8.0, net472 and net462. Seven tests added, six covering
the `:contains` streaming matcher where the regression risk is real — matches spanning child
elements (`Climb<b>ing</b> Directory`), deep nesting, and correct restart on partial matches
(`aab` within `aaab`) both inside a single text node and across a node boundary — plus one
asserting `QuerySelector` returns the same element as `QuerySelectorAll[0]`, since those are
now two separate traversal implementations.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
