### PR TITLE
Fixed selector text dropping the nth-child of clause

### DIFF
--- a/src/AngleSharp.Core.Tests/Css/CssSelectorParserTests.cs
+++ b/src/AngleSharp.Core.Tests/Css/CssSelectorParserTests.cs
@@ -1,5 +1,6 @@
 namespace AngleSharp.Core.Tests.Css
 {
+    using System;
     using AngleSharp.Css.Parser;
     using NUnit.Framework;
 
@@ -58,6 +59,38 @@ namespace AngleSharp.Core.Tests.Css
 
             Assert.NotNull(selector);
             Assert.AreEqual(":host-context(.card)", selector!.Text);
+        }
+
+        [Test]
+        public void ParseSelector_WithOfClause_KeepsTheFilterInText()
+        {
+            var parser = new CssSelectorParser();
+
+            var selector = parser.ParseSelector("li:nth-child(2 of .item)");
+
+            Assert.NotNull(selector);
+            Assert.AreEqual("li:nth-child(0n+2 of .item)", selector!.Text);
+        }
+
+        [TestCase("nth-child")]
+        [TestCase("nth-last-child")]
+        public void ParseSelector_WithOfClause_SerializesToAnEquivalentSelector(String name)
+        {
+            // The of-clause decides which siblings are counted at all, so losing it in Text
+            // widens the selector and drops the inner selector out of the specificity with it.
+            var text = $"li:{name}(2n+1 of .item)";
+
+            var selector = new CssSelectorParser().ParseSelector(text);
+
+            Assert.NotNull(selector);
+
+            // A parser of its own: the one above caches by selector text and would answer a
+            // re-parse of an unchanged serialization out of that cache.
+            var reparsed = new CssSelectorParser().ParseSelector(selector!.Text);
+
+            Assert.NotNull(reparsed);
+            Assert.AreEqual(selector.Text, reparsed!.Text);
+            Assert.AreEqual(selector.Specificity, reparsed.Specificity);
         }
     }
 }

--- a/src/AngleSharp/Css/Dom/Internal/ChildSelector.cs
+++ b/src/AngleSharp/Css/Dom/Internal/ChildSelector.cs
@@ -69,7 +69,14 @@
                     c = (-_offset).ToString();
                 }
 
-                return String.Format(":{0}({1}n{2}{3})", _name, a, b, c);
+                // The of-clause decides which siblings are counted at all, so a serialization
+                // without it names a different selector: one that counts every sibling, and one
+                // whose specificity no longer carries the inner selector.
+                var d = ReferenceEquals(_kind, AllSelector.Instance)
+                    ? String.Empty
+                    : String.Concat(" of ", _kind.Text);
+
+                return String.Format(":{0}({1}n{2}{3}{4})", _name, a, b, c, d);
             }
         }
 


### PR DESCRIPTION
# Types of Changes

## Prerequisites

- [x] I have read the **CONTRIBUTING** document
- [x] My code follows the code style of this project

## Contribution Type

- [x] Bug fix (non-breaking change which fixes an issue, please reference the issue id)
- [ ] New feature (non-breaking change which adds functionality, make sure to open an associated issue first)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] My change requires a change to the documentation
- [ ] I have updated the documentation accordingly
- [x] I have added tests to cover my changes
- [x] All new and existing tests passed

## Description

`ISelector.Text` drops the `of S` clause of `:nth-child` and `:nth-last-child`, so the
serialization names a different selector:

```csharp
var selector = new CssSelectorParser().ParseSelector("li:nth-child(2 of .item)");
selector.Text;          // li:nth-child(0n+2)  -- the filter is gone
selector.Specificity;   // (0, 0, 2, 1), but the re-parsed text gives (0, 0, 1, 1)
```

`ChildSelector.Text` wrote back only the `An+B` part. The of-clause decides which siblings are
counted at all, so losing it widens the selector, and it takes the inner selector out of the
specificity with it.

### The fix

`ChildSelector.Text` appends ` of <filter>` whenever the filter is not the universal selector.
Only `:nth-child` and `:nth-last-child` accept the clause (`withOptionalSelector: true` in
`CssSelectorConstructor`); everywhere else the filter is `AllSelector.Instance` and the output
is unchanged.

### Tests

`CssSelectorParserTests` gains a case for the reported selector and a `TestCase` for each of
the two pseudo-classes that accept the clause, asserting that the text and the specificity both
survive a serialize and re-parse. All three fail on `devel` and pass with the fix; the full
suite passes.

Found by fuzzing the selector parser with SharpFuzz/libFuzzer, checking that a parsed selector
and its own serialization agree on specificity and on the elements they select.
