### PR TITLE
Reflected DOMString attributes return the empty string when absent

### DIFF
--- a/src/AngleSharp.Core.Tests/Css/CssSelector.cs
+++ b/src/AngleSharp.Core.Tests/Css/CssSelector.cs
@@ -809,7 +809,8 @@ nav h1, nav h2, nav h3, nav h4, nav h5, nav h6";
             Assert.AreEqual("span", result[1].GetTagName());
             Assert.AreEqual("span", result[2].GetTagName());
             Assert.AreEqual("italic", result[0].ClassName);
-            Assert.AreEqual(null, result[1].ClassName);
+            // A missing class attribute reflects as the empty string, not null.
+            Assert.AreEqual("", result[1].ClassName);
             Assert.AreEqual("this", result[2].ClassName);
             Assert.AreEqual("2", result[0].TextContent);
             Assert.AreEqual("4", result[1].TextContent);
@@ -837,7 +838,8 @@ nav h1, nav h2, nav h3, nav h4, nav h5, nav h6";
             var result = document.QuerySelectorAll(selector);
             Assert.AreEqual(1, result.Length);
             Assert.AreEqual("span", result[0].GetTagName());
-            Assert.AreEqual(null, result[0].ClassName);
+            // A missing class attribute reflects as the empty string, not null.
+            Assert.AreEqual("", result[0].ClassName);
             Assert.AreEqual("1", result[0].TextContent);
         }
 

--- a/src/AngleSharp.Core.Tests/Library/ReflectedAttributes.cs
+++ b/src/AngleSharp.Core.Tests/Library/ReflectedAttributes.cs
@@ -1,0 +1,95 @@
+namespace AngleSharp.Core.Tests.Library
+{
+    using AngleSharp.Dom;
+    using AngleSharp.Html.Dom;
+    using NUnit.Framework;
+
+    [TestFixture]
+    public class ReflectedAttributeTests
+    {
+        [Test]
+        public void MissingIdAndClassNameReflectAsEmptyString()
+        {
+            var document = "<div></div>".ToHtmlDocument();
+            var div = document.QuerySelector("div");
+
+            Assert.IsFalse(div.HasAttribute("id"));
+            Assert.IsFalse(div.HasAttribute("class"));
+            Assert.AreEqual("", div.Id);
+            Assert.AreEqual("", div.ClassName);
+        }
+
+        [Test]
+        public void MissingSlotReflectsAsEmptyString()
+        {
+            var document = "<div></div>".ToHtmlDocument();
+            var div = document.QuerySelector("div");
+
+            Assert.IsFalse(div.HasAttribute("slot"));
+            Assert.AreEqual("", div.Slot);
+        }
+
+        [Test]
+        public void MissingTitleAndDirectionReflectAsEmptyString()
+        {
+            var document = "<div></div>".ToHtmlDocument();
+            var div = (IHtmlElement)document.QuerySelector("div");
+
+            Assert.IsFalse(div.HasAttribute("title"));
+            Assert.IsFalse(div.HasAttribute("dir"));
+            Assert.AreEqual("", div.Title);
+            Assert.AreEqual("", div.Direction);
+        }
+
+        [Test]
+        public void MissingSlotNameReflectsAsEmptyString()
+        {
+            var document = "<slot></slot>".ToHtmlDocument();
+            var slot = (IHtmlSlotElement)document.QuerySelector("slot");
+
+            Assert.IsFalse(slot.HasAttribute("name"));
+            Assert.AreEqual("", slot.Name);
+        }
+
+        [Test]
+        public void PresentAttributesAreStillReflected()
+        {
+            var document = "<div id=foo class=bar slot=baz title=qux dir=rtl></div>".ToHtmlDocument();
+            var div = (IHtmlElement)document.QuerySelector("div");
+
+            Assert.AreEqual("foo", div.Id);
+            Assert.AreEqual("bar", div.ClassName);
+            Assert.AreEqual("baz", div.Slot);
+            Assert.AreEqual("qux", div.Title);
+            Assert.AreEqual("rtl", div.Direction);
+        }
+
+        [Test]
+        public void AnEmptyAttributeIsNotConfusedWithAMissingOne()
+        {
+            var document = "<div id=\"\"></div>".ToHtmlDocument();
+            var div = document.QuerySelector("div");
+
+            Assert.IsTrue(div.HasAttribute("id"));
+            Assert.AreEqual("", div.Id);
+        }
+
+        [Test]
+        public void SettingTheReflectedValueSetsTheAttribute()
+        {
+            var document = "<div></div>".ToHtmlDocument();
+            var div = document.QuerySelector("div");
+
+            div.Id = "foo";
+
+            Assert.IsTrue(div.HasAttribute("id"));
+            Assert.AreEqual("foo", div.GetAttribute("id"));
+            Assert.AreEqual("foo", div.Id);
+
+            div.Id = "";
+
+            Assert.IsTrue(div.HasAttribute("id"));
+            Assert.AreEqual("", div.Id);
+        }
+    }
+}

