### PR TITLE
Added the DomSameObject annotation for the [SameObject] IDL members

### DIFF
--- a/src/AngleSharp.Core.Tests/Library/DomSameObjectTests.cs
+++ b/src/AngleSharp.Core.Tests/Library/DomSameObjectTests.cs
@@ -1,0 +1,73 @@
+namespace AngleSharp.Core.Tests.Library
+{
+    using AngleSharp.Attributes;
+    using AngleSharp.Dom;
+    using AngleSharp.Html.Dom;
+    using NUnit.Framework;
+    using System;
+    using System.Linq;
+    using System.Reflection;
+
+    [TestFixture]
+    public class DomSameObjectTests
+    {
+        private static PropertyInfo[] GetAnnotatedProperties()
+        {
+            return typeof(IElement).Assembly.GetTypes()
+                .SelectMany(m => m.GetProperties())
+                .Where(m => m.GetCustomAttribute<DomSameObjectAttribute>() != null)
+                .ToArray();
+        }
+
+        [Test]
+        public void SameObjectMembersAreReadOnlyPropertiesOfAReferenceType()
+        {
+            var properties = GetAnnotatedProperties();
+
+            Assert.IsNotEmpty(properties);
+
+            foreach (var property in properties)
+            {
+                var name = property.DeclaringType.Name + "." + property.Name;
+                Assert.IsFalse(property.PropertyType.IsValueType, name + " must return a reference type");
+                Assert.IsNotNull(property.GetMethod, name + " must be readable");
+                Assert.IsNull(property.SetMethod, name + " must be read only");
+                Assert.IsNotEmpty(property.GetCustomAttributes<DomNameAttribute>(), name + " must be a DOM member");
+            }
+        }
+
+        [TestCase(typeof(INode), nameof(INode.ChildNodes))]
+        [TestCase(typeof(IElement), nameof(IElement.Attributes))]
+        [TestCase(typeof(IElement), nameof(IElement.ClassList))]
+        [TestCase(typeof(IParentNode), nameof(IParentNode.Children))]
+        [TestCase(typeof(IDocument), nameof(IDocument.Implementation))]
+        [TestCase(typeof(IDocument), nameof(IDocument.Forms))]
+        [TestCase(typeof(IDocumentStyle), nameof(IDocumentStyle.StyleSheets))]
+        [TestCase(typeof(IStyleSheet), nameof(IStyleSheet.Media))]
+        [TestCase(typeof(IHtmlElement), nameof(IHtmlElement.Dataset))]
+        [TestCase(typeof(IHtmlFormElement), nameof(IHtmlFormElement.Elements))]
+        [TestCase(typeof(IHtmlSelectElement), nameof(IHtmlSelectElement.Options))]
+        [TestCase(typeof(IHtmlTableElement), nameof(IHtmlTableElement.Rows))]
+        [TestCase(typeof(IHtmlTableRowElement), nameof(IHtmlTableRowElement.Cells))]
+        [TestCase(typeof(IHtmlAnchorElement), nameof(IHtmlAnchorElement.RelationList))]
+        [TestCase(typeof(IHtmlOutputElement), nameof(IHtmlOutputElement.HtmlFor))]
+        public void MemberIsMarkedAsSameObject(Type type, String name)
+        {
+            var property = type.GetProperty(name);
+
+            Assert.IsNotNull(property);
+            Assert.IsNotNull(property.GetCustomAttribute<DomSameObjectAttribute>());
+        }
+
+        [TestCase(typeof(IHtmlTemplateElement), nameof(IHtmlTemplateElement.Content))]
+        [TestCase(typeof(IHtmlInputElement), nameof(IHtmlInputElement.Files))]
+        [TestCase(typeof(IValidation), nameof(IValidation.Validity))]
+        public void MemberIsNotMarkedAsSameObject(Type type, String name)
+        {
+            var property = type.GetProperty(name);
+
+            Assert.IsNotNull(property);
+            Assert.IsNull(property.GetCustomAttribute<DomSameObjectAttribute>());
+        }
+    }
+}

