### PR TITLE
Fixed selector text dropping the case-insensitive modifier

### DIFF
--- a/src/AngleSharp.Core.Tests/Css/CssSelectorParserTests.cs
+++ b/src/AngleSharp.Core.Tests/Css/CssSelectorParserTests.cs
@@ -1,5 +1,6 @@
 namespace AngleSharp.Core.Tests.Css
 {
+    using System;
     using AngleSharp.Css.Parser;
     using NUnit.Framework;
 
@@ -58,6 +59,38 @@ namespace AngleSharp.Core.Tests.Css
 
             Assert.NotNull(selector);
             Assert.AreEqual(":host-context(.card)", selector!.Text);
+        }
+
+        [Test]
+        public void ParseSelector_WithCaseInsensitiveAttributeValue_KeepsModifierInText()
+        {
+            var parser = new CssSelectorParser();
+
+            var selector = parser.ParseSelector("[href$=\"B\" i]");
+
+            Assert.NotNull(selector);
+            Assert.AreEqual("[href$=\"B\" i]", selector!.Text);
+        }
+
+        [TestCase("=")]
+        [TestCase("~=")]
+        [TestCase("|=")]
+        [TestCase("^=")]
+        [TestCase("$=")]
+        [TestCase("*=")]
+        [TestCase("!=")]
+        public void ParseSelector_WithCaseInsensitiveAttributeValue_SerializesToAnEquivalentSelector(String op)
+        {
+            // Text is what every consumer stores, compares and re-parses, so a modifier dropped
+            // here silently turns a case-insensitive selector into a case-sensitive one.
+            var text = $"[href{op}\"B\" i]";
+            var parser = new CssSelectorParser();
+
+            var selector = parser.ParseSelector(text);
+
+            Assert.NotNull(selector);
+            Assert.AreEqual(text, selector!.Text);
+            Assert.AreEqual(text, parser.ParseSelector(selector.Text)!.Text);
         }
     }
 }

--- a/src/AngleSharp.Core.Tests/Css/CssSelectorParserTests.cs
+++ b/src/AngleSharp.Core.Tests/Css/CssSelectorParserTests.cs
@@ -93,6 +93,7 @@ namespace AngleSharp.Core.Tests.Css
             Assert.AreEqual(text, parser.ParseSelector(selector.Text)!.Text);
         }
 