--- a/src/AngleSharp/Dom/ElementExtensions.cs
+++ b/src/AngleSharp/Dom/ElementExtensions.cs
@@ -277,7 +277,7 @@ namespace AngleSharp.Dom
         {
             var id = element.Id;
             var hash = element.Owner?.Location.Hash;
-            return id != null && hash != null && String.Compare(id, 0, hash, hash.Length > 0 ? 1 : 0, Int32.MaxValue) == 0;
+            return !String.IsNullOrEmpty(id) && hash != null && String.Compare(id, 0, hash, hash.Length > 0 ? 1 : 0, Int32.MaxValue) == 0;
         }
 
         /// <summary>

--- a/src/AngleSharp/Dom/IElement.cs
+++ b/src/AngleSharp/Dom/IElement.cs
@@ -46,13 +46,15 @@ namespace AngleSharp.Dom
         ITokenList ClassList { get; }
 
         /// <summary>
-        /// Gets or sets the value of the class attribute.
+        /// Gets or sets the value of the class attribute. Returns the empty
+        /// string if the attribute is not present.
         /// </summary>
         [DomName("className")]
         String? ClassName { get; set; }
 
         /// <summary>
-        /// Gets or sets the id value of the element.
+        /// Gets or sets the id value of the element. Returns the empty string
+        /// if the attribute is not present.
         /// </summary>
         [DomName("id")]
         String? Id { get; set; }
@@ -263,7 +265,8 @@ namespace AngleSharp.Dom
         IElement? AssignedSlot { get; }
 
         /// <summary>
-        /// Gets the value of the slot attribute.
+        /// Gets the value of the slot attribute. Returns the empty string if
+        /// the attribute is not present.
         /// </summary>
         [DomName("slot")]
         String? Slot { get; set; }

--- a/src/AngleSharp/Dom/Internal/Element.cs
+++ b/src/AngleSharp/Dom/Internal/Element.cs
@@ -64,7 +64,7 @@ namespace AngleSharp.Dom
         /// <inheritdoc />
         public String? Slot
         {
-            get => this.GetOwnAttribute(AttributeNames.Slot);
+            get => this.GetOwnAttribute(AttributeNames.Slot) ?? String.Empty;
             set => this.SetOwnAttribute(AttributeNames.Slot, value);
         }
 
@@ -121,14 +121,14 @@ namespace AngleSharp.Dom
         /// <inheritdoc />
         public String? ClassName
         {
-            get => this.GetOwnAttribute(AttributeNames.Class);
+            get => this.GetOwnAttribute(AttributeNames.Class) ?? String.Empty;
             set => this.SetOwnAttribute(AttributeNames.Class, value);
         }
 
         /// <inheritdoc />
         public String? Id
         {
-            get => this.GetOwnAttribute(AttributeNames.Id);
+            get => this.GetOwnAttribute(AttributeNames.Id) ?? String.Empty;
             set => this.SetOwnAttribute(AttributeNames.Id, value);
         }
 

--- a/src/AngleSharp/Dom/Internal/TextNode.cs
+++ b/src/AngleSharp/Dom/Internal/TextNode.cs
@@ -74,7 +74,7 @@ namespace AngleSharp.Dom
                 if (parent.IsShadow())
                 {
                     var tree = parent.ShadowRoot;
-                    return tree?.GetAssignedSlot(null);
+                    return tree?.GetAssignedSlot(String.Empty);
                 }
 
                 return null;

--- a/src/AngleSharp/Html/Dom/IHtmlElement.cs
+++ b/src/AngleSharp/Html/Dom/IHtmlElement.cs
@@ -19,13 +19,15 @@ namespace AngleSharp.Html.Dom
         String? Language { get; set; }
 
         /// <summary>
-        /// Gets or sets the value of the title attribute.
+        /// Gets or sets the value of the title attribute. Returns the empty
+        /// string if the attribute is not present.
         /// </summary>
         [DomName("title")]
         String? Title { get; set; }
 
         /// <summary>
-        /// Gets or sets the value of the dir attribute.
+        /// Gets or sets the value of the dir attribute. Returns the empty
+        /// string if the attribute is not present.
         /// </summary>
         [DomName("dir")]
         String? Direction { get; set; }