--- a/src/AngleSharp/Attributes/DomSameObjectAttribute.cs
+++ b/src/AngleSharp/Attributes/DomSameObjectAttribute.cs
@@ -1,0 +1,14 @@
+namespace AngleSharp.Attributes
+{
+    using System;
+
+    /// <summary>
+    /// Decorates a read only attribute declaration whose type is an interface
+    /// type. It indicates that reading the attribute always yields the same
+    /// object, i.e., the value is not re-created on every access.
+    /// </summary>
+    [AttributeUsage(AttributeTargets.Property, Inherited = false)]
+    public sealed class DomSameObjectAttribute : Attribute
+    {
+    }
+}

--- a/src/AngleSharp/Dom/IDocument.cs
+++ b/src/AngleSharp/Dom/IDocument.cs
@@ -18,18 +18,21 @@ namespace AngleSharp.Dom
         /// Gets a list of all elements in the document.
         /// </summary>
         [DomName("all")]
+        [DomSameObject]
         IHtmlAllCollection All { get; }
 
         /// <summary>
         /// Gets a list of all of the anchors in the document.
         /// </summary>
         [DomName("anchors")]
+        [DomSameObject]
         IHtmlCollection<IHtmlAnchorElement> Anchors { get; }
 
         /// <summary>
         /// Gets the DOM implementation associated with the current document.
         /// </summary>
         [DomName("implementation")]
+        [DomSameObject]
         IImplementation Implementation { get; }
 
         /// <summary>
@@ -381,18 +384,21 @@ namespace AngleSharp.Dom
         /// Gets the forms in the document.
         /// </summary>
         [DomName("forms")]
+        [DomSameObject]
         IHtmlCollection<IHtmlFormElement> Forms { get; }
 
         /// <summary>
         /// Gets the images in the document.
         /// </summary>
         [DomName("images")]
+        [DomSameObject]
         IHtmlCollection<IHtmlImageElement> Images { get; }
 
         /// <summary>
         /// Gets the scripts in the document.
         /// </summary>
         [DomName("scripts")]
+        [DomSameObject]
         IHtmlCollection<IHtmlScriptElement> Scripts { get; }
 
         /// <summary>
@@ -400,6 +406,7 @@ namespace AngleSharp.Dom
         /// </summary>
         [DomName("embeds")]
         [DomName("plugins")]
+        [DomSameObject]
         IHtmlCollection<IHtmlEmbedElement> Plugins { get; }
 
         /// <summary>
@@ -414,6 +421,7 @@ namespace AngleSharp.Dom
         /// with a value for the href attribute.
         /// </summary>
         [DomName("links")]
+        [DomSameObject]
         IHtmlCollection<IElement> Links { get; }
 
         /// <summary>

--- a/src/AngleSharp/Dom/IDocumentStyle.cs
+++ b/src/AngleSharp/Dom/IDocumentStyle.cs
@@ -15,6 +15,7 @@ namespace AngleSharp.Dom
         /// into or embedded in a document.
         /// </summary>
         [DomName("styleSheets")]
+        [DomSameObject]
         IStyleSheetList StyleSheets { get; }
 
         /// <summary>

--- a/src/AngleSharp/Dom/IElement.cs
+++ b/src/AngleSharp/Dom/IElement.cs
@@ -37,12 +37,14 @@ namespace AngleSharp.Dom
         /// Gets the sequence of associated attributes.
         /// </summary>
         [DomName("attributes")]
+        [DomSameObject]
         INamedNodeMap Attributes { get; }
 
         /// <summary>
         /// Gets the list of class names.
         /// </summary>
         [DomName("classList")]
+        [DomSameObject]
         ITokenList ClassList { get; }
 
         /// <summary>

--- a/src/AngleSharp/Dom/IMutationRecord.cs
+++ b/src/AngleSharp/Dom/IMutationRecord.cs
@@ -25,18 +25,21 @@ namespace AngleSharp.Dom
         /// the node whose children changed.
         /// </summary>
         [DomName("target")]
+        [DomSameObject]
         INode Target { get; }
 
         /// <summary>
         /// Gets the nodes added, or null.
         /// </summary>
         [DomName("addedNodes")]
+        [DomSameObject]
         INodeList? Added { get; }
 
         /// <summary>
         /// Gets the nodes removed, or null.
         /// </summary>
         [DomName("removedNodes")]
+        [DomSameObject]
         INodeList? Removed { get; }
 
         /// <summary>

