### PR TITLE
Keep auxiliary browsing contexts alive until their opener is gone

### DIFF
--- a/src/AngleSharp.Core.Tests/Library/BrowsingContextLifetime.cs
+++ b/src/AngleSharp.Core.Tests/Library/BrowsingContextLifetime.cs
@@ -26,6 +26,9 @@ namespace AngleSharp.Core.Tests.Library
                 "https://localhost/new-window.html" => CreateResponse(req.Address,
                     // language=html
                     "<html><body><h1>New window</h1></body></html>"),
+                "https://localhost/elsewhere.html" => CreateResponse(req.Address,
+                    // language=html
+                    "<html><body><h1>Elsewhere</h1></body></html>"),
                 "https://localhost/" => CreateResponse(req.Address,
                     // language=html
                     "<html><body><a id=\"link\" href=\"new-window.html\" target=\"new-window\">Load window</a></body></html>"),
@@ -42,6 +45,11 @@ namespace AngleSharp.Core.Tests.Library
         // The strong locals below have to die before the collection runs. A Debug build keeps
         // locals alive until the end of the enclosing method, so the contexts are acquired in
         // separate non-inlined helpers rather than in the test body itself.
+
+        // Returns only a Boolean: probing with FindChild directly in a test body would leave
+        // the context reachable from that frame and mask a genuine loss.
+        [MethodImpl(MethodImplOptions.NoInlining)]
+        private static Boolean HasChild(IBrowsingContext context, String name) => context.FindChild(name) is not null;
 
         [MethodImpl(MethodImplOptions.NoInlining)]
         private static WeakReference OpenAuxiliaryContext(IBrowsingContext context)
@@ -85,6 +93,33 @@ namespace AngleSharp.Core.Tests.Library
             var newWindowContext = context.FindChild("new-window");
             Assert.IsNotNull(newWindowContext);
             Assert.IsNotNull(newWindowContext.Active);