--- a/src/AngleSharp/Html/Dom/IHtmlSlotElement.cs
+++ b/src/AngleSharp/Html/Dom/IHtmlSlotElement.cs
@@ -12,7 +12,8 @@ namespace AngleSharp.Html.Dom
     public interface IHtmlSlotElement : IHtmlElement
     {
         /// <summary>
-        /// Gets or sets the name attribute.
+        /// Gets or sets the name attribute. Returns the empty string if the
+        /// attribute is not present.
         /// </summary>
         [DomName("name")]
         String? Name { get; set; }

--- a/src/AngleSharp/Html/Dom/Internal/HtmlElement.cs
+++ b/src/AngleSharp/Html/Dom/Internal/HtmlElement.cs
@@ -511,14 +511,14 @@ namespace AngleSharp.Html.Dom
         /// <inheritdoc />
         public String? Title
         {
-            get => this.GetOwnAttribute(AttributeNames.Title);
+            get => this.GetOwnAttribute(AttributeNames.Title) ?? String.Empty;
             set => this.SetOwnAttribute(AttributeNames.Title, value);
         }
 
         /// <inheritdoc />
         public String? Direction
         {
-            get => this.GetOwnAttribute(AttributeNames.Dir);
+            get => this.GetOwnAttribute(AttributeNames.Dir) ?? String.Empty;
             set => this.SetOwnAttribute(AttributeNames.Dir, value);
         }
 

--- a/src/AngleSharp/Html/Dom/Internal/HtmlLinkElementExtensions.cs
+++ b/src/AngleSharp/Html/Dom/Internal/HtmlLinkElementExtensions.cs
@@ -1,5 +1,6 @@
 ﻿namespace AngleSharp.Html.Dom
 {
+    using AngleSharp.Dom;
     using AngleSharp.Html;
     using AngleSharp.Text;
     using System;
@@ -18,7 +19,7 @@
         /// <returns>True if the link hosts a persistent stylesheet.</returns>
         public static Boolean IsPersistent(this IHtmlLinkElement link)
         {
-            return link.Relation.Isi(LinkRelNames.StyleSheet) && link.Title is null;
+            return link.Relation.Isi(LinkRelNames.StyleSheet) && !link.HasAttribute(AttributeNames.Title);
         }
 
         /// <summary>
@@ -28,7 +29,7 @@
         /// <returns>True if the link hosts a preferred stylesheet.</returns>
         public static Boolean IsPreferred(this IHtmlLinkElement link)
         {
-            return link.Relation.Isi(LinkRelNames.StyleSheet) && link.Title != null;
+            return link.Relation.Isi(LinkRelNames.StyleSheet) && link.HasAttribute(AttributeNames.Title);
         }
 
         /// <summary>
@@ -39,7 +40,7 @@
         public static Boolean IsAlternate(this IHtmlLinkElement link)
         {
             var relation = link.RelationList;
-            return relation.Contains(LinkRelNames.StyleSheet) && relation.Contains(LinkRelNames.Alternate) && link.Title != null;
+            return relation.Contains(LinkRelNames.StyleSheet) && relation.Contains(LinkRelNames.Alternate) && link.HasAttribute(AttributeNames.Title);
         }
 
         #endregion

--- a/src/AngleSharp/Html/Dom/Internal/HtmlSlotElement.cs
+++ b/src/AngleSharp/Html/Dom/Internal/HtmlSlotElement.cs
@@ -22,7 +22,7 @@ namespace AngleSharp.Html.Dom
 
         public String? Name
         {
-            get => this.GetOwnAttribute(AttributeNames.Name);
+            get => this.GetOwnAttribute(AttributeNames.Name) ?? String.Empty;
             set => this.SetOwnAttribute(AttributeNames.Name, value);
         }
 


### PR DESCRIPTION
A reflected `DOMString` IDL attribute returns the empty string when the content attribute is absent (https://html.spec.whatwg.org/multipage/common-dom-interfaces.html#reflecting-content-attributes-in-idl-attributes), but AngleSharp returned `null`, so a script binding that projects the property straight through hands `null` where a browser hands `""`. This is the first step, limited to the members that every element carries, so the change stays reviewable; the CLR types stay `String?` and the setters are untouched.

Changed: `IElement.Id` (`id`), `IElement.ClassName` (`class`), `IElement.Slot` (`slot`), `IHtmlElement.Title` (`title`), `IHtmlElement.Direction` (`dir`) and `IHtmlSlotElement.Name` (`name`, the counterpart of `slot`, which has to move with it so an unnamed `<slot>` still matches an element without a `slot` attribute). `IHtmlElement.AccessKey` already did this.

Three call sites relied on the `null`: `:target` now requires a non-empty `id` rather than a non-null one; `IsPersistent`/`IsPreferred`/`IsAlternate` now ask whether the link has a `title` attribute, which is what the stylesheet-set rules actually say (https://html.spec.whatwg.org/multipage/semantics.html#link-type-stylesheet); and a text node's default slot is looked up by the empty name. Two `nth-child` selector tests asserted `null` for a missing `class` and now assert `""`, with a comment saying why.

A follow-up can cover the remaining per-element reflections (`alt`, `src`, `href`, `type`, `placeholder`, `name`, `value`, …). Those need to be taken one at a time, because several look like plain reflections and are not: `crossOrigin` is `DOMString?` and must keep returning `null`, `contentEditable` is an enumerated attribute whose missing default is `"inherit"`, `HTMLOptionElement.value`/`label` fall back to the element's text, and `input.value` has value modes. `dir` is also "limited to only known values", so an unknown value should reflect as `""` too — left out of this PR.

Fixes #1304