--- a/src/AngleSharp/Dom/INode.cs
+++ b/src/AngleSharp/Dom/INode.cs
@@ -35,6 +35,7 @@ namespace AngleSharp.Dom
         /// NodeList object is automatically updated.
         /// </summary>
         [DomName("childNodes")]
+        [DomSameObject]
         INodeList ChildNodes { get; }
 
         /// <summary>

--- a/src/AngleSharp/Dom/INodeIterator.cs
+++ b/src/AngleSharp/Dom/INodeIterator.cs
@@ -16,6 +16,7 @@ namespace AngleSharp.Dom
         /// NodeIterator was created.
         /// </summary>
         [DomName("root")]
+        [DomSameObject]
         INode Root { get; }
 
         /// <summary>

--- a/src/AngleSharp/Dom/IParentNode.cs
+++ b/src/AngleSharp/Dom/IParentNode.cs
@@ -15,6 +15,7 @@ namespace AngleSharp.Dom
         /// Gets the child elements.
         /// </summary>
         [DomName("children")]
+        [DomSameObject]
         IHtmlCollection<IElement> Children { get; }
 
         /// <summary>

--- a/src/AngleSharp/Dom/IShadowRoot.cs
+++ b/src/AngleSharp/Dom/IShadowRoot.cs
@@ -37,6 +37,7 @@ namespace AngleSharp.Dom
         /// Gets the shadow root style sheets.
         /// </summary>
         [DomName("styleSheets")]
+        [DomSameObject]
         IStyleSheetList StyleSheets { get; }
     }
 }

--- a/src/AngleSharp/Dom/IStyleSheet.cs
+++ b/src/AngleSharp/Dom/IStyleSheet.cs
@@ -44,6 +44,7 @@
         /// specified, the MediaList is empty.
         /// </summary>
         [DomName("media")]
+        [DomSameObject]
         [DomPutForwards("mediaText")]
         IMediaList Media { get; }
 

--- a/src/AngleSharp/Dom/ITreeWalker.cs
+++ b/src/AngleSharp/Dom/ITreeWalker.cs
@@ -14,6 +14,7 @@ namespace AngleSharp.Dom
         /// TreeWalker was created.
         /// </summary>
         [DomName("root")]
+        [DomSameObject]
         INode Root { get; }
 
         /// <summary>

--- a/src/AngleSharp/Html/Dom/IHtmlAnchorElement.cs
+++ b/src/AngleSharp/Html/Dom/IHtmlAnchorElement.cs
@@ -41,6 +41,7 @@ namespace AngleSharp.Html.Dom
         /// Gets the rel HTML attribute, as a list of tokens.
         /// </summary>
         [DomName("relList")]
+        [DomSameObject]
         ITokenList RelationList { get; }
 
         /// <summary>

--- a/src/AngleSharp/Html/Dom/IHtmlAreaElement.cs
+++ b/src/AngleSharp/Html/Dom/IHtmlAreaElement.cs
@@ -60,6 +60,7 @@ namespace AngleSharp.Html.Dom
         /// document to the linked resource, as a list of tokens.
         /// </summary>
         [DomName("relList")]
+        [DomSameObject]
         ITokenList RelationList { get; }
 
         /// <summary>

--- a/src/AngleSharp/Html/Dom/IHtmlDataListElement.cs
+++ b/src/AngleSharp/Html/Dom/IHtmlDataListElement.cs
@@ -13,6 +13,7 @@
         /// Gets the associated options.
         /// </summary>
         [DomName("options")]
+        [DomSameObject]
         IHtmlCollection<IHtmlOptionElement> Options { get; }
     }
 }

--- a/src/AngleSharp/Html/Dom/IHtmlElement.cs
+++ b/src/AngleSharp/Html/Dom/IHtmlElement.cs
@@ -35,6 +35,7 @@ namespace AngleSharp.Html.Dom
         /// one entry for each custom data attribute.
         /// </summary>
         [DomName("dataset")]
+        [DomSameObject]
         IStringMap Dataset { get; }
 
         /// <summary>

--- a/src/AngleSharp/Html/Dom/IHtmlFieldSetElement.cs
+++ b/src/AngleSharp/Html/Dom/IHtmlFieldSetElement.cs
@@ -37,6 +37,7 @@ namespace AngleSharp.Html.Dom
         /// Gets the elements belonging to this field set.
         /// </summary>
         [DomName("elements")]