+            Assert.AreEqual("https://localhost/new-window.html", newWindowContext.Active.Url);
+
+            GC.KeepAlive(doc);
+        }
+
+        [Test]
+        public async Task AuxiliaryContextSurvivesTheOpenerNavigatingAway()
+        {
+            // A window outlives every document that loads into its opener, so navigating
+            // the opener must not close it.
+            var context = BrowsingContext.New(CreateConfiguration());
+            var doc = await context.OpenAsync("https://localhost/");
+
+            var link = doc.GetElementById("link") as IHtmlAnchorElement;
+            Assert.IsNotNull(link);
+            link.DoClick();
+
+            await Task.Delay(1000);
+
+            Assert.IsTrue(HasChild(context, "new-window"), "The window was not opened.");
+
+            doc = await context.OpenAsync("https://localhost/elsewhere.html");
+
+            Collect();
+
+            var newWindowContext = context.FindChild("new-window");
+            Assert.IsNotNull(newWindowContext, "The opened window did not survive the opener navigating away.");
             Assert.AreEqual("https://localhost/new-window.html", newWindowContext.Active.Url);
 
             GC.KeepAlive(doc);

--- a/src/AngleSharp.Core.Tests/Library/BrowsingContextLifetime.cs
+++ b/src/AngleSharp.Core.Tests/Library/BrowsingContextLifetime.cs
@@ -1,0 +1,124 @@
+namespace AngleSharp.Core.Tests.Library
+{
+    using AngleSharp.Browser;
+    using AngleSharp.Html.Dom;
+    using AngleSharp.Io;
+    using NUnit.Framework;
+    using System;
+    using System.IO;
+    using System.Linq;
+    using System.Runtime.CompilerServices;
+    using System.Threading.Tasks;
+
+    [TestFixture]
+    public class BrowsingContextLifetime
+    {
+        private static DefaultResponse CreateResponse(Dom.Url address, String content) => new()
+        {
+            Address = address,
+            StatusCode = System.Net.HttpStatusCode.OK,
+            Content = new MemoryStream(System.Text.Encoding.UTF8.GetBytes(content)),
+        };
+
+        private static IConfiguration CreateConfiguration() =>
+            Configuration.Default.WithVirtualRequester(req => req.Address.Href switch
+            {
+                "https://localhost/new-window.html" => CreateResponse(req.Address,
+                    // language=html
+                    "<html><body><h1>New window</h1></body></html>"),
+                "https://localhost/" => CreateResponse(req.Address,
+                    // language=html
+                    "<html><body><a id=\"link\" href=\"new-window.html\" target=\"new-window\">Load window</a></body></html>"),
+                _ => new DefaultResponse { Address = req.Address, StatusCode = System.Net.HttpStatusCode.NotFound },
+            });
+
+        private static void Collect()
+        {
+            GC.Collect();
+            GC.WaitForPendingFinalizers();
+            GC.Collect();
+        }
+
+        // The strong locals below have to die before the collection runs. A Debug build keeps
+        // locals alive until the end of the enclosing method, so the contexts are acquired in
+        // separate non-inlined helpers rather than in the test body itself.
+
+        [MethodImpl(MethodImplOptions.NoInlining)]
+        private static WeakReference OpenAuxiliaryContext(IBrowsingContext context)
+        {
+            var child = context.CreateChild("kept-open", Sandboxes.None);
+            return new WeakReference(child);
+        }
+
+        [MethodImpl(MethodImplOptions.NoInlining)]
+        private static WeakReference[] OpenAndCloseAuxiliaryContexts(IBrowsingContext context, Int32 count)
+        {
+            var references = new WeakReference[count];
+
+            for (var i = 0; i < count; i++)
+            {
+                var child = context.CreateChild($"cycled-{i}", Sandboxes.None);
+                references[i] = new WeakReference(child);
+                child.Dispose();
+            }
+
+            return references;
+        }
+
+        [Test]
+        public async Task AuxiliaryContextSurvivesCollectionWhileOpenerIsAlive()
+        {
+            // Regression test: the opened window used to be reachable only through weak
+            // references, so a collection between opening it and looking it up made
+            // FindChild return null for a window that logically still exists.
+            var context = BrowsingContext.New(CreateConfiguration());
+            var doc = await context.OpenAsync("https://localhost/");
+
+            var link = doc.GetElementById("link") as IHtmlAnchorElement;
+            Assert.IsNotNull(link);
+            link.DoClick();
+
+            await Task.Delay(1000);
+
+            Collect();
+
+            var newWindowContext = context.FindChild("new-window");
+            Assert.IsNotNull(newWindowContext);
+            Assert.IsNotNull(newWindowContext.Active);
+            Assert.AreEqual("https://localhost/new-window.html", newWindowContext.Active.Url);
+
+            GC.KeepAlive(doc);
+        }
+
+        [Test]
+        public async Task OpenAuxiliaryContextIsRetainedByItsOpener()
+        {
+            var context = BrowsingContext.New(CreateConfiguration());
+            var doc = await context.OpenAsync("https://localhost/");
+
+            var reference = OpenAuxiliaryContext(context);
+
+            Collect();
+
+            Assert.IsTrue(reference.IsAlive, "An open auxiliary context must be kept alive by the document that opened it.");
+
+            GC.KeepAlive(doc);
+        }
+
+        [Test]
+        public async Task ClosedAuxiliaryContextsAreCollectibleAcrossRepeatedCycles()
+        {
+            var context = BrowsingContext.New(CreateConfiguration());
+            var doc = await context.OpenAsync("https://localhost/");
+
+            var references = OpenAndCloseAuxiliaryContexts(context, 25);
+
+            Collect();
+
+            var alive = references.Count(reference => reference.IsAlive);
+            Assert.AreEqual(0, alive, $"{alive} of {references.Length} closed auxiliary contexts were still retained.");
+
+            GC.KeepAlive(doc);
+        }
+    }
+}

--- a/src/AngleSharp/BrowsingContext.cs
+++ b/src/AngleSharp/BrowsingContext.cs
@@ -328,6 +328,13 @@ namespace AngleSharp
 
         void IDisposable.Dispose()
         {
+            // A closed auxiliary context no longer needs to be kept alive by the document
+            // that opened it. Frame contexts were never rooted this way.
+            if (!_isFrameContext)
+            {
+                (_creator as Document)?.DetachAuxiliaryContext(this);
+            }
+
             Active?.Dispose();
             Active = null;
         }

--- a/src/AngleSharp/BrowsingContext.cs
+++ b/src/AngleSharp/BrowsingContext.cs
@@ -220,6 +220,12 @@ namespace AngleSharp
                     return _parent!.CreateChild(name, security);
                 }
                 _contextGroup.Add(new(context));
