### PR TITLE
Add handle-based HTML tree construction backend

### DIFF
--- a/src/AngleSharp.Core.Tests/Library/HandleTreeConstructionTests.cs
+++ b/src/AngleSharp.Core.Tests/Library/HandleTreeConstructionTests.cs
@@ -1,0 +1,48 @@
+namespace AngleSharp.Core.Tests.Library;
+
+using System.IO;
+using System.Text;
+using System.Threading.Tasks;
+using AngleSharp.Dom;
+using AngleSharp.Html.Construction;
+using AngleSharp.Html.Parser;
+using AngleSharp.Text;
+using NUnit.Framework;
+
+[TestFixture]
+public sealed class HandleTreeConstructionTests
+{
+    private const string Markup =
+        "<table>before<tr><td><svg viewbox='0 0 1 1'><foreignObject><p>inside</p></foreignObject></svg></td></tr>after</table>";
+
+    [Test]
+    public void HandleBackendMatchesStandardTreeConstruction()
+    {
+        var parser = new HtmlParser();
+        var factory = CreateFactory();
+        using var expected = parser.ParseDocument(Markup);
+        using var source = new TextSource(Markup);
+        using var actual = parser.ParseDocument<Document, ConstructableDomNode>(source, factory);
+
+        Assert.That(actual.ToHtml(), Is.EqualTo(expected.ToHtml()));
+    }
+
+    [Test]
+    public async Task HandleBackendSupportsAsynchronousStreamParsing()
+    {
+        var parser = new HtmlParser();
+        var factory = CreateFactory();
+        using var expected = parser.ParseDocument(Markup);
+        using var stream = new MemoryStream(Encoding.UTF8.GetBytes(Markup));
+        using var actual = await parser.ParseDocumentAsync<Document, ConstructableDomNode>(
+            stream,
+            HtmlStreamSourceMode.Streaming,
+            factory,
+            Encoding.UTF8);
+
+        Assert.That(actual.ToHtml(), Is.EqualTo(expected.ToHtml()));
+    }
+
+    private static ConstructableDomTreeFactory<Document, Element> CreateFactory() =>
+        new(HtmlDomConstructionFactory.Instance);
+}

--- a/src/AngleSharp/Dom/Internal/Document.cs
+++ b/src/AngleSharp/Dom/Internal/Document.cs
@@ -1609,11 +1609,11 @@ namespace AngleSharp.Dom
 
         #region Construction
 
-        TextSource IConstructableDocument.Source => _source;
+        TextSource IConstructableDocumentState.Source => _source;
 
-        IDisposable? IConstructableDocument.Builder { get; set; }
+        IDisposable? IConstructableDocumentState.Builder { get; set; }
 