+        [DomSameObject]
         IHtmlFormControlsCollection Elements { get; }
     }
 }

--- a/src/AngleSharp/Html/Dom/IHtmlFormElement.cs
+++ b/src/AngleSharp/Html/Dom/IHtmlFormElement.cs
@@ -76,6 +76,7 @@ namespace AngleSharp.Html.Dom
         /// Gets all the form controls belonging to this form element.
         /// </summary>
         [DomName("elements")]
+        [DomSameObject]
         IHtmlFormControlsCollection Elements { get; }
 
         /// <summary>

--- a/src/AngleSharp/Html/Dom/IHtmlInlineFrameElement.cs
+++ b/src/AngleSharp/Html/Dom/IHtmlInlineFrameElement.cs
@@ -33,6 +33,7 @@ namespace AngleSharp.Html.Dom
         /// Gets the tokens of the sandbox attribute.
         /// </summary>
         [DomName("sandbox")]
+        [DomSameObject]
         ISettableTokenList Sandbox { get; }
 
         /// <summary>

--- a/src/AngleSharp/Html/Dom/IHtmlLinkElement.cs
+++ b/src/AngleSharp/Html/Dom/IHtmlLinkElement.cs
@@ -39,6 +39,7 @@ namespace AngleSharp.Html.Dom
         /// Gets the list of relations contained in the rel attribute.
         /// </summary>
         [DomName("relList")]
+        [DomSameObject]
         ITokenList RelationList { get; }
 
         /// <summary>
@@ -63,6 +64,7 @@ namespace AngleSharp.Html.Dom
         /// Gets the list of sizes defined in the sizes attribute.
         /// </summary>
         [DomName("sizes")]
+        [DomSameObject]
         ISettableTokenList Sizes { get; }
 
         /// <summary>

--- a/src/AngleSharp/Html/Dom/IHtmlMapElement.cs
+++ b/src/AngleSharp/Html/Dom/IHtmlMapElement.cs
@@ -21,6 +21,7 @@ namespace AngleSharp.Html.Dom
         /// associated to this map.
         /// </summary>
         [DomName("areas")]
+        [DomSameObject]
         IHtmlCollection<IHtmlAreaElement> Areas { get; }
 
         /// <summary>

--- a/src/AngleSharp/Html/Dom/IHtmlMediaElement.cs
+++ b/src/AngleSharp/Html/Dom/IHtmlMediaElement.cs
@@ -119,18 +119,21 @@ namespace AngleSharp.Html.Dom
         /// Gets a list of contained audio tracks.
         /// </summary>
         [DomName("audioTracks")]
+        [DomSameObject]
         IAudioTrackList? AudioTracks { get; }
 
         /// <summary>
         /// Gets a list of contained video tracks.
         /// </summary>
         [DomName("videoTracks")]
+        [DomSameObject]
         IVideoTrackList? VideoTracks { get; }
 
         /// <summary>
         /// Gets a list of contained text tracks.
         /// </summary>
         [DomName("textTracks")]
+        [DomSameObject]
         ITextTrackList? TextTracks { get; }
 
         /// <summary>

--- a/src/AngleSharp/Html/Dom/IHtmlOutputElement.cs
+++ b/src/AngleSharp/Html/Dom/IHtmlOutputElement.cs
@@ -14,6 +14,7 @@ namespace AngleSharp.Html.Dom
         /// Gets or sets the IDs of the input elements.
         /// </summary>
         [DomName("htmlFor")]
+        [DomSameObject]
         ISettableTokenList HtmlFor { get; }
 
         /// <summary>

--- a/src/AngleSharp/Html/Dom/IHtmlSelectElement.cs
+++ b/src/AngleSharp/Html/Dom/IHtmlSelectElement.cs
@@ -63,6 +63,7 @@ namespace AngleSharp.Html.Dom
         /// Gets the set of options that are selected.
         /// </summary>
         [DomName("selectedOptions")]
+        [DomSameObject]
         IHtmlCollection<IHtmlOptionElement> SelectedOptions { get; }
 
         /// <summary>