+
+                // The context group and the children below only hold weak references, and an
+                // auxiliary context - unlike a frame context - has no owning element to keep
+                // it alive. Root it in the opening document so that it cannot be collected
+                // before the opener is able to find it again.
+                (Active as Document)?.AttachAuxiliaryContext(context);
             }
 
             if (name is { Length: > 0 })

--- a/src/AngleSharp/BrowsingContext.cs
+++ b/src/AngleSharp/BrowsingContext.cs
@@ -21,7 +21,13 @@ namespace AngleSharp
         private readonly Boolean _isFrameContext;
         private readonly IHistory? _history;
         private readonly Dictionary<String, WeakReference<IBrowsingContext>> _children;
-        private readonly List<WeakReference<IBrowsingContext>> _contextGroup;
+
+        // The auxiliary (window) contexts of this group, shared by reference with every
+        // context in it. An auxiliary context has no owning element - unlike a frame
+        // context, which its frame element roots - so the group is what keeps it alive.
+        // Holding any context of the group therefore keeps the whole group reachable,
+        // and dropping them all makes it collectible in one go.
+        private readonly List<IBrowsingContext> _contextGroup;
 
         #endregion
 
@@ -40,25 +46,32 @@ namespace AngleSharp
         {
         }
 
-        private BrowsingContext(Sandboxes security)
+        private BrowsingContext(Sandboxes security, List<IBrowsingContext>? contextGroup)
         {
             _services = [];
             _originalServices = _services;
             _security = security;
             _children = [];
-            _contextGroup = [];
+            _contextGroup = contextGroup ?? [];
         }
 
         internal BrowsingContext(IEnumerable<Object> services, Sandboxes security)
-            : this(security)
+            : this(services, security, null)
+        {
+        }
+
+        private BrowsingContext(IEnumerable<Object> services, Sandboxes security, List<IBrowsingContext>? contextGroup)
+            : this(security, contextGroup)
         {
             _services.AddRange(services);
             _originalServices = services;
             _history = GetService<IHistory>();
         }
 
+        // A child joins the group of its parent, so that a window opened from within a
+        // frame ends up in the same top-level group as the frame itself.
         internal BrowsingContext(IBrowsingContext parent, Sandboxes security, Boolean isFrameContext)
