### PR TITLE
Fixed IStringMap.Remove leaving the data-* attribute in place

### DIFF
--- a/src/AngleSharp.Core.Tests/Html/DOM.cs
+++ b/src/AngleSharp.Core.Tests/Html/DOM.cs
@@ -186,6 +186,20 @@ namespace AngleSharp.Core.Tests.Html
         }
 
         [Test]
+        public void DOMStringMapRemoveDeletesTheAttribute()
+        {
+            var document = new HtmlDocument();
+            var div = new HtmlDivElement(document);
+            div.SetAttribute("data-some", "test");
+            div.SetAttribute("data-another", "value");
+            div.Dataset.Remove("some");
+            Assert.IsFalse(div.HasAttribute("data-some"));
+            Assert.AreEqual("<div data-another=\"value\"></div>", div.ToHtml());
+            Assert.AreEqual(1, div.Dataset.Count());
+            Assert.AreEqual("another", div.Dataset.Single().Key);
+        }
+
+        [Test]
         public void HtmlCustomTitleGeneration()
         {
             var document = new HtmlDocument();

--- a/src/AngleSharp.Core.Tests/Library/StringMapTests.cs
+++ b/src/AngleSharp.Core.Tests/Library/StringMapTests.cs
@@ -3,6 +3,7 @@
     using AngleSharp.Dom;
     using AngleSharp.Html.Dom;
     using NUnit.Framework;
+    using System.Linq;
 
     [TestFixture]
     public class StringMapTests
@@ -25,6 +26,30 @@
         {
             stringMap.Remove("b");
             Assert.AreEqual(a.GetAttribute("data-b"), null);
+        }
+
+        [Test]
+        public void RemoveDeletesTheAttribute()
+        {
+            stringMap.Remove("b");
+            Assert.IsFalse(a.HasAttribute("data-b"));
+            Assert.IsFalse(stringMap.Contains("b"));
+        }
+
+        [Test]
+        public void RemoveDropsTheNameFromTheEnumeration()
+        {
+            stringMap.Remove("b");
+            Assert.AreEqual(1, stringMap.Count());
+            Assert.AreEqual("test1", stringMap.Single().Key);
+        }
+
+        [Test]
+        public void RemoveOfUnknownNameKeepsTheOtherAttributes()
+        {
+            stringMap.Remove("c");
+            Assert.AreEqual(2, stringMap.Count());
+            Assert.IsTrue(a.HasAttribute("data-b"));
         }
 
         [Test]

--- a/src/AngleSharp/Dom/Internal/StringMap.cs
+++ b/src/AngleSharp/Dom/Internal/StringMap.cs
@@ -41,10 +41,7 @@ namespace AngleSharp.Dom
 
         public void Remove(String name)
         {
-            if (Contains(name))
-            {
-                this[name] = null;
-            }
+            _parent.Attributes.RemoveNamedItemOrDefault(null, _prefix + Check(name));
         }
 
         public Boolean Contains(String name)


### PR DESCRIPTION
`IStringMap.Remove(name)` set the `data-*` attribute's value to `null` instead of removing the attribute, so `HasAttribute("data-foo")` stayed true afterwards, the map kept enumerating the name, and the attribute was still serialized. It now deletes the attribute from the element, which is what the `DOMStringMap` deleter specifies (https://html.spec.whatwg.org/multipage/dom.html#dom-domstringmap-removeitem).

The name is still validated the same way before the removal, and removing an unknown name remains a no-op. The tests cover the attribute being gone, the map no longer enumerating the name, and the serialization.

Fixes #1303
