### PR TITLE
Use interface dispatch for tokenizer character reads

### DIFF
--- a/src/AngleSharp.Benchmarks/Program.cs
+++ b/src/AngleSharp.Benchmarks/Program.cs
@@ -10,6 +10,24 @@ namespace AngleSharp.Benchmarks
         {
             Encoding.RegisterProvider(CodePagesEncodingProvider.Instance);
 
+            if (
+                args.Length == 1
+                && args[0].Equals("--text-source-dispatch", StringComparison.OrdinalIgnoreCase)
+            )
+            {
+                BenchmarkRunner.Run<TextSourceDispatchBenchmark>();
+                return;
+            }
+
+            if (
+                args.Length == 1
+                && args[0].Equals("--scan-data-text", StringComparison.OrdinalIgnoreCase)
+            )
+            {
+                BenchmarkRunner.Run<ScanDataTextBenchmark>();
+                return;
+            }
+
             BenchmarkSwitcher.FromAssembly(typeof(Program).Assembly).Run(args);
         }
     }

--- a/src/AngleSharp.Benchmarks/TextSourceDispatchBenchmark.cs
+++ b/src/AngleSharp.Benchmarks/TextSourceDispatchBenchmark.cs
@@ -1,0 +1,113 @@
+﻿namespace AngleSharp.Benchmarks;
+
+using System;
+using BenchmarkDotNet.Attributes;
+using Text;
+
+[MemoryDiagnoser, ShortRunJob]
+public class TextSourceDispatchBenchmark
+{
+    private IReadOnlyTextSource _interfaceSource;
+    private CachedTypeChecks _cachedTypeChecks;
+
+    [Params(32, 4096)]
+    public Int32 Length { get; set; }
+
+    [Params(SourceKind.CharArray, SourceKind.Memory, SourceKind.String)]
+    public SourceKind Source { get; set; }
+
+    [GlobalSetup]
+    public void Setup()
+    {
+        var text = new String('a', Length);
+        _interfaceSource = CreateSource(Source, text);
+        _cachedTypeChecks = new CachedTypeChecks(CreateSource(Source, text));
+    }
+
+    [Benchmark(Baseline = true)]
+    public Int32 ManualTypeChecks()
+    {
+        _cachedTypeChecks.Reset();
+        return _cachedTypeChecks.Read(Length);
+    }
+
+    [Benchmark]
+    public Int32 InterfaceDispatch()
+    {
+        _interfaceSource.Index = 0;
+        var checksum = 0;
+
+        for (var i = 0; i < Length; i++)
+        {
+            checksum += _interfaceSource.ReadCharacter();
+        }
+
+        return checksum;
+    }
+
+    private static IReadOnlyTextSource CreateSource(SourceKind kind, String text) => kind switch
+    {
+        SourceKind.CharArray => new CharArrayTextSource(text.ToCharArray(), text.Length),
+        SourceKind.Memory => new ReadOnlyMemoryTextSource(text.AsMemory()),
+        SourceKind.String => new StringTextSource(text),
+        _ => throw new ArgumentOutOfRangeException(nameof(kind)),
+    };
+
+    public enum SourceKind
+    {
+        CharArray,
+        Memory,
+        String,
+    }
+
+    private sealed class CachedTypeChecks
+    {
+        private readonly IReadOnlyTextSource _source;
+        private readonly StringTextSource _firstConcreteSource;
+        private readonly CharArrayTextSource _charArraySource;
+        private readonly ReadOnlyMemoryTextSource _memorySource;
+
+        public CachedTypeChecks(IReadOnlyTextSource source)
+        {
+            _source = source;
+            // Represents the first cached concrete-source check in BaseTokenizer.
+            _firstConcreteSource = null;
+            _charArraySource = source as CharArrayTextSource;
+            _memorySource = source as ReadOnlyMemoryTextSource;
+        }
+
+        public void Reset() => _source.Index = 0;
+
+        public Int32 Read(Int32 length)
+        {
+            var checksum = 0;
+
+            for (var i = 0; i < length; i++)
+            {
+                checksum += ReadCharacter();
+            }
+
+            return checksum;
+        }
+
+        private Char ReadCharacter()
+        {
+            if (_firstConcreteSource is not null)
+            {
+                return _firstConcreteSource.ReadCharacter();
+            }
+
+            if (_charArraySource is not null)
+            {
+                return _charArraySource.ReadCharacter();
+            }
+
+            if (_memorySource is not null)
+            {
+                return _memorySource.ReadCharacter();
+            }
+
+            return _source.ReadCharacter();
+        }
+    }
+}

