### PR TITLE
Allow custom DOMs to retain whitespace-only text nodes

### DIFF
--- a/src/AngleSharp.Core.Tests/Html/CustomTreeWhitespace.cs
+++ b/src/AngleSharp.Core.Tests/Html/CustomTreeWhitespace.cs
@@ -1,0 +1,54 @@
+namespace AngleSharp.Core.Tests.Html;
+
+using System;
+using AngleSharp.Dom;
+using AngleSharp.Html.Parser;
+using AngleSharp.Text;
+using NUnit.Framework;
+
+[TestFixture]
+public sealed class CustomTreeWhitespaceTests
+{
+    private const String Source =
+        "<html><body><span>Hello</span> <span>world</span></body></html>";
+
+    [Test]
+    public void CustomTreeDropsWhitespaceOnlyTextNodesByDefault()
+    {
+        var context = BrowsingContext.New(Configuration.Default);
+        var parser = new HtmlParser(new HtmlParserOptions(), context);
+
+        using var document = parser.ParseDocument<Document, Element>(new TextSource(Source));
+
+        Assert.That(document.Body.ChildNodes.Length, Is.EqualTo(2));
+        Assert.That(document.Body.TextContent, Is.EqualTo("Helloworld"));
+    }
+
+    [Test]
+    public void CustomTreeKeepsWhitespaceOnlyTextNodesWhenRequested()
+    {
+        var options = new HtmlParserOptions { IsKeepingWhitespaceTextNodes = true };
+        var context = BrowsingContext.New(Configuration.Default);
+        var parser = new HtmlParser(options, context);
+
+        using var document = parser.ParseDocument<Document, Element>(new TextSource(Source));
+
+        Assert.That(document.Body.ChildNodes.Length, Is.EqualTo(3));
+        Assert.That(document.Body.ChildNodes[1].NodeType, Is.EqualTo(NodeType.Text));
+        Assert.That(document.Body.TextContent, Is.EqualTo("Hello world"));
+    }
+
+    [TestCase(false)]
+    [TestCase(true)]
+    public void StandardDomAlwaysKeepsWhitespaceOnlyTextNodes(Boolean keepWhitespace)
+    {
+        var options = new HtmlParserOptions { IsKeepingWhitespaceTextNodes = keepWhitespace };
+        var parser = new HtmlParser(options);
+
+        using var document = parser.ParseDocument(Source);
+
+        Assert.That(document.Body.ChildNodes.Length, Is.EqualTo(3));
+        Assert.That(document.Body.ChildNodes[1].NodeType, Is.EqualTo(NodeType.Text));
+        Assert.That(document.Body.TextContent, Is.EqualTo("Hello world"));
+    }
+}

--- a/src/AngleSharp/Html/Parser/HtmlDomBuilder.cs
+++ b/src/AngleSharp/Html/Parser/HtmlDomBuilder.cs
@@ -47,7 +47,7 @@ namespace AngleSharp.Html.Parser
         private Func<IConstructableElement, Boolean>? _shouldEnd;
         private readonly IDomConstructionElementFactory<TDocument, TElement> _elementFactory;
         private Task? _waiting;
-        private readonly Boolean _emitWhitespaceTextNodes;
+        private Boolean _emitWhitespaceTextNodes;
 
         #endregion
 
@@ -392,6 +392,7 @@ namespace AngleSharp.Html.Parser
             _tokenizer.DisableElementPositionTracking = options.DisableElementPositionTracking;
             _tokenizer.OnToken = options.OnToken;
             _options = options;
+            _emitWhitespaceTextNodes |= options.IsKeepingWhitespaceTextNodes;
         }
 
         #endregion

--- a/src/AngleSharp/Html/Parser/HtmlParserOptions.cs
+++ b/src/AngleSharp/Html/Parser/HtmlParserOptions.cs
@@ -59,6 +59,13 @@ namespace AngleSharp.Html.Parser
         public Boolean IsKeepingSourceReferences { get; set; }
 
         /// <summary>
+        /// Gets or sets if whitespace-only text nodes should be kept when parsing into a custom
+        /// document through a generic tree-construction entry point. Custom documents omit these
+        /// nodes by default, while the standard AngleSharp DOM always keeps them.
+        /// </summary>
+        public Boolean IsKeepingWhitespaceTextNodes { get; set; }
+
+        /// <summary>
         /// Gets or sets if the parsing of character references should
         /// be avoided.
         /// Note: With this option there is no way to determine from


### PR DESCRIPTION
# Types of Changes

## Prerequisites

- [ ] I have read the **CONTRIBUTING** document (the repository currently has no CONTRIBUTING document)
- [x] My code follows the code style of this project

## Contribution Type

- [ ] Bug fix
- [x] New feature
- [ ] Breaking change
- [ ] My change requires a change to the documentation
- [x] I have added tests to cover my changes
- [x] All new and existing tests passed

## Description

Generic custom-DOM construction currently passes `false` to `AppendText` and `InsertText` for whitespace-only runs. A custom DOM therefore turns:

```html
<span>Hello</span> <span>world</span>
```

into `Helloworld`, and there is no public way to retain the separating text node. The standard AngleSharp DOM already preserves it.

This adds the opt-in `HtmlParserOptions.IsKeepingWhitespaceTextNodes` option. Its default is `false`, so existing custom backends keep their current allocation and tree-shape behavior. The builder combines it with its constructor-level setting using OR, which also guarantees that the standard DOM continues to preserve whitespace regardless of the option value.

The production diff is intentionally small: one option property, one mutable builder flag, and one assignment when parser options are applied. Tests cover the custom default, custom opt-in, and unchanged standard DOM behavior.

### Validation

- `dotnet build src/AngleSharp/AngleSharp.Core.csproj` — netstandard2.0, net8.0, net10.0; 0 warnings, 0 errors
- `dotnet test src/AngleSharp.Core.Tests/AngleSharp.Core.Tests.csproj -f net10.0` — 3752 passed, 2 skipped, 0 failed

This is independent of #1285 and #1286.