### PR TITLE
Add missing DomName/DomAccessor annotations on four spec DOM members

### DIFF
--- a/src/AngleSharp/Dom/IShadowRoot.cs
+++ b/src/AngleSharp/Dom/IShadowRoot.cs
@@ -30,6 +30,7 @@ namespace AngleSharp.Dom
         /// <summary>
         /// Gets the mode of this shadow root.
         /// </summary>
+        [DomName("mode")]
         ShadowRootMode Mode { get; }
 
         /// <summary>

--- a/src/AngleSharp/Dom/IWindow.cs
+++ b/src/AngleSharp/Dom/IWindow.cs
@@ -103,6 +103,7 @@ namespace AngleSharp.Dom
         /// session history.
         /// </param>
         /// <returns>The new or reused window.</returns>
+        [DomName("open")]
         IWindow Open(String url = "about:blank", String? name = null, String? features = null, String? replace = null);
 
         /// <summary>

--- a/src/AngleSharp/Html/Dom/IHtmlMetaElement.cs
+++ b/src/AngleSharp/Html/Dom/IHtmlMetaElement.cs
@@ -25,6 +25,7 @@ namespace AngleSharp.Html.Dom
         /// <summary>
         /// Gets or sets the associated charset.
         /// </summary>
+        [DomName("charset")]
         String? Charset { get; set; }
 
         /// <summary>

--- a/src/AngleSharp/Media/Dom/ITextTrackCueList.cs
+++ b/src/AngleSharp/Media/Dom/ITextTrackCueList.cs
@@ -21,6 +21,7 @@
         /// </summary>
         /// <param name="index">The 0-based cue index.</param>
         /// <returns>The cue at the position.</returns>
+        [DomAccessor(Accessors.Getter)]
         ITextTrackCue this[Int32 index] { get; }
 
         /// <summary>


### PR DESCRIPTION
# Types of Changes

## Prerequisites

- [x] I have read the **CONTRIBUTING** document
- [x] My code follows the code style of this project

## Contribution Type

- [x] Bug fix (non-breaking change which fixes an issue, please reference the issue id)
- [ ] New feature (non-breaking change which adds functionality, make sure to open an associated issue first)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] My change requires a change to the documentation
- [ ] I have updated the documentation accordingly
- [ ] I have added tests to cover my changes
- [x] All new and existing tests passed

## Description

Four IDL members were unannotated and therefore invisible to script:

Each is a real IDL member, and every neighbouring member in the same interface already carries the attribute. Enum-typed properties are not exempt — `IDocument.ReadyState` carries `[DomName("readyState")]`, which is the precedent for `IShadowRoot.Mode`. The `TextTrackCueList` IDL defines `getter TextTrackCue (unsigned long index)`, and the sibling `IAudioTrackList` / `ITextTrackList` / `IVideoTrackList` indexers all already carry `[DomAccessor(Accessors.Getter)]`.