-        QuirksMode IConstructableDocument.QuirksMode
+        QuirksMode IConstructableDocumentState.QuirksMode
         {
             get => QuirksMode;
             set => QuirksMode = value;
@@ -1623,39 +1623,39 @@ namespace AngleSharp.Dom
 
         IConstructableElement IConstructableDocument.DocumentElement => this.FindChild<HtmlHtmlElement>()!;
 
-        void IConstructableDocument.PerformMicrotaskCheckpoint()
+        void IConstructableDocumentHost.PerformMicrotaskCheckpoint()
         {
             this.PerformMicrotaskCheckpoint();
         }
 
-        void IConstructableDocument.ProvideStableState()
+        void IConstructableDocumentHost.ProvideStableState()
         {
             this.ProvideStableState();
         }
 
-        void IConstructableDocument.AddComment(ref StructHtmlToken token)
+        void IConstructableDocumentState.AddComment(ref StructHtmlToken token)
         {
             HtmlDomBuilderExtensions.AddComment(this, ref token);
         }
 
-        void IConstructableDocument.TrackError(Exception exception)
+        void IConstructableDocumentState.TrackError(Exception exception)
         {
             Context.TrackError(exception);
         }
 
-        Task IConstructableDocument.WaitForReadyAsync(CancellationToken cancelToken)
+        Task IConstructableDocumentHost.WaitForReadyAsync(CancellationToken cancelToken)
         {
             return this.WaitForReadyAsync();
         }
 
-        void IConstructableDocument.ApplyManifest()
+        void IConstructableDocumentHost.ApplyManifest()
         {
             this.ApplyManifest();
         }
 
-        Boolean IConstructableDocument.IsLoading => IsLoading;
+        Boolean IConstructableDocumentHost.IsLoading => IsLoading;
 
-        Task IConstructableDocument.FinishLoadingAsync()
+        Task IConstructableDocumentHost.FinishLoadingAsync()
         {
             return this.FinishLoadingAsync();
         }

--- a/src/AngleSharp/Dom/Internal/Element.cs
+++ b/src/AngleSharp/Dom/Internal/Element.cs
@@ -14,7 +14,7 @@ namespace AngleSharp.Dom
     /// <summary>
     /// Represents an element node.
     /// </summary>
-    public abstract class Element : Node, IElement, IConstructableElement
+    public abstract class Element : Node, IElement, IConstructableElement, IConstructableElementAttributesByRef
     {
         #region Fields
 
@@ -728,6 +728,16 @@ namespace AngleSharp.Dom
         }
 
         void IConstructableElement.SetAttributes(StructAttributes tagAttributes)
+        {
+            SetAttributesCore(in tagAttributes);
+        }
+
+        void IConstructableElementAttributesByRef.SetAttributes(in StructAttributes tagAttributes)
+        {
+            SetAttributesCore(in tagAttributes);
+        }
+
+        private void SetAttributesCore(in StructAttributes tagAttributes)
         {
             var container = Attributes;
 

--- a/src/AngleSharp/Html/Construction/ConstructableDomTreeAdapter.cs
+++ b/src/AngleSharp/Html/Construction/ConstructableDomTreeAdapter.cs
@@ -1,0 +1,170 @@
+namespace AngleSharp.Html.Construction;
+
+using System;
+using System.Threading;
+using System.Threading.Tasks;
+using AngleSharp.Common;
+using AngleSharp.Dom;
+using AngleSharp.Html.Parser.Tokens.Struct;
+using AngleSharp.Text;
+
+internal readonly struct ConstructableDomNode : IHtmlTreeConstructionNode<ConstructableDomNode>, IEquatable<ConstructableDomNode>
+{
+    private readonly IConstructableNode? _node;
+
+    public ConstructableDomNode(IConstructableNode? node)
+    {
+        _node = node;
+    }
+
+    public Boolean IsNull => _node is null;
+    public Boolean IsTemplate => _node is IConstructableTemplateElement;
+    public Boolean IsForm => _node is IConstructableFormElement;
+    public Boolean IsScript => _node is IConstructableScriptElement;
+    public StringOrMemory NodeName => _node!.NodeName;
+    public StringOrMemory LocalName => Element.LocalName;
+    public StringOrMemory Prefix => Element.Prefix;
+    public StringOrMemory NamespaceUri => Element.NamespaceUri;
+    public NodeFlags Flags => _node!.Flags;
+    public ConstructableDomNode Parent => new(_node!.Parent);
+    public Int32 ChildCount => _node!.ChildNodes.Length;
+    public IElement? AsDomElement => _node as IElement;
+
+    internal IConstructableElement ConstructableElement => Element;
+
+    private IConstructableElement Element => (IConstructableElement)_node!;
+
+    public ConstructableDomNode ChildAt(Int32 index) => new(_node!.ChildNodes[index]);
+
+    public void ClearChildren() => _node!.ChildNodes.Clear();
+
+    public void RemoveFromParent() => _node!.RemoveFromParent();
+
+    public void RemoveChild(ConstructableDomNode child) => _node!.RemoveChild(child._node!);
+
+    public void RemoveNode(Int32 index, ConstructableDomNode child) => _node!.RemoveNode(index, child._node!);
+
+    public void InsertNode(Int32 index, ConstructableDomNode child) => _node!.InsertNode(index, child._node!);
+
+    public void AddNode(ConstructableDomNode child) => _node!.AddNode(child._node!);
+
+    public void AppendText(StringOrMemory text, Boolean emitWhiteSpaceOnly = false) =>
+        _node!.AppendText(text, emitWhiteSpaceOnly);
+
+    public void InsertText(Int32 index, StringOrMemory text, Boolean emitWhiteSpaceOnly = false) =>
+        _node!.InsertText(index, text, emitWhiteSpaceOnly);
+
+    public void AddComment(ref StructHtmlToken token) => Element.AddComment(ref token);
+
+    public StringOrMemory GetAttribute(StringOrMemory namespaceUri, StringOrMemory localName) =>
+        Element.GetAttribute(namespaceUri, localName);
+
+    public Boolean HasAttribute(StringOrMemory name) => Element.HasAttribute(name);
+
+    public void SetAttribute(String? namespaceUri, StringOrMemory name, StringOrMemory value) =>
+        Element.SetAttribute(namespaceUri, name, value);
+
+    public void SetOwnAttribute(StringOrMemory name, StringOrMemory value) => Element.SetOwnAttribute(name, value);
+
+    public void SetAttributes(in StructAttributes attributes)
+    {
+        if (Element is IConstructableElementAttributesByRef byRef)
+        {
+            byRef.SetAttributes(in attributes);
+        }
+        else
+        {
+            Element.SetAttributes(attributes);
+        }
+    }
+
+    public Boolean AttributesSame(ConstructableDomNode other) =>
+        Element.Attributes.SameAs(other.Element.Attributes);
+
+    public void SetupElement() => Element.SetupElement();
+
+    public ConstructableDomNode ShallowCopy() => new(Element.ShallowCopy());
+
+    public void SetSourceReference(ISourceReference sourceReference) => Element.SourceReference = sourceReference;
+
+    public void PopulateFragment() => ((IConstructableTemplateElement)_node!).PopulateFragment();
+
+    public void HandleMeta() => ((IConstructableMetaElement)_node!).Handle();
+
+    public Boolean PrepareScript(IConstructableDocumentState document) =>
+        // Script execution needs a full browsing-host document; a backend that only implements the
+        // node facet has no lifecycle to run a script against, so it never prepares one.
+        document is IConstructableDocument host && ((IConstructableScriptElement)_node!).Prepare(host);
+
+    public Task RunScriptAsync(CancellationToken cancel) =>
+        ((IConstructableScriptElement)_node!).RunAsync(cancel);
+
+    public Boolean Equals(ConstructableDomNode other) => ReferenceEquals(_node, other._node);
+
+    public override Boolean Equals(Object? obj) => obj is ConstructableDomNode other && Equals(other);
+
+    public override Int32 GetHashCode() => _node?.GetHashCode() ?? 0;
+
+    public static Boolean operator ==(ConstructableDomNode left, ConstructableDomNode right) => left.Equals(right);
+
+    public static Boolean operator !=(ConstructableDomNode left, ConstructableDomNode right) => !left.Equals(right);
+}
+
+internal sealed class ConstructableDomTreeFactory<TDocument, TElement>
+    : IHtmlTreeConstructionFactory<TDocument, ConstructableDomNode>
+    where TDocument : class, IConstructableDocument
+    where TElement : class, IConstructableElement
+{
+    private readonly IDomConstructionElementFactory<TDocument, TElement> _factory;
+
+    public ConstructableDomTreeFactory(IDomConstructionElementFactory<TDocument, TElement> factory)
+    {
+        _factory = factory;
+    }
+
+    public ConstructableDomNode Create(
+        TDocument document,
+        StringOrMemory localName,
+        StringOrMemory prefix = default,
+        NodeFlags flags = NodeFlags.None
+    ) => new(_factory.Create(document, localName, prefix, flags));
+
+    public ConstructableDomNode CreateNoScript(TDocument document, Boolean scripting) =>
+        new(_factory.CreateNoScript(document, scripting));
+
+    public ConstructableDomNode CreateDocumentType(
+        TDocument document,
+        StringOrMemory name,
+        StringOrMemory publicIdentifier,
+        StringOrMemory systemIdentifier
+    ) => new(_factory.CreateDocumentType(document, name, publicIdentifier, systemIdentifier));
+
+    public ConstructableDomNode CreateMath(TDocument document, StringOrMemory name = default) =>
+        new(_factory.CreateMath(document, name));
+
+    public ConstructableDomNode CreateSvg(TDocument document, StringOrMemory name = default) =>
+        new(_factory.CreateSvg(document, name));
+
+    public ConstructableDomNode CreateMeta(TDocument document) => new(_factory.CreateMeta(document));
+
+    public ConstructableDomNode CreateScript(TDocument document, Boolean parserInserted, Boolean started) =>
+        new(_factory.CreateScript(document, parserInserted, started));
+
+    public ConstructableDomNode CreateFrame(TDocument document) => new(_factory.CreateFrame(document));
+
+    public ConstructableDomNode CreateTemplate(TDocument document) => new(_factory.CreateTemplate(document));
+
+    public ConstructableDomNode CreateForm(TDocument document) => new(_factory.CreateForm(document));
+
+    public ConstructableDomNode CreateUnknown(TDocument document, StringOrMemory tagName) =>
+        new(_factory.CreateUnknown(document, tagName));
+
+    public TDocument CreateDocument(TextSource source, IBrowsingContext? context = null) =>
+        _factory.CreateDocument(source, context);
+
+    public ConstructableDomNode GetDocumentNode(TDocument document) => new(document);
+
+    public ConstructableDomNode GetDocumentElement(TDocument document) => new(document.DocumentElement);
+
+    public ConstructableDomNode GetHead(TDocument document) => new(document.Head);
+}

--- a/src/AngleSharp/Html/Construction/IConstructableDocument.cs
+++ b/src/AngleSharp/Html/Construction/IConstructableDocument.cs
@@ -1,32 +1,12 @@
 ﻿namespace AngleSharp.Html.Construction;
 
-using System;
-using System.Threading;
-using System.Threading.Tasks;
-using AngleSharp.Dom;
-using Parser.Tokens.Struct;
-using Text;
-
 /// <summary>
-/// Represents a constructable document.
+/// Represents a constructable document that is a DOM-shaped node and participates in a browsing
+/// host's script and load lifecycle. Handle-oriented construction backends only need to implement
+/// <see cref="IConstructableDocumentState"/>.
 /// </summary>
-public interface IConstructableDocument : IConstructableNode
+public interface IConstructableDocument : IConstructableDocumentHost, IConstructableNode
 {
-    /// <summary>
-    /// Document source.
-    /// </summary>
-    TextSource Source { get; }
-
-    /// <summary>
-    /// Builder instance to dispose and tie lifetime to the document.
-    /// </summary>
-    IDisposable? Builder { get; set; }
-
-    /// <summary>
-    /// Quirks mode of the document.
-    /// </summary>
-    QuirksMode QuirksMode { get; set; }
-
     /// <summary>
     /// Head element of the document.
     /// </summary>
@@ -36,53 +16,6 @@ public interface IConstructableDocument : IConstructableNode
     /// Document element of the document.
     /// </summary>
     IConstructableElement DocumentElement { get; }
-
-    /// <summary>
-    /// Is the document currently loading?
-    /// </summary>
-    Boolean IsLoading { get; }
-
-    /// <summary>
-    /// Performs a microtask checkpoint using the mutations host.
-    /// Queue a mutation observer compound microtask.
-    /// </summary>
-    void PerformMicrotaskCheckpoint();
-
-    /// <summary>
-    /// Provides a stable state by running the synchronous sections of
-    /// asynchronously-running algorithms until the asynchronous algorithm
-    /// can be resumed (if appropriate).
-    /// </summary>
-    void ProvideStableState();
-
-    /// <summary>
-    /// Ads a new dom representation of a comment and adds it to the document.
-    /// </summary>
-    /// <param name="token">The token to use.</param>
-    void AddComment(ref StructHtmlToken token);
-
-    /// <summary>
-    /// Tracks the given exception which happened during parsing.
-    /// </summary>
-    void TrackError(Exception exception);
-
-    /// <summary>
-    /// Spins the event loop until all stylesheets are downloaded (if
-    /// required) and all scripts are ready to be parser executed.
-    /// http://www.w3.org/html/wg/drafts/html/master/syntax.html#the-end
-    /// (bullet 3)
-    /// </summary>
-    Task WaitForReadyAsync(CancellationToken cancelToken);
-
-    /// <summary>
-    /// Finishes writing to a document.
-    /// </summary>
-    Task FinishLoadingAsync();
-
-    /// <summary>
-    /// Applies the manifest to the document.
-    /// </summary>
-    void ApplyManifest();
 
     /// <summary>
     /// Clears the document.

--- a/src/AngleSharp/Html/Construction/IConstructableDocumentHost.cs
+++ b/src/AngleSharp/Html/Construction/IConstructableDocumentHost.cs
@@ -1,0 +1,51 @@
+namespace AngleSharp.Html.Construction;
+
+using System;
+using System.Threading;
+using System.Threading.Tasks;
+
+/// <summary>
+/// Represents the browsing-host lifecycle a document participates in while it is being parsed:
+/// script execution checkpoints, stylesheet/script readiness, loading, and the application cache
+/// manifest. A construction backend that does not execute scripts or load resources omits this
+/// interface entirely rather than supplying no-op members, and the tree builder skips the
+/// corresponding steps.
+/// </summary>
+public interface IConstructableDocumentHost : IConstructableDocumentState
+{
+    /// <summary>
+    /// Is the document currently loading?
+    /// </summary>
+    Boolean IsLoading { get; }
+
+    /// <summary>
+    /// Performs a microtask checkpoint using the mutations host.
+    /// Queue a mutation observer compound microtask.
+    /// </summary>
+    void PerformMicrotaskCheckpoint();
+
+    /// <summary>
+    /// Provides a stable state by running the synchronous sections of
+    /// asynchronously-running algorithms until the asynchronous algorithm
+    /// can be resumed (if appropriate).
+    /// </summary>
+    void ProvideStableState();
+
+    /// <summary>
+    /// Spins the event loop until all stylesheets are downloaded (if
+    /// required) and all scripts are ready to be parser executed.
+    /// http://www.w3.org/html/wg/drafts/html/master/syntax.html#the-end
+    /// (bullet 3)
+    /// </summary>
+    Task WaitForReadyAsync(CancellationToken cancelToken);
+
+    /// <summary>
+    /// Finishes writing to a document.
+    /// </summary>
+    Task FinishLoadingAsync();
+
+    /// <summary>
+    /// Applies the manifest to the document.
+    /// </summary>
+    void ApplyManifest();
+}

--- a/src/AngleSharp/Html/Construction/IConstructableDocumentState.cs
+++ b/src/AngleSharp/Html/Construction/IConstructableDocumentState.cs
@@ -1,0 +1,43 @@
+namespace AngleSharp.Html.Construction;
+
+using System;
+using AngleSharp.Dom;
+using Parser.Tokens.Struct;
+using Text;
+
+/// <summary>
+/// Represents the document state required by the HTML tree-construction algorithm. This is
+/// deliberately free of node and tree members: a construction backend reaches tree topology through
+/// <see cref="IHtmlTreeConstructionFactory{TDocument,TNode}"/>, so a backend whose nodes are
+/// value-type identities never needs a DOM-shaped document object. Backends that also participate in
+/// a browsing host's script and load lifecycle additionally implement
+/// <see cref="IConstructableDocumentHost"/>.
+/// </summary>
+public interface IConstructableDocumentState
+{
+    /// <summary>
+    /// Document source.
+    /// </summary>
+    TextSource Source { get; }
+
+    /// <summary>
+    /// Builder instance to dispose and tie lifetime to the document.
+    /// </summary>
+    IDisposable? Builder { get; set; }
+
+    /// <summary>
+    /// Quirks mode of the document.
+    /// </summary>
+    QuirksMode QuirksMode { get; set; }
+
+    /// <summary>
+    /// Adds a new DOM representation of a comment to the document.
+    /// </summary>
+    /// <param name="token">The token to use.</param>
+    void AddComment(ref StructHtmlToken token);
+
+    /// <summary>
+    /// Tracks the given exception which happened during parsing.
+    /// </summary>
+    void TrackError(Exception exception);
+}

--- a/src/AngleSharp/Html/Construction/IConstructableElement.cs
+++ b/src/AngleSharp/Html/Construction/IConstructableElement.cs
@@ -98,3 +98,8 @@ public interface IConstructableElement : IConstructableNode
     /// </summary>
     IConstructableNode ShallowCopy();
 }
+
+internal interface IConstructableElementAttributesByRef
+{
+    void SetAttributes(in StructAttributes tagAttributes);
+}

--- a/src/AngleSharp/Html/Construction/IHtmlTreeConstructionFactory.cs
+++ b/src/AngleSharp/Html/Construction/IHtmlTreeConstructionFactory.cs
@@ -1,0 +1,69 @@
+namespace AngleSharp.Html.Construction;
+
+using System;
+using AngleSharp.Common;
+using AngleSharp.Dom;
+using AngleSharp.Text;
+
+/// <summary>
+/// Creates value-type node identities for the HTML tree-construction algorithm.
+/// </summary>
+public interface IHtmlTreeConstructionFactory<TDocument, TNode>
+    where TDocument : class, IConstructableDocumentState
+    where TNode : struct, IHtmlTreeConstructionNode<TNode>
+{
+    /// <summary>Creates a normal HTML element.</summary>
+    TNode Create(
+        TDocument document,
+        StringOrMemory localName,
+        StringOrMemory prefix = default,
+        NodeFlags flags = NodeFlags.None
+    );
+
+    /// <summary>Creates a noscript element.</summary>
+    TNode CreateNoScript(TDocument document, Boolean scripting);
+
+    /// <summary>Creates a document type node.</summary>
+    TNode CreateDocumentType(
+        TDocument document,
+        StringOrMemory name,
+        StringOrMemory publicIdentifier,
+        StringOrMemory systemIdentifier
+    );
+
+    /// <summary>Creates a MathML element.</summary>
+    TNode CreateMath(TDocument document, StringOrMemory name = default);
+
+    /// <summary>Creates an SVG element.</summary>
+    TNode CreateSvg(TDocument document, StringOrMemory name = default);
+
+    /// <summary>Creates a meta element.</summary>
+    TNode CreateMeta(TDocument document);
+
+    /// <summary>Creates a script element.</summary>
+    TNode CreateScript(TDocument document, Boolean parserInserted, Boolean started);
+
+    /// <summary>Creates a frame element.</summary>
+    TNode CreateFrame(TDocument document);
+
+    /// <summary>Creates a template element.</summary>
+    TNode CreateTemplate(TDocument document);
+
+    /// <summary>Creates a form element.</summary>
+    TNode CreateForm(TDocument document);
+
+    /// <summary>Creates an unknown element.</summary>
+    TNode CreateUnknown(TDocument document, StringOrMemory tagName);
+
+    /// <summary>Creates the construction document.</summary>
+    TDocument CreateDocument(TextSource source, IBrowsingContext? context = null);
+
+    /// <summary>Gets the document node identity.</summary>
+    TNode GetDocumentNode(TDocument document);
+
+    /// <summary>Gets the current document element or the null node.</summary>
+    TNode GetDocumentElement(TDocument document);
+
+    /// <summary>Gets the current head element or the null node.</summary>
+    TNode GetHead(TDocument document);
+}

--- a/src/AngleSharp/Html/Construction/IHtmlTreeConstructionNode.cs
+++ b/src/AngleSharp/Html/Construction/IHtmlTreeConstructionNode.cs
@@ -1,0 +1,128 @@
+namespace AngleSharp.Html.Construction;
+
+using System;
+using System.Threading;
+using System.Threading.Tasks;
+using AngleSharp.Common;
+using AngleSharp.Dom;
+using AngleSharp.Html.Parser.Tokens.Struct;
+
+/// <summary>
+/// Represents a stable node identity used by the HTML tree-construction algorithm.
+/// </summary>
+/// <typeparam name="TSelf">The value-type identity exposed by a construction backend.</typeparam>
+/// <remarks>
+/// Unlike <see cref="IConstructableNode"/>, this contract does not require one CLR object per
+/// parsed node. A backend may implement it with an arena reference and an integer handle while
+/// still supporting all tree mutations required by the HTML parsing specification.
+/// </remarks>
+public interface IHtmlTreeConstructionNode<TSelf> : IEquatable<TSelf>
+    where TSelf : struct, IHtmlTreeConstructionNode<TSelf>
+{
+    /// <summary>Gets whether this value is the backend's null node.</summary>
+    Boolean IsNull { get; }
+
+    /// <summary>Gets whether this node is a template element.</summary>
+    Boolean IsTemplate { get; }
+
+    /// <summary>Gets whether this node is a form element.</summary>
+    Boolean IsForm { get; }
+
+    /// <summary>Gets whether this node is a script element.</summary>
+    Boolean IsScript { get; }
+
+    /// <summary>Gets the node name.</summary>
+    StringOrMemory NodeName { get; }
+
+    /// <summary>Gets the local element name.</summary>
+    StringOrMemory LocalName { get; }
+
+    /// <summary>Gets the namespace prefix.</summary>
+    StringOrMemory Prefix { get; }
+
+    /// <summary>Gets the namespace URI.</summary>
+    StringOrMemory NamespaceUri { get; }
+
+    /// <summary>Gets the parser-relevant node flags.</summary>
+    NodeFlags Flags { get; }
+
+    /// <summary>Gets the current parent or the null node.</summary>
+    TSelf Parent { get; }
+
+    /// <summary>Gets the number of children.</summary>
+    Int32 ChildCount { get; }
+
+    /// <summary>Gets a child by index.</summary>
+    TSelf ChildAt(Int32 index);
+
+    /// <summary>Removes every child from this node.</summary>
+    void ClearChildren();
+
+    /// <summary>Removes this node from its parent.</summary>
+    void RemoveFromParent();
+
+    /// <summary>Removes a child from this node.</summary>
+    void RemoveChild(TSelf child);
+
+    /// <summary>Removes the child at the supplied index.</summary>
+    void RemoveNode(Int32 index, TSelf child);
+
+    /// <summary>Inserts a child at the supplied index.</summary>
+    void InsertNode(Int32 index, TSelf child);
+
+    /// <summary>Appends a child.</summary>
+    void AddNode(TSelf child);
+
+    /// <summary>Appends character data.</summary>
+    void AppendText(StringOrMemory text, Boolean emitWhiteSpaceOnly = false);
+
+    /// <summary>Inserts character data at the supplied child index.</summary>
+    void InsertText(Int32 index, StringOrMemory text, Boolean emitWhiteSpaceOnly = false);
+
+    /// <summary>Adds a comment represented by the token.</summary>
+    void AddComment(ref StructHtmlToken token);
+
+    /// <summary>Gets an attribute value or an empty value when it is absent.</summary>
+    StringOrMemory GetAttribute(StringOrMemory namespaceUri, StringOrMemory localName);
+
+    /// <summary>Gets whether an attribute is present.</summary>
+    Boolean HasAttribute(StringOrMemory name);
+
+    /// <summary>Sets an attribute value.</summary>
+    void SetAttribute(String? namespaceUri, StringOrMemory name, StringOrMemory value);
+
+    /// <summary>Sets a parser-owned attribute without namespace validation.</summary>
+    void SetOwnAttribute(StringOrMemory name, StringOrMemory value);
+
+    /// <summary>Sets attributes directly from a tokenizer attribute buffer.</summary>
+    void SetAttributes(in StructAttributes attributes);
+
+    /// <summary>Gets whether this node and another node have equivalent attributes.</summary>
+    Boolean AttributesSame(TSelf other);
+
+    /// <summary>Completes element-specific setup.</summary>
+    void SetupElement();
+
+    /// <summary>Creates a shallow element copy with a distinct identity.</summary>
+    TSelf ShallowCopy();
+
+    /// <summary>Stores a source reference when requested by parser options.</summary>
+    void SetSourceReference(ISourceReference sourceReference);
+
+    /// <summary>Moves template children into template contents.</summary>
+    void PopulateFragment();
+
+    /// <summary>Runs meta-element handling.</summary>
+    void HandleMeta();
+
+    /// <summary>Prepares a script element for execution.</summary>
+    Boolean PrepareScript(IConstructableDocumentState document);
+
+    /// <summary>Runs a prepared script element.</summary>
+    Task RunScriptAsync(CancellationToken cancel);
+
+    /// <summary>
+    /// Gets the full DOM element represented by this identity, if the backend creates one.
+    /// </summary>
+    IElement? AsDomElement { get; }
+}

--- a/src/AngleSharp/Html/Parser/HtmlDomBuilder.cs
+++ b/src/AngleSharp/Html/Parser/HtmlDomBuilder.cs
@@ -18,34 +18,40 @@ namespace AngleSharp.Html.Parser
     /// 8.2.5 Tree construction, on the following page:
     /// http://www.w3.org/html/wg/drafts/html/master/syntax.html
     /// </summary>
-    class HtmlDomBuilder<TDocument, TElement> : IDisposable
-        where TElement : class, IConstructableElement
-        where TDocument : class, IConstructableDocument
+    class HtmlTreeBuilder<TDocument, TNode> : IDisposable
+        where TDocument : class, IConstructableDocumentState
+        where TNode : struct, IHtmlTreeConstructionNode<TNode>
     {
         #region Fields
 
         private readonly TokenConsumer _consumeAsDelegate;
         private readonly HtmlTokenizer _tokenizer;
         private readonly TDocument _document;
-        private readonly List<IConstructableElement> _openElements;
-        private readonly List<IConstructableElement> _formattingElements;
+
+        /// <summary>
+        /// The browsing-host lifecycle of <see cref="_document"/>, or null when the construction
+        /// backend does not execute scripts or load resources. Resolved once so the lifecycle steps
+        /// cost a null check rather than a type test.
+        /// </summary>
+        private readonly IConstructableDocumentHost? _host;
+        private readonly List<TNode> _openElements;
+        private readonly List<TNode> _formattingElements;
         private readonly Stack<HtmlTreeMode> _templateModes;
 
-        private IConstructableElement? _currentFormElement;
+        private TNode _currentFormElement;
 
         private HtmlTreeMode _currentMode;
         private HtmlTreeMode _previousMode;
 
         private HtmlParserOptions _options;
 
-        private IConstructableElement? _fragmentContext;
+        private TNode _fragmentContext;
 
         private Boolean _foster;
         private Boolean _frameset;
         private Boolean _ended;
-
-        private Func<IConstructableElement, Boolean>? _shouldEnd;
-        private readonly IDomConstructionElementFactory<TDocument, TElement> _elementFactory;
+        private Func<TNode, Boolean>? _shouldEnd;
+        private readonly IHtmlTreeConstructionFactory<TDocument, TNode> _elementFactory;
         private Task? _waiting;
         private readonly Boolean _emitWhitespaceTextNodes;
 
@@ -63,17 +69,18 @@ namespace AngleSharp.Html.Parser
 
         #region ctor
 
-        public HtmlDomBuilder(
-            IDomConstructionElementFactory<TDocument, TElement> elementFactory,
+        public HtmlTreeBuilder(
+            IHtmlTreeConstructionFactory<TDocument, TNode> elementFactory,
             TDocument document,
             HtmlTokenizerOptions? maybeOptions = null,
             Boolean emitWhitespaceTextNodes = false,
-            Func<IConstructableElement, Boolean>? shouldEnd = null)
+            Func<TNode, Boolean>? shouldEnd = null)
         {
             _shouldEnd = shouldEnd;
             _elementFactory = elementFactory;
             _tokenizer = new HtmlTokenizer(document.Source, HtmlEntityProvider.ResolverExtended);
             _document = document;
+            _host = document as IConstructableDocumentHost;
             _openElements = [];
             _templateModes = new Stack<HtmlTreeMode>();
             _formattingElements = [];
@@ -115,18 +122,18 @@ namespace AngleSharp.Html.Parser
         /// <summary>
         /// Gets if the tree builder has been created for parsing fragments.
         /// </summary>
-        public Boolean IsFragmentCase => _fragmentContext is not null;
+        public Boolean IsFragmentCase => !_fragmentContext.IsNull;
 
         /// <summary>
         /// Gets the adjusted current node.
         /// </summary>
-        public IConstructableElement? AdjustedCurrentNode =>
-            (_fragmentContext is not null && _openElements.Count == 1) ? _fragmentContext : CurrentNode;
+        public TNode AdjustedCurrentNode =>
+            (!_fragmentContext.IsNull && _openElements.Count == 1) ? _fragmentContext : CurrentNode;
 
         /// <summary>
         /// Gets the current node.
         /// </summary>
-        public IConstructableElement CurrentNode => _openElements.Count > 0 ? _openElements[_openElements.Count - 1] : null!;
+        public TNode CurrentNode => _openElements.Count > 0 ? _openElements[_openElements.Count - 1] : default;
 
         #endregion
 
@@ -241,7 +248,7 @@ namespace AngleSharp.Html.Parser
         {
             _currentMode = HtmlTreeMode.Initial;
             _tokenizer.State = HtmlParseMode.PCData;
-            _document.Clear();
+            _elementFactory.GetDocumentNode(_document).ClearChildren();
             _ended = false;
             _frameset = true;
             _openElements.Clear();
@@ -261,7 +268,7 @@ namespace AngleSharp.Html.Parser
                 var element = _openElements[i];
                 var last = i == 0;
 
-                if (last && _fragmentContext is not null)
+                if (last && !_fragmentContext.IsNull)
                 {
                     element = _fragmentContext;
                 }
@@ -284,9 +291,12 @@ namespace AngleSharp.Html.Parser
         /// <param name="context">
         /// The context element where the algorithm is applied to.
         /// </param>
-        public TDocument ParseFragment(HtmlParserOptions options, TElement context)
+        public TDocument ParseFragment(HtmlParserOptions options, TNode context)
         {
-            context = context ?? throw new ArgumentNullException(nameof(context));
+            if (context.IsNull)
+            {
+                throw new ArgumentNullException(nameof(context));
+            }
 
             _fragmentContext = context;
 
@@ -320,31 +330,31 @@ namespace AngleSharp.Html.Parser
 
             var root = _elementFactory.Create(_document, TagNames.Html);
 
-            _document.AddNode(root);
+            _elementFactory.GetDocumentNode(_document).AddNode(root);
             _openElements.Add(root);
 
-            if (context is IConstructableTemplateElement)
+            if (context.IsTemplate)
             {
                 _templateModes.Push(HtmlTreeMode.InTemplate);
             }
 
             Reset();
 
-            _tokenizer.IsAcceptingCharacterData = !AdjustedCurrentNode!.Flags.HasFlag(NodeFlags.HtmlMember);
+            _tokenizer.IsAcceptingCharacterData = !AdjustedCurrentNode.Flags.HasFlag(NodeFlags.HtmlMember);
 
-            IConstructableNode? contextNode = context;
+            var contextNode = context;
 
             do
             {
-                if (contextNode is IConstructableFormElement formEl)
+                if (contextNode.IsForm)
                 {
-                    _currentFormElement = formEl;
+                    _currentFormElement = contextNode;
                     break;
                 }
 
                 contextNode = contextNode.Parent;
             }
-            while (contextNode is not null);
+            while (!contextNode.IsNull);
 
             return Parse(options);
         }
@@ -356,8 +366,8 @@ namespace AngleSharp.Html.Parser
         private void Consume(ref StructHtmlToken token)
         {
             var node = AdjustedCurrentNode;
-            
-            if (node is null || token.Type == HtmlTokenType.EndOfFile ||
+
+            if (node.IsNull || token.Type == HtmlTokenType.EndOfFile ||
                 node.Flags.HasFlag(NodeFlags.HtmlMember) ||
                 (token.IsHtmlCompatible && IsHtmlTip(node)) ||
                 (node.Flags.HasFlag(NodeFlags.MathTip) && token.IsMathCompatible) ||
@@ -514,7 +524,7 @@ namespace AngleSharp.Html.Parser
                     var doctype = _elementFactory.CreateDocumentType(_document, token.Name, token.PublicIdentifier,
                         token.SystemIdentifier);
 
-                    _document.AddNode(doctype);
+                    _elementFactory.GetDocumentNode(_document).AddNode(doctype);
 
                     _document.QuirksMode = token.GetQuirksMode();
                     _currentMode = HtmlTreeMode.BeforeHtml;
@@ -717,7 +727,7 @@ namespace AngleSharp.Html.Parser
 
                         try
                         {
-                            element.Handle();
+                            element.HandleMeta();
                         }
                         catch (NotSupportedException ex)
                         {
@@ -810,7 +820,7 @@ namespace AngleSharp.Html.Parser
                         CloseCurrentNode();
 
                         _currentMode = HtmlTreeMode.AfterHead;
-                        _waiting = _document.WaitForReadyAsync(CancellationToken.None);
+                        _waiting = _host?.WaitForReadyAsync(CancellationToken.None);
                         return;
                     }
                     else if (tagName.Is(TagNames.Template))
@@ -984,10 +994,10 @@ namespace AngleSharp.Html.Parser
                     else if (TagNames.AllHeadNoTemplate.Contains(tagName))
                     {
                         RaiseErrorOccurred(HtmlParseError.TagMustBeInHead, ref token);
-                        var head = _document.Head;
-                        _openElements.Add(head!);
+                        var head = _elementFactory.GetHead(_document);
+                        _openElements.Add(head);
                         InHead(ref token);
-                        CloseNode(head!);
+                        CloseNode(head);
                     }
                     else if (tagName.Is(TagNames.Head))
                     {
@@ -1033,7 +1043,7 @@ namespace AngleSharp.Html.Parser
             }
             else if (tagName.Is(TagNames.A))
             {
-                for (var i = _formattingElements.Count - 1; i >= 0 && _formattingElements[i] is not null; i--)
+                for (var i = _formattingElements.Count - 1; i >= 0 && !_formattingElements[i].IsNull; i--)
                 {
                     if (_formattingElements[i].LocalName.Is(TagNames.A))
                     {
@@ -1113,7 +1123,7 @@ namespace AngleSharp.Html.Parser
             }
             else if (tagName.Is(TagNames.Form))
             {
-                if (_currentFormElement is null)
+                if (_currentFormElement.IsNull)
                 {
                     if (IsInButtonScope())
                     {
@@ -1337,7 +1347,7 @@ namespace AngleSharp.Html.Parser
             {
                 var element = _elementFactory.CreateMath(_document, tagName);
                 ReconstructFormatting();
-                AddElement(element.Setup(ref tag));
+                AddElement(element.SetupMath(ref tag));
 
                 if (tag.IsSelfClosing)
                 {
@@ -1348,7 +1358,7 @@ namespace AngleSharp.Html.Parser
             {
                 var element = _elementFactory.CreateSvg(_document, tagName);
                 ReconstructFormatting();
-                AddElement(element.Setup(ref tag));
+                AddElement(element.SetupSvg(ref tag));
 
                 if (tag.IsSelfClosing)
                 {
@@ -1406,14 +1416,14 @@ namespace AngleSharp.Html.Parser
             {
                 RaiseErrorOccurred(HtmlParseError.TagInappropriate, ref tag);
 
-                if (_currentFormElement is null)
+                if (_currentFormElement.IsNull)
                 {
                     var temp = StructHtmlToken.Open(TagNames.Form);
                     InBody(ref temp);
 
                     if (tag.GetAttribute(AttributeNames.Action).Length > 0)
                     {
-                        _currentFormElement!.SetAttribute(
+                        _currentFormElement.SetAttribute(
                             null,
                             AttributeNames.Action,
                             tag.GetAttribute(AttributeNames.Action));
@@ -1436,9 +1446,10 @@ namespace AngleSharp.Html.Parser
                     var input = StructHtmlToken.Open(TagNames.Input);
                     input.AddAttribute(AttributeNames.Name, TagNames.IsIndex);
 
-                    for (var i = 0; i < tag.Attributes.Count; i++)
+                    ref readonly var attributes = ref StructHtmlToken.GetAttributesReference(ref tag);
+                    for (var i = 0; i < attributes.Count; i++)
                     {
-                        var attr = tag.Attributes[i];
+                        var attr = attributes[i];
 
                         if (!attr.Name.IsOneOf(AttributeNames.Name, AttributeNames.Action, AttributeNames.Prompt))
                         {
@@ -1512,13 +1523,13 @@ namespace AngleSharp.Html.Parser
             else if (tagName.Is(TagNames.Form))
             {
                 var node = _currentFormElement;
-                _currentFormElement = null;
+                _currentFormElement = default;
 
-                if (node is not null && IsInScope(node.LocalName))
+                if (!node.IsNull && IsInScope(node.LocalName))
                 {
                     GenerateImpliedEndTags();
 
-                    if (CurrentNode != node)
+                    if (!CurrentNode.Equals(node))
                     {
                         RaiseErrorOccurred(HtmlParseError.FormClosedWrong, ref tag);
                     }
@@ -1690,7 +1701,7 @@ namespace AngleSharp.Html.Parser
                     }
                     else
                     {
-                        HandleScript((IConstructableScriptElement)CurrentNode);
+                        HandleScript(CurrentNode);
                     }
 
                     return;
@@ -1792,7 +1803,7 @@ namespace AngleSharp.Html.Parser
                     {
                         RaiseErrorOccurred(HtmlParseError.FormInappropriate, ref token);
 
-                        if (_currentFormElement is null)
+                        if (_currentFormElement.IsNull)
                         {
                             _currentFormElement = _elementFactory.CreateForm(_document);
                             AddElement(_currentFormElement, ref token);
@@ -2729,7 +2740,7 @@ namespace AngleSharp.Html.Parser
                 {
                     if (token.Name.Is(TagNames.Frameset))
                     {
-                        if (CurrentNode != _openElements[0])
+                        if (!CurrentNode.Equals(_openElements[0]))
                         {
                             CloseCurrentNode();
 
@@ -2750,7 +2761,7 @@ namespace AngleSharp.Html.Parser
                 }
                 case HtmlTokenType.EndOfFile:
                 {
-                    if (CurrentNode != _document.DocumentElement)
+                    if (!CurrentNode.Equals(_elementFactory.GetDocumentElement(_document)))
                     {
                         RaiseErrorOccurred(HtmlParseError.CurrentNodeIsNotRoot, ref token);
                     }
@@ -2979,9 +2990,9 @@ namespace AngleSharp.Html.Parser
                 var currentNode = CurrentNode;
                 CloseCurrentNode();
 
-                if (currentNode is IConstructableTemplateElement template)
+                if (currentNode.IsTemplate)
                 {
-                    template.PopulateFragment();
+                    currentNode.PopulateFragment();
                     break;
                 }
             }
@@ -3238,12 +3249,12 @@ namespace AngleSharp.Html.Parser
 
             for (var outer = 0; outer < 8; outer++)
             {
-                var formattingElement = default(IConstructableElement);
-                var furthestBlock = default(IConstructableElement);
+                var formattingElement = default(TNode);
+                var furthestBlock = default(TNode);
                 var index = 0;
                 var inner = 0;
 
-                for (var j = _formattingElements.Count - 1; j >= 0 && _formattingElements[j] is not null; j--)
+                for (var j = _formattingElements.Count - 1; j >= 0 && !_formattingElements[j].IsNull; j--)
                 {
                     if (_formattingElements[j].LocalName.Is(tag.Name))
                     {
@@ -3253,7 +3264,7 @@ namespace AngleSharp.Html.Parser
                     }
                 }
 
-                if (formattingElement is null)
+                if (formattingElement.IsNull)
                 {
                     InBodyEndTagAnythingElse(ref tag);
                     break;
@@ -3291,14 +3302,14 @@ namespace AngleSharp.Html.Parser
                     }
                 }
 
-                if (furthestBlock is null)
+                if (furthestBlock.IsNull)
                 {
                     do
                     {
                         furthestBlock = CurrentNode;
                         CloseCurrentNode();
                     }
-                    while (furthestBlock != formattingElement);
+                    while (!furthestBlock.Equals(formattingElement));
 
                     _formattingElements.Remove(formattingElement);
                     break;
@@ -3312,7 +3323,7 @@ namespace AngleSharp.Html.Parser
                     inner++;
                     var node = _openElements[--index];
 
-                    if (node == formattingElement)
+                    if (node.Equals(formattingElement))
                     {
                         break;
                     }
@@ -3334,7 +3345,7 @@ namespace AngleSharp.Html.Parser
 
                     for (var l = 0; l != _formattingElements.Count; l++)
                     {
-                        if (_formattingElements[l] == node)
+                        if (_formattingElements[l].Equals(node))
                         {
                             _formattingElements[l] = newElement;
                             break;
@@ -3343,17 +3354,25 @@ namespace AngleSharp.Html.Parser
 
                     node = newElement;
 
-                    if (lastNode == furthestBlock)
+                    if (lastNode.Equals(furthestBlock))
                     {
                         bookmark++;
                     }
 
-                    lastNode.Parent?.RemoveChild(lastNode);
+                    var lastParent = lastNode.Parent;
+                    if (!lastParent.IsNull)
+                    {
+                        lastParent.RemoveChild(lastNode);
+                    }
                     node.AddNode(lastNode);
                     lastNode = node;
                 }
 
-                lastNode.Parent?.RemoveChild(lastNode);
+                var parent = lastNode.Parent;
+                if (!parent.IsNull)
+                {
+                    parent.RemoveChild(lastNode);
+                }
 
                 if (!TagNames.AllTableMajor.Contains(commonAncestor.LocalName))
                 {
@@ -3366,9 +3385,9 @@ namespace AngleSharp.Html.Parser
 
                 var element = CopyElement(formattingElement);
 
-                while (furthestBlock.ChildNodes.Length > 0)
+                while (furthestBlock.ChildCount > 0)
                 {
-                    var childNode = furthestBlock.ChildNodes[0];
+                    var childNode = furthestBlock.ChildAt(0);
                     furthestBlock.RemoveNode(0, childNode);
                     element.AddNode(childNode);
                 }
@@ -3392,9 +3411,9 @@ namespace AngleSharp.Html.Parser
         /// </summary>
         /// <param name="element">The old element (source).</param>
         /// <returns>The new element (target).</returns>
-        private IConstructableElement CopyElement(IConstructableElement element)
+        private static TNode CopyElement(TNode element)
         {
-            return (IConstructableElement)element.ShallowCopy();
+            return element.ShallowCopy();
         }
 
         /// <summary>
@@ -3417,7 +3436,7 @@ namespace AngleSharp.Html.Parser
             var index = _openElements.Count - 1;
             var node = CurrentNode;
 
-            while (node is not null)
+            while (!node.IsNull)
             {
                 if (node.LocalName.Is(tag.Name))
                 {
@@ -3629,9 +3648,10 @@ namespace AngleSharp.Html.Parser
 
                     if (tagName.Is(TagNames.Font))
                     {
-                        for (var i = 0; i != token.Attributes.Count; i++)
+                        ref readonly var attributes = ref StructHtmlToken.GetAttributesReference(ref token);
+                        for (var i = 0; i != attributes.Count; i++)
                         {
-                            if (token.Attributes[i].Name.IsOneOf(AttributeNames.Color, AttributeNames.Face, AttributeNames.Size))
+                            if (attributes[i].Name.IsOneOf(AttributeNames.Color, AttributeNames.Face, AttributeNames.Size))
                             {
                                 ForeignNormalTag(ref token);
                                 return;
@@ -3656,9 +3676,9 @@ namespace AngleSharp.Html.Parser
                     var tagName = token.Name;
                     var node = CurrentNode;
 
-                    if (node is IConstructableScriptElement script)
+                    if (node.IsScript)
                     {
-                        HandleScript(script);
+                        HandleScript(node);
                         return;
                     }
 
@@ -3707,7 +3727,7 @@ namespace AngleSharp.Html.Parser
         {
             var node = CreateForeignElementFrom(ref tag);
 
-            if (node is not null)
+            if (!node.IsNull)
             {
                 var selfClosing = tag.IsSelfClosing;
                 CurrentNode.AddNode(node);
@@ -3735,24 +3755,24 @@ namespace AngleSharp.Html.Parser
         /// </summary>
         /// <param name="tag">The tag of the foreign element.</param>
         /// <returns>The element or NULL if it is no MathML or SVG element.</returns>
-        private IConstructableElement? CreateForeignElementFrom(ref StructHtmlToken tag)
+        private TNode CreateForeignElementFrom(ref StructHtmlToken tag)
         {
-            if (AdjustedCurrentNode!.Flags.HasFlag(NodeFlags.MathMember))
+            if (AdjustedCurrentNode.Flags.HasFlag(NodeFlags.MathMember))
             {
                 var tagName = tag.Name;
                 var element = _elementFactory.CreateMath(_document, tagName);
                 AuxiliarySetupSteps(element, ref tag);
-                return element.Setup(ref tag);
+                return element.SetupMath(ref tag);
             }
             else if (AdjustedCurrentNode.Flags.HasFlag(NodeFlags.SvgMember))
             {
                 var tagName = tag.Name.SanatizeSvgTagName();
                 var element = _elementFactory.CreateSvg(_document, tagName);
                 AuxiliarySetupSteps(element, ref tag);
-                return element.Setup(ref tag);
+                return element.SetupSvg(ref tag);
             }
 
-            return null;
+            return default;
         }
 
         /// <summary>
@@ -3969,14 +3989,14 @@ namespace AngleSharp.Html.Parser
         /// <summary>
         /// Checks if the given element is actually an HTML Text Insertation Point.
         /// </summary>
-        private static Boolean IsHtmlTip(IConstructableElement node)
+        private static Boolean IsHtmlTip(TNode node)
         {
             if (!node.Flags.HasFlag(NodeFlags.HtmlTip))
             {
                 if (node.Flags.HasFlag(NodeFlags.MathMember) && node.LocalName.Is(TagNames.AnnotationXml))
                 {
-                    var encoding = node.Attributes["encoding"]?.Value;
-                    
+                    var encoding = node.GetAttribute(default, "encoding");
+
                     if (encoding == MimeTypeNames.Html || encoding == MimeTypeNames.ApplicationXHtml)
                     {
                         return true;
@@ -3997,9 +4017,9 @@ namespace AngleSharp.Html.Parser
         /// <summary>
         /// Runs a script given by the current node.
         /// </summary>
-        private void HandleScript(IConstructableScriptElement script)
+        private void HandleScript(TNode script)
         {
-            if (script is not null)
+            if (!script.IsNull)
             {
                 //Disable scripting for HTML fragments (security reasons)
                 if (IsFragmentCase)
@@ -4009,12 +4029,12 @@ namespace AngleSharp.Html.Parser
                 }
                 else
                 {
-                    _document.PerformMicrotaskCheckpoint();
-                    _document.ProvideStableState();
+                    _host?.PerformMicrotaskCheckpoint();
+                    _host?.ProvideStableState();
                     CloseCurrentNode();
                     _currentMode = _previousMode;
 
-                    if (script.Prepare(_document))
+                    if (script.PrepareScript(_document))
                     {
                         _waiting = RunScript(script);
                     }
@@ -4026,10 +4046,14 @@ namespace AngleSharp.Html.Parser
         /// Runs the current script element, if there is one.
         /// </summary>
         /// <returns>The task waiting for the document to be ready.</returns>
-        private async Task RunScript(IConstructableScriptElement script)
+        private async Task RunScript(TNode script)
         {
-            await _document.WaitForReadyAsync(CancellationToken.None).ConfigureAwait(false);
-            await script.RunAsync(CancellationToken.None).ConfigureAwait(false);
+            if (_host is not null)
+            {
+                await _host.WaitForReadyAsync(CancellationToken.None).ConfigureAwait(false);
+            }
+
+            await script.RunScriptAsync(CancellationToken.None).ConfigureAwait(false);
         }
 
         /// <summary>
@@ -4075,7 +4099,6 @@ namespace AngleSharp.Html.Parser
         private void PreventNewLine()
         {
             var temp = _tokenizer.GetStructToken();
-
             if (temp.Type == HtmlTokenType.Character)
             {
                 temp.RemoveNewLine();
@@ -4094,9 +4117,9 @@ namespace AngleSharp.Html.Parser
                 CloseCurrentNode();
             }
 
-            if (_document.IsLoading)
+            if (_host is { IsLoading: true })
             {
-                _waiting = _document.FinishLoadingAsync();
+                _waiting = _host.FinishLoadingAsync();
             }
         }
 
@@ -4111,14 +4134,14 @@ namespace AngleSharp.Html.Parser
         private void AddRoot(ref StructHtmlToken tag)
         {
             var element = _elementFactory.Create(_document, TagNames.Html);
-            _document.AddNode(element);
+            _elementFactory.GetDocumentNode(_document).AddNode(element);
             SetupElement(element, ref tag, false);
             _openElements.Add(element);
             _tokenizer.IsAcceptingCharacterData = false;
-            _document.ApplyManifest();
+            _host?.ApplyManifest();
         }
 
-        private void CheckEnded(IConstructableElement element)
+        private void CheckEnded(TNode element)
         {
             if (_shouldEnd?.Invoke(element) ?? false)
             {
@@ -4134,7 +4157,7 @@ namespace AngleSharp.Html.Parser
             CheckEnded(openElement);
         }
 
-        private void CloseNode(IConstructableElement element)
+        private void CloseNode(TNode element)
         {
             element.SetupElement();
             _openElements.Remove(element);
@@ -4160,7 +4183,7 @@ namespace AngleSharp.Html.Parser
             {
                 CloseNodeAt(_openElements.Count - 1);
                 var node = AdjustedCurrentNode;
-                _tokenizer.IsAcceptingCharacterData = node is not null && !node.Flags.HasFlag(NodeFlags.HtmlMember);
+                _tokenizer.IsAcceptingCharacterData = !node.IsNull && !node.Flags.HasFlag(NodeFlags.HtmlMember);
             }
         }
 
@@ -4171,7 +4194,7 @@ namespace AngleSharp.Html.Parser
         /// <param name="element">The node which will be added to the list.</param>
         /// <param name="tag">The associated tag token.</param>
         /// <param name="acknowledgeSelfClosing">Should the self-closing be acknowledged?</param>
-        private void SetupElement(IConstructableElement element, ref StructHtmlToken tag, Boolean acknowledgeSelfClosing)
+        private void SetupElement(TNode element, ref StructHtmlToken tag, Boolean acknowledgeSelfClosing)
         {
             if (tag.IsSelfClosing && !acknowledgeSelfClosing)
             {
@@ -4179,7 +4202,7 @@ namespace AngleSharp.Html.Parser
             }
 
             AuxiliarySetupSteps(element, ref tag);
-            element.SetAttributes(tag.Attributes);
+            element.SetTokenAttributes(ref tag);
         }
 
         /// <summary>
@@ -4189,7 +4212,7 @@ namespace AngleSharp.Html.Parser
         /// </summary>
         /// <param name="tag">The associated tag token.</param>
         /// <param name="acknowledgeSelfClosing">Should the self-closing be acknowledged?</param>
-        private TElement AddElement(ref StructHtmlToken tag, Boolean acknowledgeSelfClosing = false)
+        private TNode AddElement(ref StructHtmlToken tag, Boolean acknowledgeSelfClosing = false)
         {
             var element = _elementFactory.Create(_document, tag.Name);
             SetupElement(element, ref tag, acknowledgeSelfClosing);
@@ -4219,7 +4242,7 @@ namespace AngleSharp.Html.Parser
         /// <param name="element">The node which will be added to the list.</param>
         /// <param name="tag">The associated tag token.</param>
         /// <param name="acknowledgeSelfClosing">Should the self-closing be acknowledged?</param>
-        private void AddElement(IConstructableElement element, ref StructHtmlToken tag, Boolean acknowledgeSelfClosing = false)
+        private void AddElement(TNode element, ref StructHtmlToken tag, Boolean acknowledgeSelfClosing = false)
         {
             SetupElement(element, ref tag, acknowledgeSelfClosing);
             AddElement(element);
@@ -4229,7 +4252,7 @@ namespace AngleSharp.Html.Parser
         /// Appends a configured node to the current node.
         /// </summary>
         /// <param name="element">The node which will be added to the list.</param>
-        private void AddElement(IConstructableElement element)
+        private void AddElement(TNode element)
         {
             var node = CurrentNode;
 
@@ -4251,7 +4274,7 @@ namespace AngleSharp.Html.Parser
         /// http://www.w3.org/html/wg/drafts/html/master/syntax.html#foster-parent
         /// </summary>
         /// <param name="element">The node which will be added to the list.</param>
-        private void AddElementWithFoster(IConstructableElement element)
+        private void AddElementWithFoster(TNode element)
         {
             var table = false;
             var index = _openElements.Count;
@@ -4260,12 +4283,12 @@ namespace AngleSharp.Html.Parser
             {
                 var el = _openElements[index];
 
-                if (el is HtmlTemplateElement)
+                if (el.IsTemplate)
                 {
                     el.AddNode(element);
                     return;
                 }
-                else if (el is HtmlTableElement)
+                else if (el.Flags.HasFlag(NodeFlags.HtmlMember) && el.LocalName.Is(TagNames.Table))
                 {
                     table = true;
                     break;
@@ -4273,13 +4296,17 @@ namespace AngleSharp.Html.Parser
             }
 
             var current = _openElements[index];
-            var foster = current.Parent ?? _openElements[index + 1];
-
-            if (table && current.Parent is not null)
+            var foster = current.Parent;
+            if (foster.IsNull)
             {
-                for (var i = 0; i < foster.ChildNodes.Length; i++)
+                foster = _openElements[index + 1];
+            }
+
+            if (table && !current.Parent.IsNull)
+            {
+				for (var i = 0; i < foster.ChildCount; i++)
 			    {
-                    if (foster.ChildNodes[i] == current)
+                    if (foster.ChildAt(i).Equals(current))
                     {
                         foster.InsertNode(i, element);
                         break;
@@ -4336,13 +4363,17 @@ namespace AngleSharp.Html.Parser
                 }
             }
 
-            var foster = _openElements[index].Parent ?? _openElements[index + 1];
-
-            if (table && _openElements[index].Parent is not null)
+            var foster = _openElements[index].Parent;
+            if (foster.IsNull)
             {
-                for (var i = 0; i < foster.ChildNodes.Length; i++)
+                foster = _openElements[index + 1];
+            }
+
+            if (table && !_openElements[index].Parent.IsNull)
+            {
+                for (var i = 0; i < foster.ChildCount; i++)
                 {
-                    if (foster.ChildNodes[i] == _openElements[index])
+                    if (foster.ChildAt(i).Equals(_openElements[index]))
                     {
                         foster.InsertText(i, text, _emitWhitespaceTextNodes);
                         break;
@@ -4355,14 +4386,14 @@ namespace AngleSharp.Html.Parser
             }
         }
 
-        private void AuxiliarySetupSteps(IConstructableElement element, ref StructHtmlToken tag)
+        private void AuxiliarySetupSteps(TNode element, ref StructHtmlToken tag)
         {
             if (_options.IsKeepingSourceReferences)
             {
-                element.SourceReference = tag.ToHtmlToken();
+                element.SetSourceReference(tag.ToHtmlToken());
             }
 
-            if (_options.OnCreated is not null && element is IElement e)
+            if (_options.OnCreated is not null && element.AsDomElement is { } e)
             {
                 _options.OnCreated.Invoke(e, tag.Position);
             }
@@ -4380,7 +4411,11 @@ namespace AngleSharp.Html.Parser
         {
             var node = CurrentNode;
 
-            while (!node.LocalName.Is(tagName) && !(node is HtmlHtmlElement || node is HtmlTemplateElement))
+            while (
+                !node.LocalName.Is(tagName)
+                && !(node.Flags.HasFlag(NodeFlags.HtmlMember) && node.LocalName.Is(TagNames.Html))
+                && !node.IsTemplate
+            )
             {
                 CloseCurrentNode();
                 node = CurrentNode;
@@ -4445,7 +4480,7 @@ namespace AngleSharp.Html.Parser
             var index = _formattingElements.Count - 1;
             var entry = _formattingElements[index];
 
-            if (entry is null || _openElements.Contains(entry))
+            if (entry.IsNull || _openElements.Contains(entry))
             {
                 return;
             }
@@ -4454,7 +4489,7 @@ namespace AngleSharp.Html.Parser
             {
                 entry = _formattingElements[--index];
 
-                if (entry is null || _openElements.Contains(entry))
+                if (entry.IsNull || _openElements.Contains(entry))
                 {
                     index++;
                     break;
@@ -4473,7 +4508,8 @@ namespace AngleSharp.Html.Parser
 
         #region Handlers
 
-        private void RaiseErrorOccurred(HtmlParseError code, ref StructHtmlToken token) => _tokenizer.RaiseErrorOccurred(code, token.Position);
+        private void RaiseErrorOccurred(HtmlParseError code, ref StructHtmlToken token) =>
+            _tokenizer.RaiseErrorOccurred(code, token.Position);
 
         #endregion
 
@@ -4481,6 +4517,29 @@ namespace AngleSharp.Html.Parser
         {
             _tokenizer.Dispose();
         }
+    }
+
+    class HtmlDomBuilder<TDocument, TElement> : HtmlTreeBuilder<TDocument, ConstructableDomNode>
+        where TDocument : class, IConstructableDocument
+        where TElement : class, IConstructableElement
+    {
+        public HtmlDomBuilder(
+            IDomConstructionElementFactory<TDocument, TElement> elementFactory,
+            TDocument document,
+            HtmlTokenizerOptions? maybeOptions = null,
+            Boolean emitWhitespaceTextNodes = false,
+            Func<IConstructableElement, Boolean>? shouldEnd = null)
+            : base(
+                new ConstructableDomTreeFactory<TDocument, TElement>(elementFactory),
+                document,
+                maybeOptions,
+                emitWhitespaceTextNodes,
+                shouldEnd is null ? null : node => shouldEnd(node.ConstructableElement))
+        {
+        }
+
+        public TDocument ParseFragment(HtmlParserOptions options, TElement context) =>
+            base.ParseFragment(options, new ConstructableDomNode(context));
     }
 
     sealed class HtmlDomBuilder : HtmlDomBuilder<Document, Element>

--- a/src/AngleSharp/Html/Parser/HtmlDomBuilderExtensions.cs
+++ b/src/AngleSharp/Html/Parser/HtmlDomBuilderExtensions.cs
@@ -15,7 +15,8 @@ namespace AngleSharp.Html.Parser
     /// </summary>
     static class HtmlDomBuilderExtensions
     {
-        public static HtmlTreeMode? SelectMode(this IConstructableElement element, Boolean isLast, Stack<HtmlTreeMode> templateModes)
+        public static HtmlTreeMode? SelectMode<TNode>(this TNode element, Boolean isLast, Stack<HtmlTreeMode> templateModes)
+            where TNode : struct, IHtmlTreeConstructionNode<TNode>
         {
             if (element.Flags.HasFlag(NodeFlags.HtmlMember))
             {
@@ -86,27 +87,33 @@ namespace AngleSharp.Html.Parser
             return (Int32)code;
         }
 
-        public static void SetUniqueAttributes<TElement>(this TElement element, ref StructHtmlToken token)
-            where TElement: class, IConstructableElement
+        public static void SetUniqueAttributes<TNode>(this TNode element, ref StructHtmlToken token)
+            where TNode : struct, IHtmlTreeConstructionNode<TNode>
         {
-            for (var i = token.Attributes.Count - 1; i >= 0; i--)
+            ref readonly var attributes = ref StructHtmlToken.GetAttributesReference(ref token);
+            for (var i = attributes.Count - 1; i >= 0; i--)
             {
-                if (element.HasAttribute(token.Attributes[i].Name))
+                if (element.HasAttribute(attributes[i].Name))
                 {
                     token.RemoveAttributeAt(i);
                 }
             }
 
-            element.SetAttributes(token.Attributes);
+            element.SetTokenAttributes(ref token);
         }
 
-        public static void AddFormatting(this List<Element> formatting, Element element)
+        internal static void SetTokenAttributes<TNode>(
+            this TNode element,
+            ref StructHtmlToken token
+        )
+            where TNode : struct, IHtmlTreeConstructionNode<TNode>
         {
-            AddFormatting<Element>(formatting, element);
+            ref readonly var attributes = ref StructHtmlToken.GetAttributesReference(ref token);
+            element.SetAttributes(in attributes);
         }
 
-        public static void AddFormatting<TElement>(this List<TElement> formatting, TElement element)
-            where TElement: class, IConstructableElement
+        public static void AddFormatting<TNode>(this List<TNode> formatting, TNode element)
+            where TNode : struct, IHtmlTreeConstructionNode<TNode>
         {
             var count = 0;
 
@@ -114,14 +121,14 @@ namespace AngleSharp.Html.Parser
             {
                 var format = formatting[i];
 
-                if (format is null)
+                if (format.IsNull)
                 {
                     break;
                 }
 
                 if (format.NodeName.Is(element.NodeName) &&
                     format.NamespaceUri.Is(element.NamespaceUri) &&
-                    format.Attributes.SameAs(element.Attributes) && ++count == 3)
+                    format.AttributesSame(element) && ++count == 3)
                 {
                     formatting.RemoveAt(i);
                     break;
@@ -131,13 +138,8 @@ namespace AngleSharp.Html.Parser
             formatting.Add(element);
         }
 
-        public static void ClearFormatting(this List<Element> formatting)
-        {
-            ClearFormatting<Element>(formatting);
-        }
-
-        public static void ClearFormatting<TElement>(this List<TElement> formatting)
-            where TElement: class, IConstructableElement
+        public static void ClearFormatting<TNode>(this List<TNode> formatting)
+            where TNode : struct, IHtmlTreeConstructionNode<TNode>
         {
             while (formatting.Count != 0)
             {
@@ -145,7 +147,7 @@ namespace AngleSharp.Html.Parser
                 var entry = formatting[index];
                 formatting.RemoveAt(index);
 
-                if (entry is null)
+                if (entry.IsNull)
                 {
                     break;
                 }
@@ -153,16 +155,10 @@ namespace AngleSharp.Html.Parser
         }
 
         [MethodImpl(MethodImplOptions.AggressiveInlining)]
-        public static void AddScopeMarker(this List<Element> formatting)
+        public static void AddScopeMarker<TNode>(this List<TNode> formatting)
+            where TNode : struct, IHtmlTreeConstructionNode<TNode>
         {
-            AddScopeMarker<Element>(formatting);
-        }
-
-        [MethodImpl(MethodImplOptions.AggressiveInlining)]
-        public static void AddScopeMarker<TElement>(this List<TElement> formatting)
-            where TElement: class, IConstructableElement
-        {
-            formatting.Add(null!);
+            formatting.Add(default);
         }
 
         [MethodImpl(MethodImplOptions.AggressiveInlining)]

--- a/src/AngleSharp/Html/Parser/HtmlForeignExtensions.cs
+++ b/src/AngleSharp/Html/Parser/HtmlForeignExtensions.cs
@@ -160,11 +160,12 @@ namespace AngleSharp.Html.Parser
         /// <returns>The finished element.</returns>
         public static IConstructableMathElement Setup(this IConstructableMathElement element, ref StructHtmlToken tag)
         {
-            var count = tag.Attributes.Count;
+            ref readonly var attributes = ref StructHtmlToken.GetAttributesReference(ref tag);
+            var count = attributes.Count;
 
             for (var i = 0; i < count; i++)
             {
-                var attr = tag.Attributes[i];
+                var attr = attributes[i];
                 var name = attr.Name;
                 var value = attr.Value;
                 element.AdjustAttribute(name.AdjustToMathAttribute(), value);
@@ -181,14 +182,45 @@ namespace AngleSharp.Html.Parser
         /// <returns>The finished element.</returns>
         public static IConstructableSvgElement Setup(this IConstructableSvgElement element, ref StructHtmlToken tag)
         {
-            var count = tag.Attributes.Count;
+            ref readonly var attributes = ref StructHtmlToken.GetAttributesReference(ref tag);
+            var count = attributes.Count;
 
             for (var i = 0; i < count; i++)
             {
-                var attr = tag.Attributes[i];
+                var attr = attributes[i];
                 var name = attr.Name;
                 var value = attr.Value;
                 element.AdjustAttribute(name.AdjustToSvgAttribute(), value);
+            }
+
+            return element;
+        }
+
+        public static TNode SetupMath<TNode>(this TNode element, ref StructHtmlToken tag)
+            where TNode : struct, IHtmlTreeConstructionNode<TNode>
+        {
+            ref readonly var attributes = ref StructHtmlToken.GetAttributesReference(ref tag);
+            var count = attributes.Count;
+
+            for (var i = 0; i < count; i++)
+            {
+                var attr = attributes[i];
+                element.AdjustAttribute(attr.Name.AdjustToMathAttribute(), attr.Value);
+            }
+
+            return element;
+        }
+
+        public static TNode SetupSvg<TNode>(this TNode element, ref StructHtmlToken tag)
+            where TNode : struct, IHtmlTreeConstructionNode<TNode>
+        {
+            ref readonly var attributes = ref StructHtmlToken.GetAttributesReference(ref tag);
+            var count = attributes.Count;
+
+            for (var i = 0; i < count; i++)
+            {
+                var attr = attributes[i];
+                element.AdjustAttribute(attr.Name.AdjustToSvgAttribute(), attr.Value);
             }
 
             return element;
@@ -207,6 +239,40 @@ namespace AngleSharp.Html.Parser
             if (IsXLinkAttribute(name))
             {
                 // var newName = name.Substring(name.IndexOf(Symbols.Colon) + 1);
+                var newName = new StringOrMemory(name.Memory.Slice(name.Memory.Span.IndexOf(Symbols.Colon) + 1));
+
+                if (newName.IsXmlName() && newName.IsQualifiedName())
+                {
+                    ns = NamespaceNames.XLinkUri;
+                    name = newName;
+                }
+            }
+            else if (IsXmlAttribute(name))
+            {
+                ns = NamespaceNames.XmlUri;
+            }
+            else if (IsXmlNamespaceAttribute(name))
+            {
+                ns = NamespaceNames.XmlNsUri;
+            }
+
+            if (ns is null)
+            {
+                element.SetOwnAttribute(name, value);
+            }
+            else
+            {
+                element.SetAttribute(ns, name, value);
+            }
+        }
+
+        public static void AdjustAttribute<TNode>(this TNode element, StringOrMemory name, StringOrMemory value)
+            where TNode : struct, IHtmlTreeConstructionNode<TNode>
+        {
+            var ns = default(String);
+
+            if (IsXLinkAttribute(name))
+            {
                 var newName = new StringOrMemory(name.Memory.Slice(name.Memory.Span.IndexOf(Symbols.Colon) + 1));
 
                 if (newName.IsXmlName() && newName.IsQualifiedName())

--- a/src/AngleSharp/Html/Parser/HtmlParser.cs
+++ b/src/AngleSharp/Html/Parser/HtmlParser.cs
@@ -218,6 +218,68 @@ namespace AngleSharp.Html.Parser
         }
 
         /// <summary>
+        /// Parses into a construction backend whose nodes are represented by value-type identities.
+        /// </summary>
+        /// <typeparam name="TDocument">The construction document type.</typeparam>
+        /// <typeparam name="TNode">The backend's stable node identity.</typeparam>
+        /// <param name="source">The text source to parse.</param>
+        /// <param name="factory">The handle-oriented construction backend.</param>
+        /// <param name="middleware">Optional tokenizer middleware.</param>
+        /// <returns>The constructed document.</returns>
+        public TDocument ParseDocument<TDocument, TNode>(
+            TextSource source,
+            IHtmlTreeConstructionFactory<TDocument, TNode> factory,
+            TokenizerMiddleware? middleware = null)
+            where TDocument : class, IConstructableDocumentState
+            where TNode : struct, IHtmlTreeConstructionNode<TNode>
+        {
+            var document = factory.CreateDocument(source, _context);
+            var builder = new HtmlTreeBuilder<TDocument, TNode>(factory, document);
+
+            if (HasEventListener(EventNames.Error))
+            {
+                builder.Error += (_, ev) => InvokeEventListener(ev);
+            }
+
+            builder.Parse(_options, middleware);
+            return document;
+        }
+
+        /// <summary>
+        /// Parses a stream asynchronously into a handle-oriented construction backend.
+        /// </summary>
+        public async Task<TDocument> ParseDocumentAsync<TDocument, TNode>(
+            Stream source,
+            HtmlStreamSourceMode sourceMode,
+            IHtmlTreeConstructionFactory<TDocument, TNode> factory,
+            Encoding? encoding = null,
+            TokenizerMiddleware? middleware = null,
+            CancellationToken cancel = default)
+            where TDocument : class, IConstructableDocumentState
+            where TNode : struct, IHtmlTreeConstructionNode<TNode>
+        {
+            var textSource = CreateTextSource(source, sourceMode, encoding);
+            var document = factory.CreateDocument(textSource, _context);
+            var builder = new HtmlTreeBuilder<TDocument, TNode>(factory, document);
+
+            if (HasEventListener(EventNames.Error))
+            {
+                builder.Error += (_, ev) => InvokeEventListener(ev);
+            }
+
+            try
+            {
+                return await builder.ParseAsync(_options, middleware, cancel).ConfigureAwait(false);
+            }
+            catch
+            {
+                builder.Dispose();
+                textSource.Dispose();
+                throw;
+            }
+        }
+
+        /// <summary>
         /// Parses the stream and returns the head.
         /// </summary>
         public IHtmlHeadElement? ParseHead(Stream source)
@@ -317,6 +379,11 @@ namespace AngleSharp.Html.Parser
 
         private HtmlDocument CreateDocument(Stream source, HtmlStreamSourceMode sourceMode, Encoding? encoding)
         {
+            return CreateDocument(CreateTextSource(source, sourceMode, encoding));
+        }
+
+        private TextSource CreateTextSource(Stream source, HtmlStreamSourceMode sourceMode, Encoding? encoding)
+        {
             if (sourceMode is not HtmlStreamSourceMode.Buffered and not HtmlStreamSourceMode.Streaming)
             {
                 throw new ArgumentOutOfRangeException(nameof(sourceMode));
@@ -332,7 +399,7 @@ namespace AngleSharp.Html.Parser
                 sourceModeInternal,
                 encodingIsCertain: encoding is not null);
 
-            return CreateDocument(textSource);
+            return textSource;
         }
 
         private HtmlDocument CreateDocument(ReadOnlyMemory<Char> chars)

--- a/src/AngleSharp/Html/Parser/Tokens/Struct/StructHtmlToken.cs
+++ b/src/AngleSharp/Html/Parser/Tokens/Struct/StructHtmlToken.cs
@@ -195,6 +195,10 @@ public struct StructHtmlToken
     /// </summary>
     public StructAttributes Attributes => _attributes;
 
+    internal static ref readonly StructAttributes GetAttributesReference(
+        ref StructHtmlToken token
+    ) => ref token._attributes;
+
     #endregion
 
     #region Properties


### PR DESCRIPTION
# Types of Changes

## Prerequisites

- [x] I have read the **CONTRIBUTING** document (the repository currently has no CONTRIBUTING document)
- [x] My code follows the code style of this project

## Contribution Type

- [ ] Bug fix
- [x] New feature
- [ ] Breaking change
- [ ] My change requires a change to the documentation
- [x] I have added tests to cover my changes
- [x] All new and existing tests passed

## Description

AngleSharp currently supports custom DOM construction through class-based `IConstructableElement` nodes. That still requires one CLR object per parsed node, which prevents arena-backed or index-backed consumers from reusing the spec-compliant HTML tree-construction algorithm without paying that allocation cost.

This change:

- generalizes the internal tree builder over a value-type node identity;
- adds `IHtmlTreeConstructionFactory<TDocument, TNode>` and `IHtmlTreeConstructionNode<TNode>` as the public backend seam;
- separates the parser-required document state from the optional browsing-host lifecycle;
- keeps the existing AngleSharp DOM path behind an internal adapter;
- exposes synchronous text-source and asynchronous stream entry points for handle backends;
- adds parity tests covering foster parenting, SVG/foreign content, and both parser entry points.

The concrete downstream consumer is the arena-backed Compact DOM in [AngleSharp.ReadOnlyDom](https://github.com/dv00d00/AngleSharp.ReadOnlyDom). It represents nodes as an arena reference plus an integer handle and returns `null` for `AsDomElement`.
