### PR TITLE
Move the build orchestrator to the Fallout stable channel (10.4.0)

### DIFF
--- a/.fallout/build.schema.json
+++ b/.fallout/build.schema.json
@@ -102,6 +102,13 @@
         "Verbosity": {
           "description": "Logging verbosity during build execution. Default is 'Normal'",
           "$ref": "#/definitions/Verbosity"
+        },
+        "BuildProjectFile": {
+          "type": [
+            "null",
+            "string"
+          ],
+          "description": "Path to the build project (.csproj) relative to the repository root. Defaults to 'build/_build.csproj' when unset. Read by the Fallout global tool's in-tool runner."
         }
       }
     }
@@ -111,11 +118,11 @@
       "properties": {
         "Configuration": {
           "type": "string",
-          "description": "Configuration to build - Default is 'Debug' (local) or 'Release' (server)",
           "enum": [
             "Debug",
             "Release"
-          ]
+          ],
+          "description": "Configuration to build - Default is 'Debug' (local) or 'Release' (server)"
         },
         "ReleaseNotesFilePath": {
           "type": "string",

--- a/build/Build.cs
+++ b/build/Build.cs
@@ -2,7 +2,7 @@ using Microsoft.Build.Exceptions;
 using Fallout.Common;
 using Fallout.Common.CI.GitHubActions;
 using Fallout.Common.IO;
-using Fallout.Common.ProjectModel;
+using Fallout.Solutions;
 using Fallout.Common.Tooling;
 using Fallout.Common.Tools.DotNet;
 using Fallout.Common.Tools.GitHub;
@@ -17,7 +17,7 @@ using System.Linq;
 
 using static Fallout.Common.Tools.DotNet.DotNetTasks;
 
-using Project = Fallout.Common.ProjectModel.Project;
+using Project = Fallout.Solutions.Project;
 
 class Build : FalloutBuild
 {

--- a/build/_build.csproj
+++ b/build/_build.csproj
@@ -10,7 +10,7 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="Fallout.Common" Version="10.3.49" />
+    <PackageReference Include="Fallout.Common" Version="10.4.0" />
   </ItemGroup>
 
 </Project>


### PR DESCRIPTION
Fallout published [v10.4.0](https://github.com/Fallout-build/Fallout/releases/tag/v10.4.0), its first stable-channel release under the new dual-pace model. This repo migrated to Fallout in #1275 on 10.3.49, which still resolves the vulnerable `System.Security.Cryptography.Xml` 10.0.6 — restore currently emits **five NU1903 high-severity advisories**. 10.4.0 depends on the patched 10.0.10 (Fallout-build/Fallout#618) and the restore is clean.

Changes:

- `Fallout.Common` 10.3.49 → **10.4.0** in `build/_build.csproj`
- `build/Build.cs`: `Fallout.Common.ProjectModel` → `Fallout.Solutions` (two lines). v10.4 moved `Project` out of the transition shim, so `Solution.GetProject(...)` no longer compiles against the old namespace — this is the documented breaking change of the release.
- `.fallout/build.schema.json`: regenerated by the 10.4.0 engine (adds the new `BuildProjectFile` property).

The bootstrap scripts, tool-less `dotnet build`/`dotnet run` model, and hand-written CI workflow are unchanged — they work as-is on 10.4.0.

Verification: baseline restore on 10.3.49 reproduced the five NU1903 warnings; after the bump, forced restore is **0 warnings** with `System.Security.Cryptography.Xml/10.0.10` in the resolved graph. `./build.ps1 -Target Compile` and the full default target ran locally: **RunUnitTests Succeeded — Failed: 0, Passed: 3746 per TFM** (both prefetched text-source modes). Publish targets intentionally not run.

🤖 Generated with [Claude Code](https://claude.com/claude-code)