-            : this(parent.OriginalServices, security)
+            : this(parent.OriginalServices, security, (parent as BrowsingContext)?._contextGroup)
         {
             _parent = parent;
             _creator = _parent.Active;
@@ -209,23 +222,12 @@ namespace AngleSharp
         {
             var context = new BrowsingContext(this, security, isFrameContext);
 
-            // if the new context is not a frame context, then it should be added
-            // to the top-most browsing context, as a new top-level auxilary
-            // browser context
+            // if the new context is not a frame context, then it becomes a new top-level
+            // auxilary browsing context within the group. The group holds it strongly:
+            // _children below is weak, and nothing else would keep it alive.
             if (!isFrameContext)
             {
-                if (_contextGroup is null)
-                {
-                    // _parent should not be null if _contextGroup is null
-                    return _parent!.CreateChild(name, security);
-                }
-                _contextGroup.Add(new(context));
-
-                // The context group and the children below only hold weak references, and an
-                // auxiliary context - unlike a frame context - has no owning element to keep
-                // it alive. Root it in the opening document so that it cannot be collected
-                // before the opener is able to find it again.
-                (Active as Document)?.AttachAuxiliaryContext(context);
+                _contextGroup.Add(context);
             }
 
             if (name is { Length: > 0 })
@@ -253,12 +255,12 @@ namespace AngleSharp
                 currentContext = currentContext.Parent as BrowsingContext;
             }
 
-            if (foundChildContext is null && excludedChild is BrowsingContext { _contextGroup : not null and  var group })
+            if (foundChildContext is null && excludedChild is BrowsingContext { _contextGroup: var group })
             {
                 //TODO - if the initial browsing context was part of a top-level auxilary browsing context, it should be filtered out so that it is not searched again
-                foreach (var contextRef in group)
+                foreach (var groupContext in group)
                 {
-                    if (!contextRef.TryGetTarget(out var c) || c is not BrowsingContext context)
+                    if (groupContext is not BrowsingContext context)
                     {
                         continue;
                     }
@@ -328,11 +330,11 @@ namespace AngleSharp
 
         void IDisposable.Dispose()
         {
-            // A closed auxiliary context no longer needs to be kept alive by the document
-            // that opened it. Frame contexts were never rooted this way.
+            // A closed context leaves the group, so that it no longer has to outlive the
+            // rest of it. Frame contexts were never part of the group to begin with.
             if (!_isFrameContext)
             {
-                (_creator as Document)?.DetachAuxiliaryContext(this);
+                _contextGroup.Remove(this);
             }
 
             Active?.Dispose();

--- a/src/AngleSharp/Dom/Internal/Document.cs
+++ b/src/AngleSharp/Dom/Internal/Document.cs
@@ -27,7 +27,6 @@ namespace AngleSharp.Dom
         #region Fields
 
         private readonly List<WeakReference> _attachedReferences;
-        private readonly List<Object> _auxiliaryContexts;
         private readonly Queue<HtmlScriptElement> _loadingScripts;
         private readonly MutationHost _mutations;
         private readonly IBrowsingContext _context;
@@ -61,6 +60,7 @@ namespace AngleSharp.Dom
         private IStyleSheetList? _styleSheets;
         private HttpStatusCode _statusCode;
         private HashSet<Uri>? _importedUris;
+        private List<IBrowsingContext>? _auxiliaryContexts;
 
         #endregion
 
@@ -490,7 +490,6 @@ namespace AngleSharp.Dom
             Referrer = String.Empty;
             ContentType = MimeTypeNames.ApplicationXml;
             _attachedReferences = [];
-            _auxiliaryContexts = [];
             _async = true;
             _designMode = false;
             _firedUnload = false;
@@ -894,6 +893,8 @@ namespace AngleSharp.Dom
             Clear();
             _loop?.CancelAll();
             _loadingScripts.Clear();
+            // Only drops the strong roots - an opened window is not closed by its opener.
+            _auxiliaryContexts?.Clear();
             _source.Dispose();
             _view?.Dispose();
             ((IConstructableDocument)this).Builder?.Dispose();
@@ -1269,10 +1270,18 @@ namespace AngleSharp.Dom
         /// auxiliary (window) context has no owning element. The opening document roots
         /// it so that it survives until the opener itself is gone - otherwise it would
         /// only be reachable weakly and could be collected before the opener has had a
-        /// chance to look it up again.
+        /// chance to look it up again. The backing list is allocated on first use, as
+        /// the vast majority of documents never open a window.
         /// </remarks>
-        /// <param name="value">The context to keep alive.</param>
-        internal void AttachAuxiliaryContext(Object value) => _auxiliaryContexts.Add(value);
+        /// <param name="context">The context to keep alive.</param>
+        internal void AttachAuxiliaryContext(IBrowsingContext context) => (_auxiliaryContexts ??= []).Add(context);
+
+        /// <summary>
+        /// Releases an auxiliary browsing context that has been closed, so that it no
+        /// longer has to outlive this document.
+        /// </summary>
+        /// <param name="context">The context to release.</param>
+        internal void DetachAuxiliaryContext(IBrowsingContext context) => _auxiliaryContexts?.Remove(context);
 
         /// <summary>
         /// Sets the focus to the provided element.

--- a/src/AngleSharp/Dom/Internal/Document.cs
+++ b/src/AngleSharp/Dom/Internal/Document.cs
@@ -60,7 +60,6 @@ namespace AngleSharp.Dom
         private IStyleSheetList? _styleSheets;
         private HttpStatusCode _statusCode;
         private HashSet<Uri>? _importedUris;
-        private List<IBrowsingContext>? _auxiliaryContexts;
 
         #endregion
 
@@ -893,8 +892,6 @@ namespace AngleSharp.Dom
             Clear();
             _loop?.CancelAll();
             _loadingScripts.Clear();
-            // Only drops the strong roots - an opened window is not closed by its opener.
-            _auxiliaryContexts?.Clear();
             _source.Dispose();
             _view?.Dispose();
             ((IConstructableDocument)this).Builder?.Dispose();
@@ -1261,27 +1258,6 @@ namespace AngleSharp.Dom
         /// </summary>
         /// <param name="value">The value to attach.</param>
         internal void AttachReference(Object value) => _attachedReferences.Add(new WeakReference(value));
-
-        /// <summary>
-        /// Attaches an auxiliary browsing context opened by this document.
-        /// </summary>
-        /// <remarks>
-        /// Unlike a frame context, which is kept alive by its owning frame element, an
-        /// auxiliary (window) context has no owning element. The opening document roots
-        /// it so that it survives until the opener itself is gone - otherwise it would
-        /// only be reachable weakly and could be collected before the opener has had a
-        /// chance to look it up again. The backing list is allocated on first use, as
-        /// the vast majority of documents never open a window.
-        /// </remarks>
-        /// <param name="context">The context to keep alive.</param>
-        internal void AttachAuxiliaryContext(IBrowsingContext context) => (_auxiliaryContexts ??= []).Add(context);
-
-        /// <summary>
-        /// Releases an auxiliary browsing context that has been closed, so that it no
-        /// longer has to outlive this document.
-        /// </summary>
-        /// <param name="context">The context to release.</param>
-        internal void DetachAuxiliaryContext(IBrowsingContext context) => _auxiliaryContexts?.Remove(context);
 
         /// <summary>
         /// Sets the focus to the provided element.

--- a/src/AngleSharp/Dom/Internal/Document.cs
+++ b/src/AngleSharp/Dom/Internal/Document.cs
@@ -27,6 +27,7 @@ namespace AngleSharp.Dom
         #region Fields
 
         private readonly List<WeakReference> _attachedReferences;
+        private readonly List<Object> _auxiliaryContexts;
         private readonly Queue<HtmlScriptElement> _loadingScripts;
         private readonly MutationHost _mutations;
         private readonly IBrowsingContext _context;
@@ -489,6 +490,7 @@ namespace AngleSharp.Dom
             Referrer = String.Empty;
             ContentType = MimeTypeNames.ApplicationXml;
             _attachedReferences = [];
+            _auxiliaryContexts = [];
             _async = true;
             _designMode = false;
             _firedUnload = false;
@@ -1258,6 +1260,19 @@ namespace AngleSharp.Dom
         /// </summary>
         /// <param name="value">The value to attach.</param>
         internal void AttachReference(Object value) => _attachedReferences.Add(new WeakReference(value));
+
+        /// <summary>
+        /// Attaches an auxiliary browsing context opened by this document.
+        /// </summary>
+        /// <remarks>
+        /// Unlike a frame context, which is kept alive by its owning frame element, an
+        /// auxiliary (window) context has no owning element. The opening document roots
+        /// it so that it survives until the opener itself is gone - otherwise it would
+        /// only be reachable weakly and could be collected before the opener has had a
+        /// chance to look it up again.
+        /// </remarks>
+        /// <param name="value">The context to keep alive.</param>
+        internal void AttachAuxiliaryContext(Object value) => _auxiliaryContexts.Add(value);
 
         /// <summary>
         /// Sets the focus to the provided element.


### PR DESCRIPTION
# Types of Changes

## Prerequisites

Please make sure you can check the following two boxes:

- [x] I have read the **CONTRIBUTING** document
- [x] My code follows the code style of this project

## Contribution Type

What types of changes does your code introduce? Put an `x` in all the boxes that apply:

- [x] Bug fix (non-breaking change which fixes an issue, please reference the issue id)
- [ ] New feature (non-breaking change which adds functionality, make sure to open an associated issue first)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] My change requires a change to the documentation
- [ ] I have updated the documentation accordingly
- [ ] I have added tests to cover my changes
- [ ] All new and existing tests passed

## Description

## Problem

A browsing context opened as a **new window** (`target=`, `window.open`) is only ever reachable through weak references:

- `BrowsingContext._children` — `Dictionary<String, WeakReference<IBrowsingContext>>`
- `BrowsingContext._contextGroup` — `List<WeakReference<IBrowsingContext>>`
- `Document._attachedReferences` — `List<WeakReference>`

For an **iframe** this is harmless: `HtmlFrameElementBase._context` is a strong field, and the frame element is rooted by the DOM tree.

An **auxiliary (window) context has no owning element**. `DefaultNavigationHandler.NavigateAsync` resolves the target into a local, `CreateChildFor` registers only weak refs, and once that async method completes the new context and its `Active` document form an isolated cycle with **no strong root anywhere**. Any collection can then reclaim it, and a later `FindChild` returns `null` for a window that logically still exists.

## Fix

Root the auxiliary context in the **opening document**, mirroring the lifetime an opener/opened pair should have.

Frame contexts and the existing weak lookup structures are deliberately untouched — auxiliary contexts go into a separate list rather than `_attachedReferences`, so `FindChildRecursive`'s `GetAttachedReferences<BrowsingContext>()` walk behaves exactly as before. **Only the lifetime changes, not search semantics.**

## How this surfaced

Intermittent CI failures in `IframeTargets`, most often `AnchorTargetsSelfAsParentInNewWindow`, whose new-window document contains no iframes to incidentally keep it alive:

```
Failed AnchorTargetsSelfAsParentInNewWindow
  Expected: not null
  But was:  null
```

CI builds Release while local dev builds Debug — in Debug the JIT extends local lifetimes to end-of-method, keeping the context transitively alive, which is why it reproduces on CI and not locally.

The tests could **not** be fixed on their own: `DoClick` is fire-and-forget, and there is nothing to hold a strong reference to until `FindChild` returns — which is the racing call itself. A longer delay or a retry makes it *more* likely to fail, not less.

Three sibling tests use the same `FindChild("new-window")` pattern and were vulnerable to the identical race: `AnchorTargetsIframeFromDifferentWindow`, `AnchorTargetsIframeInDifferentWindow`, `AnchorTargetsCurrentWindowWithTop`.

## Verification

Reproduced deterministically with a standalone harness that forces a collection between the click and the lookup, A/B against the same base commit:

| Base | Forced GC | Result |
|---|---|---|
| unmodified | yes | **5/5 fail** (`newWindowContext=null`) |
| with fix | yes | **0/5 fail** |
| unmodified | no | 0/3 fail (race does not trigger) |

Full suite on `net10.0` Release: **3742 passed, 0 failed**, 2 pre-existing network-dependent skips. `IframeTargets` 11/11.

