### PR TITLE
Match the annotation-xml encoding case-insensitively

### DIFF
--- a/src/AngleSharp.Core.Tests/Html/HtmlIntegrationPoints.cs
+++ b/src/AngleSharp.Core.Tests/Html/HtmlIntegrationPoints.cs
@@ -1,0 +1,60 @@
+namespace AngleSharp.Core.Tests.Html
+{
+    using AngleSharp.Dom;
+    using NUnit.Framework;
+    using System;
+    using System.Linq;
+
+    /// <summary>
+    /// The tree construction dispatcher processes a token with HTML rules when the adjusted
+    /// current node is an HTML integration point. A MathML annotation-xml element is one when
+    /// its encoding attribute is an ASCII case-insensitive match for text/html or for
+    /// application/xhtml+xml. The html5lib-derived suites are generated from the .dat fixtures
+    /// by src/TestGeneration, so these cases live here instead.
+    /// </summary>
+    [TestFixture]
+    public class HtmlIntegrationPointTests
+    {
+        private static String AnnotationXmlWith(String encoding) =>
+            "<math><annotation-xml encoding=\"" + encoding + "\"><style><img src=x></style></annotation-xml></math>";
+
+        [TestCase("text/html")]
+        [TestCase("TEXT/HTML")]
+        [TestCase("Text/Html")]
+        [TestCase("application/xhtml+xml")]
+        [TestCase("APPLICATION/XHTML+XML")]
+        public void AnnotationXmlWithHtmlEncodingIsAnIntegrationPoint(String encoding)
+        {
+            var document = AnnotationXmlWith(encoding).ToHtmlDocument();
+            var style = document.All.First(m => m.LocalName == "style");
+
+            Assert.AreEqual(NamespaceNames.HtmlUri, style.NamespaceUri);
+            // In the HTML namespace style is a raw text element, so the img start tag
+            // is character data and no element is constructed from it.
+            Assert.IsFalse(document.All.Any(m => m.LocalName == "img"));
+        }
+
+        [TestCase("text/html; charset=utf-8")]
+        [TestCase("application/xhtml+xml; charset=utf-8")]
+        [TestCase("text/xml")]
+        [TestCase("")]
+        public void AnnotationXmlWithOtherEncodingIsNotAnIntegrationPoint(String encoding)
+        {
+            var document = AnnotationXmlWith(encoding).ToHtmlDocument();
+            var style = document.All.First(m => m.LocalName == "style");
+
+            // The value is matched as a literal string, not parsed as a MIME type, so a
+            // parameter makes it something other than text/html.
+            Assert.AreEqual(NamespaceNames.MathMlUri, style.NamespaceUri);
+        }
+
+        [Test]
+        public void AnnotationXmlWithoutEncodingIsNotAnIntegrationPoint()
+        {
+            var document = "<math><annotation-xml><style><img src=x></style></annotation-xml></math>".ToHtmlDocument();
+            var style = document.All.First(m => m.LocalName == "style");
+
+            Assert.AreEqual(NamespaceNames.MathMlUri, style.NamespaceUri);
+        }
+    }
+}

--- a/src/AngleSharp/Html/Parser/HtmlDomBuilder.cs
+++ b/src/AngleSharp/Html/Parser/HtmlDomBuilder.cs
@@ -3975,9 +3975,12 @@ namespace AngleSharp.Html.Parser
             {
                 if (node.Flags.HasFlag(NodeFlags.MathMember) && node.LocalName.Is(TagNames.AnnotationXml))
                 {
-                    var encoding = node.Attributes["encoding"]?.Value;
-                    
-                    if (encoding == MimeTypeNames.Html || encoding == MimeTypeNames.ApplicationXHtml)
+                    // The spec matches the encoding value ASCII case-insensitively, which is
+                    // why ForeignNormalTag runs the same test with Isi. An ordinal comparison
+                    // here kept TEXT/HTML out of the integration point.
+                    var encoding = node.GetAttribute(default, AttributeNames.Encoding);
+
+                    if (encoding.Isi(MimeTypeNames.Html) || encoding.Isi(MimeTypeNames.ApplicationXHtml))
                     {
                         return true;
                     }


### PR DESCRIPTION
## Prerequisites

- [x] I have read the **CONTRIBUTING** document
- [x] My code follows the code style of this project

## Contribution Type

- [x] Bug fix (non-breaking change which fixes an issue, please reference the issue id) - #1283
- [ ] New feature (non-breaking change which adds functionality, make sure to open an associated issue first)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] My change requires a change to the documentation
- [ ] I have updated the documentation accordingly
- [x] I have added tests to cover my changes
- [x] All new and existing tests passed

## Description

Fixes #1283.

`IsHtmlTip` compared the raw `encoding` attribute value against `MimeTypeNames.Html` and `MimeTypeNames.ApplicationXHtml` with ordinal equality. The spec matches that value ASCII case-insensitively, so `TEXT/HTML` was not recognised as opening an HTML integration point and the children were parsed as foreign content instead.

`ForeignNormalTag` already runs the identical test with `Isi` at line 3777, so the two halves of the parser disagreed on the same question. This makes the dispatcher agree with it, and reads the attribute through `GetAttribute` with the interned `AttributeNames.Encoding` the way that call does rather than indexing `Attributes` with a string literal.

### A correction to the issue

The issue I filed claims that exact lowercase `text/html` fails too, and it does not. I had not built it at that point. Running it on `devel` before the change:

```
encoding=text/html                  style-ns=http://www.w3.org/1999/xhtml         img=False
encoding=TEXT/HTML                  style-ns=http://www.w3.org/1998/Math/MathML   img=True
encoding=Text/Html                  style-ns=http://www.w3.org/1998/Math/MathML   img=True
encoding=application/xhtml+xml      style-ns=http://www.w3.org/1999/xhtml         img=False
encoding=text/html; charset=utf-8   style-ns=http://www.w3.org/1998/Math/MathML   img=True
```

So only the case variants were affected, and the dispatcher was reaching `IsHtmlTip` correctly all along. Sorry for sending you looking for a routing problem that was not there. The scope is smaller than the issue describes.

### Tests

`src/AngleSharp.Core.Tests/Html/HtmlIntegrationPoints.cs`. CONTRIBUTING asks for tests taken from the specification, and html5lib does cover this, but `HtmlWithMathML.cs` and `HtmlConstruction.cs` are generated from the `.dat` fixtures by `src/TestGeneration`, so I did not hand-edit them. If you would rather this lived in the generated suite I am happy to move it.

The cases cover the two accepted media types in several casings, a value carrying parameters, an unrelated value, an empty value and an absent attribute. `text/html; charset=utf-8` stays out of the integration point, which is correct: the spec matches the literal string rather than parsing a MIME type.

Before the change, 3 of the 10 fail, and they are exactly the case variants:

```
Failed AnnotationXmlWithHtmlEncodingIsAnIntegrationPoint("TEXT/HTML")
Failed AnnotationXmlWithHtmlEncodingIsAnIntegrationPoint("Text/Html")
Failed AnnotationXmlWithHtmlEncodingIsAnIntegrationPoint("APPLICATION/XHTML+XML")
Failed!  - Failed: 3, Passed: 7, Skipped: 0, Total: 10
```

After it, all 10 pass and the whole suite is green on `net10.0`:

```
Passed!  - Failed: 0, Passed: 3758, Skipped: 2, Total: 3760, Duration: 1 m 28 s
```

I left `CHANGELOG.md` alone since the top entry is the released 1.7.1 and the next version number is your call. Say the word and I will add a line under whichever heading you want.
