### PR TITLE
Fixed Document.CurrentScript answering the deferred-script queue

### DIFF
--- a/src/AngleSharp.Core.Tests/Library/BasicScripting.cs
+++ b/src/AngleSharp.Core.Tests/Library/BasicScripting.cs
@@ -4,10 +4,12 @@ namespace AngleSharp.Core.Tests.Library
     using AngleSharp.Browser;
     using AngleSharp.Core.Tests.Mocks;
     using AngleSharp.Dom;
+    using AngleSharp.Html.Dom;
     using AngleSharp.Io;
     using AngleSharp.Text;
     using NUnit.Framework;
     using System;
+    using System.Collections.Generic;
     using System.Reflection;
     using System.Text;
     using System.Threading.Tasks;
@@ -308,6 +310,68 @@ namespace AngleSharp.Core.Tests.Library
             Assert.AreEqual(originalBody, document.Body?.TextContent);
             Assert.AreEqual("café", document.Title);
             Assert.AreEqual("tail", document.Body?.TextContent);
+        }
+
+        [Test]
+        public void CurrentScriptIsTheClassicScriptBeingRun()
+        {
+            var currentScript = default(IHtmlScriptElement);
+            var scripting = new CallbackScriptEngine(options => currentScript = options.Document.CurrentScript);
+            var config = Configuration.Default.WithScripts(scripting);
+            var source = "<title>Some title</title><body><script type='c-sharp'>//...</script>";
+            var document = source.ToHtmlDocument(config);
+            var script = document.Scripts[0];
+
+            Assert.AreSame(script, currentScript);
+            Assert.IsNull(document.CurrentScript);
+        }
+
+        [Test]
+        public async Task CurrentScriptIsTheExternalClassicScriptBeingRun()
+        {
+            var currentScript = default(IHtmlScriptElement);
+            var scripting = new CallbackScriptEngine(options => currentScript = options.Document.CurrentScript);
+            var config = Configuration.Default.WithScripts(scripting).WithMockRequester();
+            var source = "<title>Some title</title><body><script type='c-sharp' src='foo.cs'></script>";
+            var document = await BrowsingContext.New(config).OpenAsync(m => m.Content(source).Address("http://www.example.com"));
+            var script = document.Scripts[0];
+
+            Assert.AreSame(script, currentScript);
+            Assert.IsNull(document.CurrentScript);
+        }
+
+        [Test]
+        public async Task CurrentScriptIsTheDeferredScriptBeingRun()
+        {
+            var seen = new List<IHtmlScriptElement>();
+            var scripting = new CallbackScriptEngine(options => seen.Add(options.Document.CurrentScript));
+            var config = Configuration.Default.WithScripts(scripting).WithMockRequester();
+            var source = "<title>Some title</title><body><script type='c-sharp' defer src='first.cs'></script><script type='c-sharp' defer src='second.cs'></script>";
+            var document = await BrowsingContext.New(config).OpenAsync(m => m.Content(source).Address("http://www.example.com"));
+
+            Assert.AreEqual(2, seen.Count);
+            Assert.AreSame(document.Scripts[0], seen[0]);
+            Assert.AreSame(document.Scripts[1], seen[1]);
+            Assert.IsNull(document.CurrentScript);
+        }
+
+        [Test]
+        public void CurrentScriptIsNullWhileRunningAModuleScript()
+        {
+            var didRun = false;
+            var currentScript = default(IHtmlScriptElement);
+            var scripting = new CallbackScriptEngine(options =>
+            {
+                didRun = true;
+                currentScript = options.Document.CurrentScript;
+            }, "module");
+            var config = Configuration.Default.WithScripts(scripting);
+            var source = "<title>Some title</title><body><script type='module'>//...</script>";
+            var document = source.ToHtmlDocument(config);
+
+            Assert.IsTrue(didRun);
+            Assert.IsNull(currentScript);
+            Assert.IsNull(document.CurrentScript);
         }
     }
 }

--- a/src/AngleSharp/Dom/IDocument.cs
+++ b/src/AngleSharp/Dom/IDocument.cs
@@ -473,7 +473,8 @@ namespace AngleSharp.Dom
         IElement? ActiveElement { get; }
 
         /// <summary>
-        /// Gets the script element which is currently being processed.
+        /// Gets the classic script element that is currently being run, if
+        /// any. It is null outside of the execution of a classic script.
         /// </summary>
         [DomName("currentScript")]
         IHtmlScriptElement? CurrentScript { get; }

--- a/src/AngleSharp/Dom/Internal/Document.cs
+++ b/src/AngleSharp/Dom/Internal/Document.cs
@@ -594,7 +594,7 @@ namespace AngleSharp.Dom
         public Boolean IsAsync => _async;
 
         /// <inheritdoc />
-        public IHtmlScriptElement? CurrentScript => _loadingScripts.Count > 0 ? _loadingScripts.Peek() : null;
+        public IHtmlScriptElement? CurrentScript { get; internal set; }
 
         /// <inheritdoc />
         public IImplementation Implementation => _implementation ??= new DomImplementation(this);

--- a/src/AngleSharp/Io/Processors/ScriptRequestProcessor.cs
+++ b/src/AngleSharp/Io/Processors/ScriptRequestProcessor.cs
@@ -12,6 +12,8 @@ namespace AngleSharp.Io.Processors
     {
         #region Fields
 
+        private const String ScriptTypeModule = "module";
+
         private readonly IBrowsingContext _context;
         private readonly Document _document;
         private readonly HtmlScriptElement _script;
@@ -61,6 +63,8 @@ namespace AngleSharp.Io.Processors
             }
         }
 
+        private Boolean IsModule => _script.Type.Isi(ScriptTypeModule);
+
         #endregion
 
         #region Methods
@@ -89,6 +93,10 @@ namespace AngleSharp.Io.Processors
                 {
                     var options = CreateOptions();
                     var insert = _document.Source.Index;
+                    var previousScript = _document.CurrentScript;
+
+                    //https://html.spec.whatwg.org/multipage/scripting.html#execute-the-script-element
+                    _document.CurrentScript = IsModule ? null : _script;
 
                     try
                     {
@@ -98,6 +106,10 @@ namespace AngleSharp.Io.Processors
                     {
                         /* We omit failed 3rd party services */
                         _context.TrackError(ex);
+                    }
+                    finally
+                    {
+                        _document.CurrentScript = previousScript;
                     }
 
                     _document.Source.Index = insert;


### PR DESCRIPTION
`Document.CurrentScript` returned the head of the deferred-script queue, so it was null exactly when a page reads it — during the execution of an ordinary classic `<script>` — and, for a deferred script, named the next queued element rather than the running one. It is now set around the evaluation of each classic script in `ScriptRequestProcessor` and restored afterwards, so it is null outside script execution and correct for inline, external and deferred classic scripts.

A script element whose `type` is `module` leaves it null, as the execution steps specify (https://html.spec.whatwg.org/multipage/scripting.html#execute-the-script-element, exposed by https://html.spec.whatwg.org/multipage/dom.html#dom-document-currentscript). The deferred queue itself is untouched; only the property stopped reading from it. Tests cover the inline, external, deferred and module cases through the scripting service.

Fixes #1308
