### PR TITLE
Fix selector specificity carrying between fields instead of saturating

### DIFF
--- a/src/AngleSharp.Core.Tests/Css/Priority.cs
+++ b/src/AngleSharp.Core.Tests/Css/Priority.cs
@@ -161,5 +161,66 @@
             Assert.AreEqual(tags, a.Tags);
             Assert.AreEqual(result, a);
         }
+
+        [Test]
+        public void PriorityTagsSaturateInsteadOfCarryingIntoClasses()
+        {
+            var a = Priority.Zero;
+
+            for (var i = 0; i < 300; i++)
+            {
+                a += Priority.OneTag;
+            }
+
+            Assert.AreEqual(new Priority(0, 0, 0, 255), a);
+            Assert.AreEqual(255, a.Tags);
+            Assert.AreEqual(0, a.Classes);
+            Assert.AreNotEqual(Priority.OneClass, a);
+        }
+
+        [Test]
+        public void PriorityClassesSaturateInsteadOfCarryingIntoIds()
+        {
+            var a = Priority.Zero;
+
+            for (var i = 0; i < 300; i++)
+            {
+                a += Priority.OneClass;
+            }
+
+            Assert.AreEqual(new Priority(0, 0, 255, 0), a);
+            Assert.AreEqual(255, a.Classes);
+            Assert.AreEqual(0, a.Ids);
+            Assert.AreNotEqual(Priority.OneId, a);
+        }
+
+        [Test]
+        public void PriorityIdsSaturateInsteadOfCarryingIntoInlines()
+        {
+            var a = Priority.Zero;
+
+            for (var i = 0; i < 300; i++)
+            {
+                a += Priority.OneId;
+            }
+
+            Assert.AreEqual(new Priority(0, 255, 0, 0), a);
+            Assert.AreEqual(255, a.Ids);
+            Assert.AreEqual(0, a.Inlines);
+            Assert.AreNotEqual(Priority.Inline, a);
+        }
+
+        [Test]
+        public void PriorityOneClassBeatsAnyNumberOfTags()
+        {
+            var tags = Priority.Zero;
+
+            for (var i = 0; i < 300; i++)
+            {
+                tags += Priority.OneTag;
+            }
+
+            Assert.IsTrue(Priority.OneClass > tags);
+        }
     }
 }

--- a/src/AngleSharp.Core.Tests/Css/SelectorPriority.cs
+++ b/src/AngleSharp.Core.Tests/Css/SelectorPriority.cs
@@ -5,6 +5,8 @@ namespace AngleSharp.Core.Tests.Css
     using AngleSharp.Css.Parser;
     using AngleSharp.Dom;
     using NUnit.Framework;
+    using System;
+    using System.Linq;
 
     [TestFixture]
     public class SelectorPriorityTests
@@ -138,6 +140,26 @@ namespace AngleSharp.Core.Tests.Css
             {
                 doc.QuerySelectorAll(selectorText);
             });
+        }
+
+        [Test]
+        public void ManyTypeSelectorsDoNotReachClassSpecificity()
+        {
+            var parser = new CssSelectorParser();
+            var selector = parser.ParseSelector(String.Join(" ", Enumerable.Repeat("div", 256)));
+
+            Assert.AreEqual(new Priority(0, 0, 0, 255), selector.Specificity);
+            Assert.IsTrue(parser.ParseSelector(".x").Specificity > selector.Specificity);
+        }
+
+        [Test]
+        public void ManyClassSelectorsDoNotReachIdSpecificity()
+        {
+            var parser = new CssSelectorParser();
+            var selector = parser.ParseSelector(String.Concat(Enumerable.Range(0, 256).Select(i => $".c{i}")));
+
+            Assert.AreEqual(new Priority(0, 0, 255, 0), selector.Specificity);
+            Assert.IsTrue(parser.ParseSelector("#x").Specificity > selector.Specificity);
         }
     }
 }

