### PR TITLE
Fixed tokenizer buffer overrun on encoding change

### DIFF
--- a/src/AngleSharp.Core.Tests/Vulnerabilities/ParserVulnerabilityTests.cs
+++ b/src/AngleSharp.Core.Tests/Vulnerabilities/ParserVulnerabilityTests.cs
@@ -1,5 +1,8 @@
 namespace AngleSharp.Core.Tests.Vulnerabilities;
 
+using System;
+using System.Linq;
+using System.Text;
 using System.Threading.Tasks;
 using AngleSharp.Html.Parser;
 using NUnit.Framework;
@@ -15,5 +18,42 @@ public class ParserVulnerabilityTests
 
         using var document = await parser.ParseDocumentAsync(source);
         Assert.AreEqual(target, document.Body.InnerHtml);
+    }
+
+    [Test]
+    public void EncodingRestartDoesNotOverrunPooledTokenizerBuffer()
+    {
+        // The tokenizer sizes its pooled character buffer from the source's character count, which
+        // is only enough for a single pass over the source. A meta charset declaration that changes
+        // the encoding makes the parser re-decode and tokenize the document from the start, so the
+        // characters before the declaration are appended to that buffer twice -- and re-decoding
+        // UTF-8 text as windows-1252 turns every two-byte sequence into two characters, making the
+        // second pass longer than the buffer was ever sized for.
+        var markup = "<p>" + new String('\u00e9', 200) + "</p><meta charset=\"windows-1252\">";
+        var bytes = Encoding.UTF8.GetBytes(markup);
+        var parser = new HtmlParser();
+
+        using var document = parser.ParseDocument(bytes.AsMemory());
+
+        Assert.AreEqual("windows-1252", document.CharacterSet);
+        Assert.AreEqual(String.Concat(Enumerable.Repeat("\u00c3\u00a9", 200)), document.Body.TextContent);
+    }
+
+    [Test]
+    public void EncodingChangeWithoutRestartDoesNotOverrunPooledTokenizerBuffer()
+    {
+        // The same buffer, reached without a restart. Here the declaration comes first, so
+        // everything consumed before it is ASCII and decodes identically under both encodings;
+        // the source keeps the reading position and the parser carries on. The buffer is still
+        // too small, because the text after the declaration is twice as many characters once
+        // the bytes are read as windows-1252.
+        var markup = "<meta charset=\"windows-1252\"><p>" + new String('\u00e9', 200) + "</p>";
+        var bytes = Encoding.UTF8.GetBytes(markup);
+        var parser = new HtmlParser();
+
+        using var document = parser.ParseDocument(bytes.AsMemory());
+
+        Assert.AreEqual("windows-1252", document.CharacterSet);
+        Assert.AreEqual(String.Concat(Enumerable.Repeat("\u00c3\u00a9", 200)), document.Body.TextContent);
     }
 }

--- a/src/AngleSharp/Common/ArrayPoolBuffer.cs
+++ b/src/AngleSharp/Common/ArrayPoolBuffer.cs
@@ -31,6 +31,37 @@ internal sealed class ArrayPoolBuffer(Int32 length) : IMutableCharBuffer
         Clear(false);
     }
 
+    public void Reset()
+    {
+        _start = 0;
+        _idx = 0;
+    }
+
+    public void EnsureCapacity(Int32 length)
+    {
+        if (length <= _buffer.Length)
+        {
+            return;
+        }
+
+        var replacement = ArrayPool<Char>.Shared.Rent(length);
+        var used = Pointer;
+
+        if (used > 0)
+        {
+            // The old array is dropped rather than returned to the pool: StringOrMemory values
+            // already handed out are slices of it, and their lifetime is tied to this buffer, so
+            // handing it to the next renter would let someone else overwrite live token text.
+            _buffer.AsSpan(0, used).CopyTo(replacement);
+        }
+        else
+        {
+            ArrayPool<Char>.Shared.Return(_buffer, false);
+        }
+
+        _buffer = replacement;
+    }
+
     private void Clear(Boolean commit)
     {
         if (commit)

--- a/src/AngleSharp/Common/BaseTokenizer.cs
+++ b/src/AngleSharp/Common/BaseTokenizer.cs
@@ -260,6 +260,35 @@ namespace AngleSharp.Common
             return c;
         }
 
+        /// <summary>
+        /// Drops everything the character buffer has accumulated so far.
+        /// </summary>
+        /// <remarks>
+        /// The pooled buffer is sized from the source's character count, which is only enough for
+        /// a single pass: every token committed to it advances a write position that is never
+        /// rewound. A parser that restarts over the same source -- which an encoding declaration
+        /// makes it do -- therefore has to say so, or the second pass appends behind the tokens of
+        /// the abandoned one and runs off the end of the rented array.
+        /// </remarks>
+        internal void ResetBuffer() => _charBuffer.Reset();
+
+        /// <summary>
+        /// Re-reads the source's character count and grows the character buffer to match.
+        /// </summary>
+        /// <remarks>
+        /// The count is only fixed for as long as the encoding is. Re-decoding the same bytes with
+        /// a single-byte encoding turns every multi-byte sequence into that many characters, so a
+        /// source can be substantially longer after an encoding declaration than the buffer was
+        /// rented for at the start of the parse.
+        /// </remarks>
+        internal void GrowBufferToSource()
+        {
+            if (_source.TryGetContentLength(out var length))
+            {
+                _charBuffer.EnsureCapacity(length);
+            }
+        }
+
         #endregion
 
         #region Source Management