+        [Test]
         public void ParseSelector_WithOfClause_KeepsTheFilterInText()
         {
             var parser = new CssSelectorParser();

--- a/src/AngleSharp/Css/Dom/Internal/AttrContainsSelector.cs
+++ b/src/AngleSharp/Css/Dom/Internal/AttrContainsSelector.cs
@@ -7,16 +7,14 @@ namespace AngleSharp.Css.Dom
     sealed class AttrContainsSelector : BaseAttrSelector, ISelector
     {
         private readonly String _value;
-        private readonly StringComparison _comparison;
 
         public AttrContainsSelector(String name, String value, String? prefix = null, Boolean insensitive = false)
-            : base(name, prefix)
+            : base(name, prefix, insensitive)
         {
             _value = value;
-            _comparison = insensitive ? StringComparison.OrdinalIgnoreCase : StringComparison.Ordinal;
         }
 
-        public String Text => String.Concat("[", Attribute, "*=", _value.CssString(), "]");
+        public String Text => String.Concat("[", Attribute, "*=", _value.CssString(), Modifier, "]");
 
         public void Accept(ISelectorVisitor visitor) => visitor.Attribute(Attribute, "*=", _value);
 
@@ -25,7 +23,7 @@ namespace AngleSharp.Css.Dom
             if (!String.IsNullOrEmpty(_value))
             {
                 var actual = element.GetAttribute(Name) ?? String.Empty;
-                return actual.IndexOf(_value, _comparison) != -1;
+                return actual.IndexOf(_value, Comparison) != -1;
             }
 
             return false;

--- a/src/AngleSharp/Css/Dom/Internal/AttrEndsWithSelector.cs
+++ b/src/AngleSharp/Css/Dom/Internal/AttrEndsWithSelector.cs
@@ -7,16 +7,14 @@ namespace AngleSharp.Css.Dom
     sealed class AttrEndsWithSelector : BaseAttrSelector, ISelector
     {
         private readonly String _value;
-        private readonly StringComparison _comparison;
 
         public AttrEndsWithSelector(String name, String value, String? prefix = null, Boolean insensitive = false)
-            : base(name, prefix)
+            : base(name, prefix, insensitive)
         {
             _value = value;
-            _comparison = insensitive ? StringComparison.OrdinalIgnoreCase : StringComparison.Ordinal;
         }
 
-        public String Text => String.Concat("[", Attribute, "$=", _value.CssString(), "]");
+        public String Text => String.Concat("[", Attribute, "$=", _value.CssString(), Modifier, "]");
 
         public void Accept(ISelectorVisitor visitor) => visitor.Attribute(Attribute, "$=", _value);
 
@@ -25,7 +23,7 @@ namespace AngleSharp.Css.Dom
             if (!String.IsNullOrEmpty(_value))
             {
                 var actual = element.GetAttribute(Name) ?? String.Empty;
-                return actual.EndsWith(_value, _comparison);
+                return actual.EndsWith(_value, Comparison);
             }
 
             return false;

--- a/src/AngleSharp/Css/Dom/Internal/AttrInListSelector.cs
+++ b/src/AngleSharp/Css/Dom/Internal/AttrInListSelector.cs
@@ -7,16 +7,14 @@ namespace AngleSharp.Css.Dom
     sealed class AttrInListSelector : BaseAttrSelector, ISelector
     {
         private readonly String _value;
-        private readonly StringComparison _comparison;
 
         public AttrInListSelector(String name, String value, String? prefix = null, Boolean insensitive = false)
-            : base(name, prefix)
+            : base(name, prefix, insensitive)
         {
             _value = value;
-            _comparison = insensitive ? StringComparison.OrdinalIgnoreCase : StringComparison.Ordinal;
         }
 
-        public String Text => String.Concat("[", Attribute, "~=", _value.CssString(), "]");
+        public String Text => String.Concat("[", Attribute, "~=", _value.CssString(), Modifier, "]");
 
         public void Accept(ISelectorVisitor visitor) => visitor.Attribute(Attribute, "~=", _value);
 
@@ -25,7 +23,7 @@ namespace AngleSharp.Css.Dom
             if (!String.IsNullOrEmpty(_value))
             {
                 var actual = element.GetAttribute(Name) ?? String.Empty;
-                return actual.SplitSpaces().Contains(_value, _comparison);
+                return actual.SplitSpaces().Contains(_value, Comparison);
             }
 
             return false;

--- a/src/AngleSharp/Css/Dom/Internal/AttrInTokenSelector.cs
+++ b/src/AngleSharp/Css/Dom/Internal/AttrInTokenSelector.cs
@@ -7,16 +7,14 @@ namespace AngleSharp.Css.Dom
     sealed class AttrInTokenSelector : BaseAttrSelector, ISelector
     {
         private readonly String _value;
-        private readonly StringComparison _comparison;
 
         public AttrInTokenSelector(String name, String value, String? prefix = null, Boolean insensitive = false)
-            : base(name, prefix)
+            : base(name, prefix, insensitive)
         {
             _value = value;
-            _comparison = insensitive ? StringComparison.OrdinalIgnoreCase : StringComparison.Ordinal;
         }
 
-        public String Text => String.Concat("[", Attribute, "|=", _value.CssString(), "]");
+        public String Text => String.Concat("[", Attribute, "|=", _value.CssString(), Modifier, "]");
 
         public void Accept(ISelectorVisitor visitor) => visitor.Attribute(Attribute, "|=", _value);
 
@@ -25,7 +23,7 @@ namespace AngleSharp.Css.Dom
             if (!String.IsNullOrEmpty(_value))
             {
                 var actual = element.GetAttribute(Name) ?? String.Empty;
-                return actual.HasHyphen(_value, _comparison);
+                return actual.HasHyphen(_value, Comparison);
             }
 
             return false;

--- a/src/AngleSharp/Css/Dom/Internal/AttrMatchSelector.cs
+++ b/src/AngleSharp/Css/Dom/Internal/AttrMatchSelector.cs
@@ -7,19 +7,17 @@ namespace AngleSharp.Css.Dom
     sealed class AttrMatchSelector : BaseAttrSelector, ISelector
     {
         private readonly String _value;
-        private readonly StringComparison _comparison;
 
         public AttrMatchSelector(String name, String value, String? prefix = null, Boolean insensitive = false)
-            : base(name, prefix)
+            : base(name, prefix, insensitive)
         {
             _value = value;
-            _comparison = insensitive ? StringComparison.OrdinalIgnoreCase : StringComparison.Ordinal;
         }
 
-        public String Text => String.Concat("[", Attribute, "=", _value.CssString(), "]");
+        public String Text => String.Concat("[", Attribute, "=", _value.CssString(), Modifier, "]");
 
         public void Accept(ISelectorVisitor visitor) => visitor.Attribute(Attribute, "=", _value);
 
-        public Boolean Match(IElement element, IElement? scope) => String.Equals(element.GetAttribute(Name), _value, _comparison);
+        public Boolean Match(IElement element, IElement? scope) => String.Equals(element.GetAttribute(Name), _value, Comparison);
     }
 }

--- a/src/AngleSharp/Css/Dom/Internal/AttrNotMatchSelector.cs
+++ b/src/AngleSharp/Css/Dom/Internal/AttrNotMatchSelector.cs
@@ -7,19 +7,17 @@ namespace AngleSharp.Css.Dom
     sealed class AttrNotMatchSelector : BaseAttrSelector, ISelector
     {
         private readonly String _value;
-        private readonly StringComparison _comparison;
 
         public AttrNotMatchSelector(String name, String value, String? prefix = null, Boolean insensitive = false)
-            : base(name, prefix)
+            : base(name, prefix, insensitive)
         {
             _value = value;
-            _comparison = insensitive ? StringComparison.OrdinalIgnoreCase : StringComparison.Ordinal;
         }
 
-        public String Text => String.Concat("[", Attribute, "!=", _value.CssString(), "]");
+        public String Text => String.Concat("[", Attribute, "!=", _value.CssString(), Modifier, "]");
 
         public void Accept(ISelectorVisitor visitor) => visitor.Attribute(Attribute, "!=", _value);
 
-        public Boolean Match(IElement element, IElement? scope) => !String.Equals(element.GetAttribute(Name), _value, _comparison);
+        public Boolean Match(IElement element, IElement? scope) => !String.Equals(element.GetAttribute(Name), _value, Comparison);
     }
 }

--- a/src/AngleSharp/Css/Dom/Internal/AttrStartsWithSelector.cs
+++ b/src/AngleSharp/Css/Dom/Internal/AttrStartsWithSelector.cs
@@ -7,16 +7,14 @@ namespace AngleSharp.Css.Dom
     sealed class AttrStartsWithSelector : BaseAttrSelector, ISelector
     {
         private readonly String _value;
-        private readonly StringComparison _comparison;
 
         public AttrStartsWithSelector(String name, String value, String? prefix = null, Boolean insensitive = false)
-            : base(name, prefix)
+            : base(name, prefix, insensitive)
         {
             _value = value;
-            _comparison = insensitive ? StringComparison.OrdinalIgnoreCase : StringComparison.Ordinal;
         }
 
-        public String Text => String.Concat("[", Attribute, "^=", _value.CssString(), "]");
+        public String Text => String.Concat("[", Attribute, "^=", _value.CssString(), Modifier, "]");
 
         public void Accept(ISelectorVisitor visitor) => visitor.Attribute(Attribute, "^=", _value);
 
@@ -25,7 +23,7 @@ namespace AngleSharp.Css.Dom
             if (!String.IsNullOrEmpty(_value))
             {
                 var actual = element.GetAttribute(Name) ?? String.Empty;
-                return actual.StartsWith(_value, _comparison);
+                return actual.StartsWith(_value, Comparison);
             }
 
             return false;

--- a/src/AngleSharp/Css/Dom/Internal/BaseAttrSelector.cs
+++ b/src/AngleSharp/Css/Dom/Internal/BaseAttrSelector.cs
@@ -7,11 +7,13 @@ namespace AngleSharp.Css.Dom
         private readonly String _name;
         private readonly String? _prefix;
         private readonly String _attr;
+        private readonly StringComparison _comparison;
 
-        public BaseAttrSelector(String name, String? prefix)
+        public BaseAttrSelector(String name, String? prefix, Boolean insensitive = false)
         {
             _name = name;
             _prefix = prefix;
+            _comparison = insensitive ? StringComparison.OrdinalIgnoreCase : StringComparison.Ordinal;
 
             if (!String.IsNullOrEmpty(prefix) && prefix is not "*")
             {
@@ -28,5 +30,20 @@ namespace AngleSharp.Css.Dom
         protected String Attribute => !String.IsNullOrEmpty(_prefix) ? String.Concat(CssUtilities.Escape(_prefix!), "|", CssUtilities.Escape(_name)) : CssUtilities.Escape(_name);
 
         protected String Name => _attr;
+
+        /// <summary>
+        /// How the attribute value is compared, which the ASCII case-insensitive modifier selects.
+        /// </summary>
+        protected StringComparison Comparison => _comparison;
+
+        /// <summary>
+        /// The case-insensitive modifier as it has to be written back out, or an empty string.
+        /// </summary>
+        /// <remarks>
+        /// Leaving it out of <see cref="ISelector.Text"/> would turn a case-insensitive selector
+        /// into a case-sensitive one the next time that text is parsed, which is what every
+        /// consumer storing or forwarding a selector ends up doing.
+        /// </remarks>
+        protected String Modifier => _comparison == StringComparison.OrdinalIgnoreCase ? " i" : String.Empty;
     }
 }


### PR DESCRIPTION
# Types of Changes

## Prerequisites

- [x] I have read the **CONTRIBUTING** document
- [x] My code follows the code style of this project

## Contribution Type

- [x] Bug fix (non-breaking change which fixes an issue, please reference the issue id)
- [ ] New feature (non-breaking change which adds functionality, make sure to open an associated issue first)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] My change requires a change to the documentation
- [ ] I have updated the documentation accordingly
- [x] I have added tests to cover my changes
- [x] All new and existing tests passed

## Description

`ISelector.Text` drops the ASCII case-insensitive modifier of an attribute selector, so a
selector does not survive being serialized and parsed again:

```csharp
var selector = new CssSelectorParser().ParseSelector("[href$=\"B\" i]");
selector.Text;                                    // [href$="B"]  -- the " i" is gone
document.QuerySelectorAll("[href$=\"B\" i]");     // 1 element
document.QuerySelectorAll(selector.Text);         // 0 elements
```

Every attribute selector took the `insensitive` flag, turned it straight into a
`StringComparison` for matching and kept nothing else, so `Text` had nothing left to write.
`Text` is what consumers store, compare, log and re-parse, and the result silently parses as a
case-sensitive selector. All seven value-carrying operators are affected: `=`, `~=`, `|=`,
`^=`, `$=`, `*=` and `!=`.

### The fix

The flag moves to `BaseAttrSelector`, which now owns both the `Comparison` used to match and
the `Modifier` used to serialize, derived from the same field — so the two cannot drift apart
again. The subclasses lose their own `_comparison` field and read `Comparison`, which is a
readonly field behind a property and costs nothing on the matching path.

`ISelectorVisitor.Attribute(name, op, value)` has the same gap and is left alone here, since
giving it the modifier means changing a public interface.

### Tests

`CssSelectorParserTests` gains a case for the reported selector and a `TestCase` per operator,
asserting the modifier survives serialization and a re-parse. All eight fail on `devel` and
pass with the fix; the full suite passes.

Found by fuzzing the selector parser with SharpFuzz/libFuzzer, checking that a parsed selector
and its own serialization select the same elements.
