### PR TITLE
Added the DomLiterals annotation to AdjacentPosition

### DIFF
--- a/src/AngleSharp.Core.Tests/Library/DomAnnotationTests.cs
+++ b/src/AngleSharp.Core.Tests/Library/DomAnnotationTests.cs
@@ -1,0 +1,31 @@
+namespace AngleSharp.Core.Tests.Library
+{
+    using AngleSharp.Attributes;
+    using AngleSharp.Dom;
+    using NUnit.Framework;
+    using System;
+    using System.Reflection;
+
+    [TestFixture]
+    public class DomAnnotationTests
+    {
+        [Test]
+        public void AdjacentPositionIsAnEnumerationOfLiterals()
+        {
+            var attribute = typeof(AdjacentPosition).GetCustomAttribute<DomLiteralsAttribute>();
+            Assert.IsNotNull(attribute);
+        }
+
+        [TestCase(AdjacentPosition.BeforeBegin, "beforebegin")]
+        [TestCase(AdjacentPosition.AfterBegin, "afterbegin")]
+        [TestCase(AdjacentPosition.BeforeEnd, "beforeend")]
+        [TestCase(AdjacentPosition.AfterEnd, "afterend")]
+        public void AdjacentPositionCarriesTheLiteralOfTheSpecification(AdjacentPosition position, String literal)
+        {
+            var field = typeof(AdjacentPosition).GetField(position.ToString());
+            var attribute = field.GetCustomAttribute<DomNameAttribute>();
+            Assert.IsNotNull(attribute);
+            Assert.AreEqual(literal, attribute.OfficialName);
+        }
+    }
+}

--- a/src/AngleSharp/Dom/AdjacentPosition.cs
+++ b/src/AngleSharp/Dom/AdjacentPosition.cs
@@ -5,6 +5,7 @@
     /// <summary>
     /// Enumeration with possible values for the adjacent position insertion.
     /// </summary>
+    [DomLiterals]
     public enum AdjacentPosition : System.Byte
     {
         /// <summary>


### PR DESCRIPTION
`AdjacentPosition` is the string enumeration behind `insertAdjacentElement`/`insertAdjacentHTML`/`insertAdjacentText` (https://html.spec.whatwg.org/multipage/dom.html#dom-element-insertadjacentelement), and its members already carry the spec literals as `[DomName]`, but the enum itself was not marked `[DomLiterals]` the way `ShadowRootMode` is. A binding generator reading the attributes as WebIDL therefore could not tell it from an ordinary numeric enum.

This adds the enum-level `[DomLiterals]`; no enum-level `[DomName]`, since the spec models the position argument as a plain `DOMString` rather than a named IDL enumeration, which is also how `DocumentReadyState` is annotated. The new test pins the annotation and the four literals.

Fixes #1306