--- a/src/AngleSharp/Css/Priority.cs
+++ b/src/AngleSharp/Css/Priority.cs
@@ -115,7 +115,16 @@ namespace AngleSharp.Css
         /// <param name="a">The first priority.</param>
         /// <param name="b">The second priority.</param>
         /// <returns>The result of adding the two priorities.</returns>
-        public static Priority operator +(Priority a, Priority b) => new(a._priority + b._priority);
+        // Added per field rather than on the packed value: a 256th tag would
+        // otherwise carry into the class field and outrank a real class.
+        public static Priority operator +(Priority a, Priority b) => new(
+            Saturate(a._inlines + b._inlines),
+            Saturate(a._ids + b._ids),
+            Saturate(a._classes + b._classes),
+            Saturate(a._tags + b._tags));
+
+        // Both operands are bytes, so the sum can never leave the Int32 range.
+        private static Byte Saturate(Int32 sum) => sum > Byte.MaxValue ? Byte.MaxValue : (Byte)sum;
 
         #endregion
 


### PR DESCRIPTION
# Types of Changes

## Prerequisites

- [x] I have read the **CONTRIBUTING** document
- [x] My code follows the code style of this project

## Contribution Type

- [x] Bug fix (non-breaking change which fixes an issue, please reference the issue id)
- [ ] New feature (non-breaking change which adds functionality, make sure to open an associated issue first)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] My change requires a change to the documentation
- [ ] I have updated the documentation accordingly
- [x] I have added tests to cover my changes
- [x] All new and existing tests passed

## Description

`Priority` overlays four `Byte` fields on a `UInt32` via `[StructLayout(LayoutKind.Explicit)]`, and `operator +` added the packed `UInt32` in one go. A carry out of one field therefore landed in the next one up.

Reproduced through the public selector parser, not just raw arithmetic — `CssSelectorParser.ParseSelector` reaches this through `ComplexSelector.Specificity`, which sums with `operator +`:

| Selector | Before | After |
| --- | --- | --- |
| `div` ×256 (descendant) | `(0, 0, 1, 0)` | `(0, 0, 0, 255)` |
| `.x` | `(0, 0, 1, 0)` | `(0, 0, 1, 0)` |

Three consequences:

1. **Field readout was wrong.** After 256 tags, `Tags` read `0` and the count had moved to `Classes`.
2. **Distinct selectors compared equal.** `div` ×256 and `.x` were byte-identical, so `==` returned true and `CompareTo` returned `0`.
3. **Tier ordering inverted** — the real cascade hazard. `div` ×257 was `(0, 0, 1, 1)` and beat `.x` at `(0, 0, 1, 0)`; likewise 257 classes was `(0, 1, 1, 0)` and beat `#x` at `(0, 1, 0, 0)`. Per CSS, no number of type selectors may outrank a single class, and no number of classes may outrank a single id.

Core itself only uses `Priority` for `IMultiSelector.GetMatchingSelector`, but AngleSharp.Css uses it for the cascade, where an inverted tier picks the wrong declaration.

### Fix

`operator +` now adds the four fields independently, clamping each at 255 rather than adding the packed value. The comparison operators still read the packed `_priority`, which is correct once no field can carry into its neighbour.

### Notes for reviewers

- **Saturation is not spec-exact.** CSS treats specificity components as unbounded, so `div` ×300 and `div` ×256 now compare equal where the spec would rank them. That ceiling is inherent to the existing 4-byte layout and is strictly better than the carry, since the tier invariant now holds. Removing it entirely would mean widening each field to a `UInt16` inside a `UInt64`, which changes the public `Byte`-typed `Tags`/`Classes`/`Ids`/`Inlines` properties and the `Priority(Byte, Byte, Byte, Byte)` constructor — a breaking API change, so I left it out. Happy to switch if you would rather have it.
- **Reachability.** The threshold is 256 compound selectors within one complex selector, so this needs a pathological selector to hit. `:is()` / `:not()` / `:where()` take a max rather than summing, so they do not accumulate toward it.