--- a/src/AngleSharp/Common/BaseTokenizer.cs
+++ b/src/AngleSharp/Common/BaseTokenizer.cs
@@ -16,7 +16,6 @@ namespace AngleSharp.Common
         private readonly Stack<UInt16> _columns;
 
         private readonly IReadOnlyTextSource _source;
-        private readonly WritableTextSource? _wts;
         private readonly CharArrayTextSource? _cats;
         private readonly ReadOnlyMemoryTextSource? _roms;
 
@@ -54,11 +53,7 @@ namespace AngleSharp.Common
 
             _source = source.GetUnderlyingTextSource();
 
-            if (_source is WritableTextSource wts)
-            {
-                _wts = wts;
-            }
-            else if (_source is CharArrayTextSource cats)
+            if (_source is CharArrayTextSource cats)
             {
                 _cats = cats;
             }
@@ -575,25 +570,7 @@ namespace AngleSharp.Common
             return Symbols.LineFeed;
         }
 
-        private Char ReadCharFromSource()
-        {
-            if (_wts is not null)
-            {
-                return _wts.ReadCharacter();
-            }
-
-            if (_cats is not null)
-            {
-                return _cats.ReadCharacter();
-            }
-
-            if (_roms is not null)
-            {
-                return _roms.ReadCharacter();
-            }
-
-            return _source.ReadCharacter();
-        }
+        private Char ReadCharFromSource() => _source.ReadCharacter();
 
         #endregion
     }


### PR DESCRIPTION
# Types of Changes

## Prerequisites

- [ ] I have read the **CONTRIBUTING** document (the repository currently has no `CONTRIBUTING` file)
- [x] My code follows the code style of this project

## Contribution Type

- [ ] Bug fix
- [ ] New feature
- [ ] Breaking change
- [ ] My change requires a change to the documentation
- [x] I have added a benchmark to cover my changes
- [x] All new and existing tests passed

## Description

Use the existing `IReadOnlyTextSource` reference directly for per-character tokenizer reads instead of checking cached concrete source references on every character.

The cached `CharArrayTextSource` and `ReadOnlyMemoryTextSource` references remain in place for the `ScanDataText` bulk-scanning optimization. The now-unused `WritableTextSource` cache is removed.

This also adds `TextSourceDispatchBenchmark`, which compares the previous cached concrete dispatch with interface dispatch for char-array, memory, and string-backed sources. Dedicated benchmark entry points avoid materializing unrelated benchmark parameter sources, so both the new microbenchmark and the existing end-to-end `ScanDataTextBenchmark` can run without the external page cache:

```console
dotnet run -c Release --project src/AngleSharp.Benchmarks -f net10.0 -- --text-source-dispatch
dotnet run -c Release --project src/AngleSharp.Benchmarks -f net10.0 -- --scan-data-text
```

### Benchmark results

BenchmarkDotNet 0.15.8, .NET 10.0.10, Intel Core i7-9750H, ShortRun. The end-to-end tokenizer benchmark at 10,000 repeats improved for every source type with unchanged allocations:

| Source | Before | After | Change | Allocated |
|---|---:|---:|---:|---:|
| String | 9.594 ms | 8.503 ms | -11.4% | 2954.8 KB |
| Char array | 5.379 ms | 4.895 ms | -9.0% | 2053.0 KB |
| Memory | 6.100 ms | 5.566 ms | -8.7% | 2053.0 KB |

The isolated 4,096-character dispatch benchmark shows the architecture-dependent trade-off explicitly: interface dispatch was 6% slower for `CharArrayTextSource`, 27% faster for `ReadOnlyMemoryTextSource`, and 22% faster for `StringTextSource`. The tokenizer-level benchmark is the representative result for this change.

### Validation

- `net472`, `net8.0`, and `net10.0` benchmark/core builds: passed with no warnings
- .NET 10 core test suite: 3,741 passed, 0 failed
- .NET 10 core test suite with `prefetched=true`: 3,740 passed, 0 failed

The .NET Framework target was compile-validated on macOS; runtime benchmarking for that target requires Windows.