@@ -75,6 +76,7 @@ namespace AngleSharp.Html.Dom
         /// Gets the set of option elements contained by this element. 
         /// </summary>
         [DomName("options")]
+        [DomSameObject]
         IHtmlOptionsCollection Options { get; }
         
         /// <summary>

--- a/src/AngleSharp/Html/Dom/IHtmlTableElement.cs
+++ b/src/AngleSharp/Html/Dom/IHtmlTableElement.cs
@@ -71,6 +71,7 @@ namespace AngleSharp.Html.Dom
         /// Gets the assigned body sections.
         /// </summary>
         [DomName("tBodies")]
+        [DomSameObject]
         IHtmlCollection<IHtmlTableSectionElement> Bodies { get; }
 
         /// <summary>
@@ -84,6 +85,7 @@ namespace AngleSharp.Html.Dom
         /// Gets the assigned table rows.
         /// </summary>
         [DomName("rows")]
+        [DomSameObject]
         IHtmlCollection<IHtmlTableRowElement> Rows { get; }
 
         /// <summary>

--- a/src/AngleSharp/Html/Dom/IHtmlTableRowElement.cs
+++ b/src/AngleSharp/Html/Dom/IHtmlTableRowElement.cs
@@ -27,6 +27,7 @@
         /// Gets the assigned table cells.
         /// </summary>
         [DomName("cells")]
+        [DomSameObject]
         IHtmlCollection<IHtmlTableCellElement> Cells { get; }
 
         /// <summary>

--- a/src/AngleSharp/Html/Dom/IHtmlTableSectionElement.cs
+++ b/src/AngleSharp/Html/Dom/IHtmlTableSectionElement.cs
@@ -14,6 +14,7 @@
         /// Gets the assigned table rows.
         /// </summary>
         [DomName("rows")]
+        [DomSameObject]
         IHtmlCollection<IHtmlTableRowElement> Rows { get; }
 
         /// <summary>


### PR DESCRIPTION
`DomSameObjectAttribute` is a marker in `AngleSharp.Attributes`, in the same shape as `DomPutForwards`/`DomLenientThis` and with no behaviour of its own, so a binding can tell which members WebIDL declares `[SameObject]` and cache one projected object per owner instead of carrying a hand-written list. The members below were taken from the extracted IDL of the three standards, not from the prose.

DOM (https://dom.spec.whatwg.org/): `Node.childNodes`, `Element.attributes`, `Element.classList`, `ParentNode.children`, `Document.implementation`, `MutationRecord.target`/`addedNodes`/`removedNodes`, `NodeIterator.root`, `TreeWalker.root`.

HTML (https://html.spec.whatwg.org/multipage/): `Document.all`/`anchors`/`images`/`embeds`/`plugins`/`links`/`forms`/`scripts` (`embeds` and `plugins` are one property here, so one marker covers both), `HTMLElement.dataset`, `HTMLFormElement.elements`, `HTMLFieldSetElement.elements`, `HTMLSelectElement.options`/`selectedOptions`, `HTMLDataListElement.options`, `HTMLOutputElement.htmlFor`, `HTMLTableElement.rows`/`tBodies`, `HTMLTableSectionElement.rows`, `HTMLTableRowElement.cells`, `HTMLLinkElement.relList`/`sizes`, `HTMLAnchorElement.relList`, `HTMLAreaElement.relList`, `HTMLIFrameElement.sandbox`, `HTMLMapElement.areas`, `HTMLMediaElement.audioTracks`/`videoTracks`/`textTracks`.

CSSOM (https://drafts.csswg.org/cssom/): `StyleSheet.media`, and `styleSheets` on both `IDocumentStyle` and `IShadowRoot`.

Left out on purpose: `HTMLTemplateElement.content` and `HTMLInputElement.files` look like candidates but are not `[SameObject]` in the IDL; `validity` is `[SameObject]` only on `HTMLFieldSetElement`, while AngleSharp declares it once on the shared `IValidation`, so marking it there would over-apply it to five other controls. `CSSStyleSheet.cssRules` and `ElementCSSInlineStyle.style` live in AngleSharp.Css. The test walks the assembly and asserts every annotated member is a read-only property of a reference type carrying `[DomName]`, plus a list of members that must and must not carry it.

Fixes #1305