--- a/src/AngleSharp/Common/IMutableCharBuffer.cs
+++ b/src/AngleSharp/Common/IMutableCharBuffer.cs
@@ -39,6 +39,19 @@ internal interface IMutableCharBuffer : ICharBuffer, IDisposable
     void Discard();
 
     /// <summary>
+    /// Discards everything the buffer holds, data already committed by
+    /// <see cref="GetDataAndClear"/> included, returning it to the state it had when it was
+    /// created.
+    /// </summary>
+    void Reset();
+
+    /// <summary>
+    /// Makes room for at least the given number of characters, keeping every
+    /// <see cref="StringOrMemory"/> already handed out valid.
+    /// </summary>
+    void EnsureCapacity(Int32 length);
+
+    /// <summary>
     /// Current capacity of the buffer.
     /// </summary>
     Int32 Capacity { get; }

--- a/src/AngleSharp/Common/StringBuilderBuffer.cs
+++ b/src/AngleSharp/Common/StringBuilderBuffer.cs
@@ -23,6 +23,16 @@ internal sealed class StringBuilderBuffer : IMutableCharBuffer
         _sb.Clear();
     }
 
+    public void Reset()
+    {
+        _sb.Clear();
+    }
+
+    public void EnsureCapacity(Int32 length)
+    {
+        _sb.EnsureCapacity(length);
+    }
+
     public Int32 Length => _sb.Length;
 
     public Int32 Capacity => _sb.Capacity;

--- a/src/AngleSharp/Html/Parser/HtmlDomBuilder.cs
+++ b/src/AngleSharp/Html/Parser/HtmlDomBuilder.cs
@@ -241,6 +241,7 @@ namespace AngleSharp.Html.Parser
         {
             _currentMode = HtmlTreeMode.Initial;
             _tokenizer.State = HtmlParseMode.PCData;
+            _tokenizer.ResetBuffer();
             _document.Clear();
             _ended = false;
             _frameset = true;
@@ -725,6 +726,11 @@ namespace AngleSharp.Html.Parser
                             Restart();
                         }
 
+                        // Handling the declaration is what re-decodes the source, so this is the
+                        // one point in a parse where the character count can change. It grows
+                        // whenever the new encoding needs more characters for the same bytes, and
+                        // the tokenizer's buffer was rented for the old count.
+                        _tokenizer.GrowBufferToSource();
                         return;
                     }
                     else if (TagNames.AllHeadBase.Contains(tagName))


### PR DESCRIPTION
# Types of Changes

## Prerequisites

- [x] I have read the **CONTRIBUTING** document
- [x] My code follows the code style of this project

## Contribution Type

- [x] Bug fix (non-breaking change which fixes an issue, please reference the issue id)
- [ ] New feature (non-breaking change which adds functionality, make sure to open an associated issue first)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] My change requires a change to the documentation
- [ ] I have updated the documentation accordingly
- [x] I have added tests to cover my changes
- [x] All new and existing tests passed

## Description

Parsing untrusted markup through `ParseDocument(ReadOnlyMemory<Byte>)` can throw
`IndexOutOfRangeException` from `ArrayPoolBuffer.Append`, so a `meta` charset declaration in
attacker-controlled input crashes the parser.

`BaseTokenizer` rents its character buffer for the source's character count, which is only
enough for one pass under one encoding. Handling a `meta` charset declaration breaks both
halves of that assumption:

* `HtmlDomBuilder.Restart()` tokenizes the source again into the same buffer, whose write
  position is never rewound, so the second pass appends behind the tokens of the abandoned
  one. Reachable when the already-consumed prefix decodes differently under the new encoding.
* Re-decoding the same bytes with a single-byte encoding turns every multi-byte sequence into
  that many characters, so the source itself grows past the rented length. Reachable with an
  ASCII prefix, where the source keeps its position and no restart happens at all.

Either one alone runs `Append` off the end of the rented array. Only `ReadOnlyByteTextSource`
combines a known content length (which selects `ArrayPoolBuffer` over `StringBuilderBuffer`)
with the possibility of an encoding restart, so `ParseDocument(ReadOnlyMemory<Byte>)` without
an explicit encoding is the affected entry point.

### The fix

`Restart()` now rewinds the buffer, and handling the declaration grows it to the source's new
character count. The growth abandons the old array rather than returning it to the pool,
because the `StringOrMemory` values already handed out are slices of it and their lifetime is
tied to the buffer. Nothing changes on the per-character append path.

### Tests

Two regression tests in `Vulnerabilities/ParserVulnerabilityTests.cs`, one per trigger. Both
fail on `devel` with `IndexOutOfRangeException` and pass with the fix. The full suite passes in
both `prefetched` modes.

Found by fuzzing the parser with SharpFuzz/libFuzzer; the smallest reproducer libFuzzer arrived
at was 50 bytes.
