### PR TITLE
Parse immutable byte buffers without a stream

### DIFF
--- a/docs/tutorials/03-Examples.md
+++ b/docs/tutorials/03-Examples.md
@@ -41,6 +41,32 @@ So we define some source code, call the `OpenAsync` method of a an `BrowsingCont
 
 In this case we use the provided source code to determine the content of the request's response. This content of the response is then parsed into an HTML document. Afterwards we serialize the DOM back to a string. Finally, we output this string in the console.
 
+## Parsing Raw Bytes from HttpClient
+
+When an HTTP response is already available as bytes, it can be parsed directly without wrapping the
+buffer in a `MemoryStream` or decoding it to a `string` first.
+
+```C#
+using System;
+using System.Net.Http;
+using AngleSharp.Html.Parser;
+
+using var client = new HttpClient();
+using var response = await client.GetAsync("https://example.com/");
+response.EnsureSuccessStatusCode();
+
+ReadOnlyMemory<byte> html = await response.Content.ReadAsByteArrayAsync();
+
+var parser = new HtmlParser();
+using var document = parser.ParseDocument(html);
+
+Console.WriteLine(document.Title);
+```
+
+Without an explicit encoding, AngleSharp detects a byte order mark and starts with UTF-8 while still
+allowing an HTML encoding declaration to restart decoding. If the transport supplies an authoritative
+encoding, pass it as the second argument to `ParseDocument`.
+
 ## Simple Document Manipulation
 
 AngleSharp constructs a DOM according to the official HTML5 specification. This also means that the resulting model is fully interactive and could be used for simple manipulation. The following example creates a document and changes the tree structure by inserting another paragraph element with some text.

--- a/src/AngleSharp.Benchmarks/ByteBufferParserBenchmark.cs
+++ b/src/AngleSharp.Benchmarks/ByteBufferParserBenchmark.cs
@@ -1,0 +1,48 @@
+namespace AngleSharp.Benchmarks;
+
+using System;
+using System.IO;
+using AngleSharp.Html.Parser;
+using BenchmarkDotNet.Attributes;
+
+[MemoryDiagnoser, ShortRunJob]
+public class ByteBufferParserBenchmark
+{
+    private readonly HtmlParser _parser = new();
+    private Byte[] _utf8 = null!;
+
+    [GlobalSetup]
+    public void Setup() => _utf8 = File.ReadAllBytes(FindPagePath());
+
+    [Benchmark(Baseline = true)]
+    public Int32 MemoryStream()
+    {
+        using var stream = new MemoryStream(_utf8, writable: false);
+        using var document = _parser.ParseDocument(stream);
+        return document.All.Length;
+    }
+
+    [Benchmark]
+    public Int32 ReadOnlyMemory()
+    {
+        using var document = _parser.ParseDocument(_utf8.AsMemory());
+        return document.All.Length;
+    }
+
+    private static String FindPagePath()
+    {
+        for (var directory = new DirectoryInfo(AppContext.BaseDirectory);
+             directory is not null;
+             directory = directory.Parent)
+        {
+            var path = Path.Combine(directory.FullName, "page.html");
+
+            if (File.Exists(path))
+            {
+                return path;
+            }
+        }
+
+        throw new FileNotFoundException("Could not locate the page.html benchmark fixture.");
+    }
+}

--- a/src/AngleSharp.Core.Tests/Library/ReadOnlyByteTextSourceTests.cs
+++ b/src/AngleSharp.Core.Tests/Library/ReadOnlyByteTextSourceTests.cs
@@ -1,0 +1,157 @@
+namespace AngleSharp.Core.Tests.Library;
+
+using System;
+using System.IO;
+using System.Linq;
+using System.Text;
+using AngleSharp.Html.Parser;
+using AngleSharp.Text;
+using NUnit.Framework;
+
+[TestFixture]
+public sealed class ReadOnlyByteTextSourceTests
+{
+    private static readonly Byte[] TwoByteSequence = [0xC3, 0xA9];
+
+    [Test]
+    public void RedecodeThatKeepsConsumedPrefixSwitchesInPlace()
+    {
+        using var source = new ReadOnlyByteTextSource(Bytes("abc", TwoByteSequence, "def"));
+
+        for (var i = 0; i < 3; i++)
+        {
+            source.ReadCharacter();
+        }
+
+        source.CurrentEncoding = Encoding.Latin1;
+
+        Assert.That(source.Index, Is.EqualTo(3));
+        Assert.That(source.Text, Is.EqualTo("abcÃ©def"));
+        Assert.That(source.ReadCharacter(), Is.EqualTo('Ã'));
+    }
+
+    [Test]
+    public void RedecodeThatShiftsConsumedPrefixRequestsRestart()
+    {
+        using var source = new ReadOnlyByteTextSource(Bytes("<!--", TwoByteSequence, "-->rest"));
+
+        for (var i = 0; i < 5; i++)
+        {
+            source.ReadCharacter();
+        }
+
+        Assert.That(() => source.CurrentEncoding = Encoding.Latin1, Throws.TypeOf<NotSupportedException>());
+        Assert.That(source.Index, Is.EqualTo(0));
+        Assert.That(source.CurrentEncoding, Is.EqualTo(Encoding.Latin1));
+        Assert.That(source.Text, Is.EqualTo("<!--Ã©-->rest"));
+    }
+
+    [Test]
+    public void RedecodeAfterReadingPastEndRequestsRestart()
+    {
+        using var source = new ReadOnlyByteTextSource(Bytes("ab", TwoByteSequence));
+
+        for (var i = 0; i < 4; i++)
+        {
+            source.ReadCharacter();
+        }
+
+        Assert.That(() => source.CurrentEncoding = Encoding.Latin1, Throws.TypeOf<NotSupportedException>());
+        Assert.That(source.Index, Is.EqualTo(0));
+        Assert.That(source.Text, Is.EqualTo("abÃ©"));
+    }
+
+    [Test]
+    public void ExplicitEncodingCannotBeReplaced()
+    {
+        using var source = new ReadOnlyByteTextSource(Bytes("abc", TwoByteSequence), Encoding.UTF8);
+
+        source.CurrentEncoding = Encoding.Latin1;
+
+        Assert.That(source.CurrentEncoding, Is.EqualTo(Encoding.UTF8));
+        Assert.That(source.Text, Is.EqualTo("abcé"));
+    }
+
+    [Test]
+    public void ParserOverloadHonorsReadOnlyMemorySliceAndByteOrderMark()
+    {
+        var markup = "<!doctype html><title>hé😀終</title><p>body";
+        var payload = Encoding.UTF8.GetPreamble().Concat(Encoding.UTF8.GetBytes(markup)).ToArray();
+        var buffer = new Byte[payload.Length + 8];
+        payload.CopyTo(buffer, 4);
+        var parser = new HtmlParser();
+
+        using var document = parser.ParseDocument(buffer.AsMemory(4, payload.Length));
+
+        Assert.That(document.Title, Is.EqualTo("hé😀終"));
+        Assert.That(document.CharacterSet, Is.EqualTo(Encoding.UTF8.WebName));
+    }
+
+    [Test]
+    public void ParserOverloadUsesAuthoritativeEncoding()
+    {
+        var encoding = Encoding.Latin1;
+        var parser = new HtmlParser();
+
+        using var document = parser.ParseDocument(
+            encoding.GetBytes("<!doctype html><title>café</title>"),
+            encoding);
+
+        Assert.That(document.Title, Is.EqualTo("café"));
+        Assert.That(document.CharacterSet, Is.EqualTo(encoding.WebName));
+    }
+
+    [Test]
+    public void LateEncodingSwitchMatchesCorrectlyDecodedDocument()
+    {
+        var bytes = Bytes(
+            "<!doctype html><!--",
+            TwoByteSequence,
+            "--><meta charset=\"iso-8859-1\"><title>t</title><p>body",
+            TwoByteSequence);
+        var declared = TextEncoding.Resolve("iso-8859-1");
+        var parser = new HtmlParser();
+
+        using var expected = parser.ParseDocument(declared.GetString(bytes));
+        using var actual = parser.ParseDocument(bytes);
+
+        Assert.That(actual.ToHtml(), Is.EqualTo(expected.ToHtml()));
+        Assert.That(actual.CharacterSet, Is.EqualTo(declared.WebName));
+    }
+
+    [Test]
+    public void ByteBufferParserMatchesAccumulatingStreamPath()
+    {
+        var bytes = Bytes(
+            "<!doctype html><!--",
+            TwoByteSequence,
+            "--><meta charset=\"iso-8859-1\"><title>t</title><p>body",
+            TwoByteSequence);
+        var parser = new HtmlParser();
+
+        using var stream = new MemoryStream(bytes);
+        using var expected = parser.ParseDocument(stream);
+        using var actual = parser.ParseDocument(bytes);
+
+        Assert.That(actual.ToHtml(), Is.EqualTo(expected.ToHtml()));
+        Assert.That(actual.CharacterSet, Is.EqualTo(expected.CharacterSet));
+    }
+
+    private static Byte[] Bytes(params Object[] parts)
+    {
+        using var buffer = new MemoryStream();
+
+        foreach (var part in parts)
+        {
+            var chunk = part switch
+            {
+                String text => Encoding.ASCII.GetBytes(text),
+                Byte[] raw => raw,
+                _ => throw new ArgumentOutOfRangeException(nameof(parts)),
+            };
+            buffer.Write(chunk, 0, chunk.Length);
+        }
+
+        return buffer.ToArray();
+    }
+}

--- a/src/AngleSharp/Html/Parser/HtmlParser.cs
+++ b/src/AngleSharp/Html/Parser/HtmlParser.cs
@@ -174,6 +174,24 @@ namespace AngleSharp.Html.Parser
         }
 
         /// <summary>
+        /// Parses an immutable byte buffer and returns the result.
+        /// </summary>
+        /// <param name="bytes">The encoded HTML bytes.</param>
+        /// <param name="encoding">
+        /// An authoritative encoding, or <c>null</c> to detect a byte order mark and allow an HTML
+        /// encoding declaration to replace the initial UTF-8 decoding.
+        /// </param>
+        /// <returns>The parsed HTML document.</returns>
+        public IHtmlDocument ParseDocument(ReadOnlyMemory<Byte> bytes, Encoding? encoding = null)
+        {
+            var byteSource = encoding is null
+                ? new ReadOnlyByteTextSource(bytes)
+                : new ReadOnlyByteTextSource(bytes, encoding);
+            var source = new TextSource(byteSource);
+            return ParseDocument(source);
+        }
+
+        /// <summary>
         /// Parses text source and returns result.
         /// </summary>
         public IHtmlDocument ParseDocument(TextSource source)

--- a/src/AngleSharp/Text/ReadOnlyByteTextSource.cs
+++ b/src/AngleSharp/Text/ReadOnlyByteTextSource.cs
@@ -1,0 +1,225 @@
+namespace AngleSharp.Text;
+
+using System;
+using System.Buffers;
+using System.Runtime.InteropServices;
+using System.Text;
+using System.Threading;
+using System.Threading.Tasks;
+using Common;
+
+/// <summary>
+/// Represents an immutable byte buffer decoded as a fully loaded text source.
+/// </summary>
+/// <remarks>
+/// The source retains the original bytes so that an encoding declaration discovered by the HTML
+/// tokenizer can re-decode the document without reopening or copying an input stream.
+/// </remarks>
+public sealed class ReadOnlyByteTextSource : IReadOnlyTextSource
+{
+    private readonly ReadOnlyMemory<Byte> _bytes;
+    private readonly Int32 _preambleLength;
+
+    private Char[] _chars;
+    private Int32 _charLength;
+    private String? _text;
+    private Encoding _encoding;
+    private Int32 _index;
+    private Boolean _encodingCertain;
+
+    /// <summary>
+    /// Creates a byte source that detects a byte order mark and otherwise starts with UTF-8.
+    /// </summary>
+    /// <param name="bytes">The immutable byte buffer.</param>
+    public ReadOnlyByteTextSource(ReadOnlyMemory<Byte> bytes)
+    {
+        _bytes = bytes;
+
+        if (ByteOrderMark.TryDetect(bytes.Span, out var encoding, out var preambleLength))
+        {
+            _encoding = encoding;
+            _preambleLength = preambleLength;
+            _encodingCertain = true;
+        }
+        else
+        {
+            _encoding = TextEncoding.Utf8;
+        }
+
+        _chars = Decode(_encoding, out _charLength);
+    }
+
+    /// <summary>
+    /// Creates a byte source decoded with an authoritative encoding.
+    /// </summary>
+    /// <param name="bytes">The immutable byte buffer.</param>
+    /// <param name="encoding">The authoritative encoding.</param>
+    public ReadOnlyByteTextSource(ReadOnlyMemory<Byte> bytes, Encoding encoding)
+    {
+        _bytes = bytes;
+        _encoding = encoding ?? throw new ArgumentNullException(nameof(encoding));
+        _encodingCertain = true;
+        _chars = Decode(encoding, out _charLength);
+    }
+
+    /// <inheritdoc />
+    public String Text => _text ??= new String(_chars, 0, _charLength);
+
+    /// <inheritdoc />
+    public Int32 Length => _charLength;
+
+    /// <inheritdoc />
+    public Encoding CurrentEncoding
+    {
+        get => _encoding;
+        set => SetEncoding(value);
+    }
+
+    /// <inheritdoc />
+    public Int32 Index
+    {
+        get => _index;
+        set => _index = value;
+    }
+
+    /// <inheritdoc />
+    public Char this[Int32 index] => _chars[index];
+
+    /// <inheritdoc />
+    public Char ReadCharacter()
+    {
+        if (_index < _charLength)
+        {
+            return _chars[_index++];
+        }
+
+        _index++;
+        return Symbols.EndOfFile;
+    }
+
+    /// <inheritdoc />
+    public String ReadCharacters(Int32 characters) => ReadMemory(characters).ToString();
+
+    /// <inheritdoc />
+    public StringOrMemory ReadMemory(Int32 characters)
+    {
+        var start = _index;
+        var end = start + characters;
+
+        if (end <= _charLength)
+        {
+            _index += characters;
+            return new ReadOnlyMemory<Char>(_chars, start, characters);
+        }
+
+        _index += characters;
+
+        if (start >= _charLength)
+        {
+            return ReadOnlyMemory<Char>.Empty;
+        }
+
+        characters = Math.Min(characters, _charLength - start);
+        return new ReadOnlyMemory<Char>(_chars, start, characters);
+    }
+
+    /// <inheritdoc />
+    public Task PrefetchAsync(Int32 length, CancellationToken cancellationToken) => Task.CompletedTask;
+
+    /// <inheritdoc />
+    public Task PrefetchAllAsync(CancellationToken cancellationToken) => Task.CompletedTask;
+
+    /// <inheritdoc />
+    public Boolean TryGetContentLength(out Int32 length)
+    {
+        length = _charLength;
+        return true;
+    }
+
+    /// <inheritdoc />
+    public void Dispose()
+    {
+        if (_chars is null)
+        {
+            return;
+        }
+
+        ArrayPool<Char>.Shared.Return(_chars);
+        _chars = null!;
+        _charLength = 0;
+        _text = null;
+    }
+
+    private void SetEncoding(Encoding? encoding)
+    {
+        if (encoding is null || _encodingCertain)
+        {
+            return;
+        }
+
+        if (_encoding.IsUnicode())
+        {
+            _encodingCertain = true;
+            return;
+        }
+
+        if (encoding.IsUnicode())
+        {
+            encoding = TextEncoding.Utf8;
+        }
+
+        if (encoding.CodePage == _encoding.CodePage)
+        {
+            _encodingCertain = true;
+            return;
+        }
+
+        var replacement = Decode(encoding, out var replacementLength);
+        var carriesPosition = _index <= _charLength &&
+            _index <= replacementLength &&
+            _chars.AsSpan(0, _index).SequenceEqual(replacement.AsSpan(0, _index));
+        var previous = _chars;
+
+        _encoding = encoding;
+        _encodingCertain = true;
+        _chars = replacement;
+        _charLength = replacementLength;
+        _text = null;
+        ArrayPool<Char>.Shared.Return(previous);
+
+        if (!carriesPosition)
+        {
+            _index = 0;
+            throw new NotSupportedException();
+        }
+    }
+
+    private Char[] Decode(Encoding encoding, out Int32 charLength)
+    {
+        var bytes = _bytes.Slice(_preambleLength);
+        var chars = ArrayPool<Char>.Shared.Rent(Math.Max(1, encoding.GetMaxCharCount(bytes.Length)));
+
+        try
+        {
+#if NET8_0_OR_GREATER
+            charLength = encoding.GetChars(bytes.Span, chars.AsSpan());
+#else
+            if (MemoryMarshal.TryGetArray(bytes, out var segment))
+            {
+                charLength = encoding.GetChars(segment.Array!, segment.Offset, segment.Count, chars, 0);
+            }
+            else
+            {
+                var copy = bytes.ToArray();
+                charLength = encoding.GetChars(copy, 0, copy.Length, chars, 0);
+            }
+#endif
+            return chars;
+        }
+        catch
+        {
+            ArrayPool<Char>.Shared.Return(chars);
+            throw;
+        }
+    }
+}

--- a/src/AngleSharp/Text/TextSource.cs
+++ b/src/AngleSharp/Text/TextSource.cs
@@ -78,6 +78,17 @@ namespace AngleSharp.Text
         }
 
         /// <summary>
+        /// Creates a new immutable text source from a <see cref="ReadOnlyByteTextSource"/>.
+        /// No underlying stream will be used.
+        /// </summary>
+        /// <param name="source">The byte-backed source.</param>
+        public TextSource(ReadOnlyByteTextSource source)
+        {
+            _writableSource = null;
+            _readOnlyTextSource = source;
+        }
+
+        /// <summary>
         /// Creates a new immutable text source from a <see cref="CharArrayTextSource"/>. No underlying stream will be used
         /// </summary>
         public TextSource(CharArrayTextSource source)


### PR DESCRIPTION
# Types of Changes

## Prerequisites

- [ ] I have read the **CONTRIBUTING** document (the repository currently has no CONTRIBUTING document)
- [x] My code follows the code style of this project

## Contribution Type

- [ ] Bug fix
- [x] New feature
- [ ] Breaking change
- [x] My change requires a change to the documentation
- [x] I have updated the documentation accordingly
- [x] I have added tests to cover my changes
- [x] All new and existing tests passed

## Description

Applications that already hold an HTTP response as `byte[]` or `ReadOnlyMemory<byte>` currently have to wrap it in a `MemoryStream` or decode it to a `string` before parsing. Both routes add buffering or allocations that are unnecessary for a fully loaded immutable response.

This change adds:

- `ReadOnlyByteTextSource`, which retains the original bytes and decodes into a pooled character buffer;
- byte order mark detection and the same HTML encoding-restart behavior as the accumulating stream source;
- `HtmlParser.ParseDocument(ReadOnlyMemory<byte>, Encoding?)` on netstandard2.0, net8.0, net10.0, and the existing .NET Framework targets;
- tests for BOM handling, sliced memory, authoritative encodings, late meta charset restarts, and parity with the stream path;
- an HttpClient example and a repeatable BenchmarkDotNet benchmark.

Typical usage:

```csharp
using var response = await client.GetAsync("https://example.com/");
response.EnsureSuccessStatusCode();
ReadOnlyMemory<byte> html = await response.Content.ReadAsByteArrayAsync();
using var document = new HtmlParser().ParseDocument(html);
```

No `MemoryStream` and no intermediate `string` are required. An authoritative transport encoding can be supplied as the second argument; otherwise BOM detection starts the source and an HTML encoding declaration may restart decoding.

### Benchmark

BenchmarkDotNet ShortRun on the existing 123,989-byte `page.html` fixture, .NET 10:

| Input path | Mean | Allocated |
|---|---:|---:|
| `MemoryStream` | 5.739 ms | 2.08 MB |
| `ReadOnlyMemory<byte>` | 4.640 ms | 1.32 MB |

The direct buffer path was about 19% faster and allocated about 37% less in this run.

### Validation

- `dotnet build src/AngleSharp/AngleSharp.Core.csproj` — netstandard2.0, net8.0, net10.0; 0 warnings, 0 errors
- `dotnet build src/AngleSharp.Benchmarks/AngleSharp.Benchmarks.csproj` — net472, net8.0, net10.0; 0 warnings, 0 errors
- `dotnet test src/AngleSharp.Core.Tests/AngleSharp.Core.Tests.csproj -f net10.0` — 3756 passed, 2 skipped, 0 failed

This is independent of #1285 and contains none of the handle-based tree-construction changes. It extracts only the byte-buffer capability that was previously mixed into #1277.