### PR TITLE
Fix ArgumentOutOfRangeException on \D800 and \DFFF CSS escapes

### DIFF
--- a/src/AngleSharp.Core.Tests/Css/CssSelector.cs
+++ b/src/AngleSharp.Core.Tests/Css/CssSelector.cs
@@ -1361,6 +1361,31 @@ nav h1, nav h2, nav h3, nav h4, nav h5, nav h6";
             Assert.AreEqual(selectorText, selector.Text);
         }
 
+        // https://drafts.csswg.org/css-syntax/#consume-escaped-code-point - a surrogate escape yields U+FFFD.
+        [TestCase(@"\D800")]
+        [TestCase(@"\DBFF")]
+        [TestCase(@"\DC00")]
+        [TestCase(@"\DFFF")]
+        public void EscapedSurrogateCodePointBecomesReplacementCharacter(String escape)
+        {
+            var document = "<div class='\uFFFD'></div>".ToHtmlDocument();
+
+            var result = document.QuerySelectorAll("." + escape + " ");
+
+            Assert.AreEqual(1, result.Length);
+        }
+
+        [TestCase(@"\D7FF", '\uD7FF')]
+        [TestCase(@"\E000", '\uE000')]
+        public void EscapedCodePointNextToSurrogateRangeIsPreserved(String escape, Char expected)
+        {
+            var document = $"<div class='{expected}'></div>".ToHtmlDocument();
+
+            var result = document.QuerySelectorAll("." + escape + " ");
+
+            Assert.AreEqual(1, result.Length);
+        }
+
         [TestCase("nth-child")]
         [TestCase("nth-last-child")]
         public void PseudoClassSpecificityExceptions_NthChild_ContributesSpecificity(String pseudoClass)

--- a/src/AngleSharp/Text/CharExtensions.cs
+++ b/src/AngleSharp/Text/CharExtensions.cs
@@ -241,6 +241,6 @@ namespace AngleSharp.Text
         /// <param name="c">The character to examine.</param>
         /// <returns>The result of the test.</returns>
         [MethodImpl(MethodImplOptions.AggressiveInlining)]
-        public static Boolean IsInvalid(this Int32 c) => c == 0 || c > Symbols.MaximumCodepoint || (c > 0xD800 && c < 0xDFFF);
+        public static Boolean IsInvalid(this Int32 c) => c == 0 || c > Symbols.MaximumCodepoint || (c >= 0xD800 && c <= 0xDFFF);
     }
 }


### PR DESCRIPTION
# Types of Changes

## Prerequisites

Please make sure you can check the following two boxes:

- [x] I have read the **CONTRIBUTING** document
- [x] My code follows the code style of this project

## Contribution Type

What types of changes does your code introduce? Put an `x` in all the boxes that apply:

- [x] Bug fix (non-breaking change which fixes an issue, please reference the issue id)
- [ ] New feature (non-breaking change which adds functionality, make sure to open an associated issue first)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] My change requires a change to the documentation
- [ ] I have updated the documentation accordingly
- [x] I have added tests to cover my changes
- [x] All new and existing tests passed

## Description

A selector containing the CSS escape `\D800` or `\DFFF` throws `ArgumentOutOfRangeException` instead of matching, from every selector position (class, id, attribute name/value, type, namespace).

`Int32.IsInvalid` (`Text/CharExtensions.cs`) used **exclusive** bounds for the surrogate range:

```csharp
c == 0 || c > Symbols.MaximumCodepoint || (c > 0xD800 && c < 0xDFFF)
```

so the two boundary code points U+D800 and U+DFFF reported *valid* and fell through to `Char.ConvertFromUtf32` in `Css/Parser/CssStringSourceExtensions.cs`, which throws on any lone surrogate. The interior of the range (`\DBFF`, `\DC00`) was already handled correctly.

Per [css-syntax § consume an escaped code point](https://drafts.csswg.org/css-syntax/#consume-escaped-code-point), a surrogate escape must yield U+FFFD. The fix makes the bounds inclusive, so the boundaries take the same replacement-character path as the rest of the range. That `Int32` overload has exactly one call site, so nothing else shifts — the `IsInvalid` on `IElement` and on `Url` are unrelated members.
