### PR TITLE
The HTML parser tracks an exception escaping host code instead of throwing it or dropping it

### DIFF
--- a/src/AngleSharp.Core.Tests/Library/BasicScripting.cs
+++ b/src/AngleSharp.Core.Tests/Library/BasicScripting.cs
@@ -1,10 +1,12 @@
-namespace AngleSharp.Core.Tests.Library
+﻿namespace AngleSharp.Core.Tests.Library
 {
     using AngleSharp;
     using AngleSharp.Browser;
     using AngleSharp.Core.Tests.Mocks;
     using AngleSharp.Dom;
     using AngleSharp.Html.Dom;
+    using AngleSharp.Html.Dom.Events;
+    using AngleSharp.Html.Parser;
     using AngleSharp.Io;
     using AngleSharp.Text;
     using NUnit.Framework;
@@ -372,6 +374,136 @@ namespace AngleSharp.Core.Tests.Library
             Assert.IsTrue(didRun);
             Assert.IsNull(currentScript);
             Assert.IsNull(document.CurrentScript);
+        }
+
+        [Test]
+        public async Task ParsingSynchronouslyTracksExceptionEscapingHostEventListener_Issue1309()
+        {
+            var scripting = new CallbackScriptEngine(_ => { });
+            var context = BrowsingContext.New(Configuration.Default.WithScripts(scripting));
+            var tracked = TrackErrorAsync(context);
+            var parser = context.GetService<IHtmlParser>();
+            ThrowFromListener(parser, EventNames.BeforeScriptExecute, "from the host");
+
+            var document = parser.ParseDocument("<body><script type='c-sharp'>//...</script>");
+            var error = await AwaitTrackedErrorAsync(tracked);
+
+            Assert.IsNotNull(document);
+            Assert.IsInstanceOf<InvalidOperationException>(error);
+            Assert.AreEqual("from the host", error.Message);
+        }
+
+        [Test]
+        public async Task ParsingAsynchronouslyTracksExceptionEscapingHostEventListener_Issue1309()
+        {
+            var scripting = new CallbackScriptEngine(_ => { });
+            var context = BrowsingContext.New(Configuration.Default.WithScripts(scripting));
+            var tracked = TrackErrorAsync(context);
+            var parser = context.GetService<IHtmlParser>();
+            ThrowFromListener(parser, EventNames.BeforeScriptExecute, "from the host");
+
+            var document = await parser.ParseDocumentAsync("<body><script type='c-sharp'>//...</script>");
+            var error = await AwaitTrackedErrorAsync(tracked);
+
+            Assert.IsNotNull(document);
+            Assert.IsInstanceOf<InvalidOperationException>(error);
+            Assert.AreEqual("from the host", error.Message);
+        }
+
+        [Test]
+        public async Task ParsingSynchronouslyTracksExceptionEscapingDomContentLoadedListener_Issue1309()
+        {
+            var context = BrowsingContext.New(Configuration.Default);
+            var tracked = TrackErrorAsync(context);
+            var parser = context.GetService<IHtmlParser>();
+            ThrowFromListener(parser, EventNames.DomContentLoaded, "from the host");
+
+            var document = parser.ParseDocument("<body><p>text</p>");
+            var error = await AwaitTrackedErrorAsync(tracked);
+
+            Assert.IsNotNull(document);
+            Assert.IsInstanceOf<InvalidOperationException>(error);
+            Assert.AreEqual("from the host", error.Message);
+        }
+
+        [Test]
+        public async Task ParsingAsynchronouslyTracksExceptionEscapingDomContentLoadedListener_Issue1309()
+        {
+            var context = BrowsingContext.New(Configuration.Default);
+            var tracked = TrackErrorAsync(context);
+            var parser = context.GetService<IHtmlParser>();
+            ThrowFromListener(parser, EventNames.DomContentLoaded, "from the host");
+
+            var document = await parser.ParseDocumentAsync("<body><p>text</p>");
+            var error = await AwaitTrackedErrorAsync(tracked);
+
+            Assert.IsNotNull(document);
+            Assert.IsInstanceOf<InvalidOperationException>(error);
+            Assert.AreEqual("from the host", error.Message);
+        }
+
+        [Test]
+        public async Task FailingScriptingServiceIsTrackedInsteadOfFaultingTheParse_Issue1309()
+        {
+            var scripting = new FailingScriptEngine("from the scripting service");
+            var context = BrowsingContext.New(Configuration.Default.WithScripts(scripting));
+            var tracked = TrackErrorAsync(context);
+            var parser = context.GetService<IHtmlParser>();
+
+            var document = await parser.ParseDocumentAsync("<body><script type='c-sharp'>//...</script>");
+            var error = await AwaitTrackedErrorAsync(tracked);
+
+            Assert.IsNotNull(document);
+            Assert.IsInstanceOf<InvalidOperationException>(error);
+            Assert.AreEqual("from the scripting service", error.Message);
+        }
+
+        [Test]
+        public async Task ReadyStateBecomesInteractiveBeforeDomContentLoaded_Issue1309()
+        {
+            var scripting = new CallbackScriptEngine(_ => { });
+            var context = BrowsingContext.New(Configuration.Default.WithScripts(scripting));
+            var parser = context.GetService<IHtmlParser>();
+            var observed = new List<String>();
+
+            parser.Parsing += (_, ev) =>
+            {
+                var parsed = ((HtmlParseEvent)ev).Document;
+                parsed.ReadyStateChanged += (_, _) => observed.Add(parsed.ReadyState.ToString());
+                parsed.AddEventListener(EventNames.DomContentLoaded, (_, _) => observed.Add("DOMContentLoaded"));
+                parsed.AddEventListener(EventNames.Load, (_, _) => observed.Add("load"));
+            };
+
+            var document = await parser.ParseDocumentAsync("<body><script type='c-sharp'>//...</script><p>text</p>");
+
+            Assert.AreEqual(DocumentReadyState.Complete, document.ReadyState);
+            Assert.AreEqual("Interactive, DOMContentLoaded, Complete, load", String.Join(", ", observed));
+        }
+
+        /// <summary>
+        /// Listens for the exceptions the browsing context tracks, i.e. what a host sees of a
+        /// failure the parser handled instead of throwing.
+        /// </summary>
+        private static Task<Exception> TrackErrorAsync(IBrowsingContext context)
+        {
+            var tcs = new TaskCompletionSource<Exception>();
+            context.AddEventListener(EventNames.Error, (_, ev) =>
+                tcs.TrySetResult(((AngleSharp.Browser.Dom.Events.TrackEvent)ev).Error));
+            return tcs.Task;
+        }
+
+        private static async Task<Exception> AwaitTrackedErrorAsync(Task<Exception> tracked)
+        {
+            var completed = await Task.WhenAny(tracked, Task.Delay(5000));
+            Assert.AreSame(tracked, completed, "The browsing context did not track any error.");
+            return await tracked;
+        }
+
+        private static void ThrowFromListener(IHtmlParser parser, String eventName, String message)
+        {
+            // Captured, as beforescriptexecute is fired at the script element without bubbling.
+            parser.Parsing += (_, ev) => ((HtmlParseEvent)ev).Document.AddEventListener(
+                eventName, (_, _) => throw new InvalidOperationException(message), capture: true);
         }
     }
 }

--- a/src/AngleSharp.Core.Tests/Mocks/FailingScriptEngine.cs
+++ b/src/AngleSharp.Core.Tests/Mocks/FailingScriptEngine.cs
@@ -1,0 +1,35 @@
+namespace AngleSharp.Core.Tests.Mocks
+{
+    using AngleSharp.Io;
+    using AngleSharp.Scripting;
+    using System;
+    using System.Threading;
+    using System.Threading.Tasks;
+
+    /// <summary>
+    /// A scripting service whose task faults only after yielding, i.e. the failure is
+    /// invisible to a caller that does not await the returned task.
+    /// </summary>
+    class FailingScriptEngine : IScriptingService
+    {
+        private readonly String _message;
+        private readonly String _type;
+
+        public FailingScriptEngine(String message, String type = null)
+        {
+            _message = message;
+            _type = type ?? "c-sharp";
+        }
+
+        public Boolean SupportsType(String mimeType)
+        {
+            return mimeType.Equals(_type, StringComparison.OrdinalIgnoreCase);
+        }
+
+        public async Task EvaluateScriptAsync(IResponse response, ScriptOptions options, CancellationToken cancel)
+        {
+            await Task.Yield();
+            throw new InvalidOperationException(_message);
+        }
+    }
+}

--- a/src/AngleSharp/Html/Parser/HtmlDomBuilder.cs
+++ b/src/AngleSharp/Html/Parser/HtmlDomBuilder.cs
@@ -816,7 +816,7 @@ namespace AngleSharp.Html.Parser
                         CloseCurrentNode();
 
                         _currentMode = HtmlTreeMode.AfterHead;
-                        _waiting = _document.WaitForReadyAsync(CancellationToken.None);
+                        WaitFor(_document.WaitForReadyAsync(CancellationToken.None));
                         return;
                     }
                     else if (tagName.Is(TagNames.Template))
@@ -4029,7 +4029,7 @@ namespace AngleSharp.Html.Parser
 
                     if (script.Prepare(_document))
                     {
-                        _waiting = RunScript(script);
+                        WaitFor(RunScript(script));
                     }
                 }
             }
@@ -4043,6 +4043,42 @@ namespace AngleSharp.Html.Parser
         {
             await _document.WaitForReadyAsync(CancellationToken.None).ConfigureAwait(false);
             await script.RunAsync(CancellationToken.None).ConfigureAwait(false);
+        }
+
+        /// <summary>
+        /// Remembers the task the parser still has to wait for.
+        /// </summary>
+        /// <remarks>
+        /// The parser never throws, so the task is wrapped in one that observes its failure
+        /// instead of propagating it. Without that wrapper an exception escaping host code -
+        /// a scripting service, an event listener, a resource task - is rethrown out of
+        /// ParseAsync, and dropped entirely by the synchronous Parse, which never awaits the
+        /// task at all.
+        /// </remarks>
+        /// <param name="task">The task the parser has to wait for.</param>
+        private void WaitFor(Task task)
+        {
+            // Nothing to observe when the task already succeeded, which is the common case
+            // for a document without scripts or pending downloads. No wrapper is allocated.
+            _waiting = task.Status == TaskStatus.RanToCompletion ? null : ObserveAsync(task);
+        }
+
+        /// <summary>
+        /// Awaits the given task and reports its failure instead of propagating it.
+        /// </summary>
+        /// <param name="task">The task to observe.</param>
+        private async Task ObserveAsync(Task task)
+        {
+            try
+            {
+                await task.ConfigureAwait(false);
+            }
+            catch (Exception ex)
+            {
+                /* The parser never throws; the same way a failing scripting service is
+                   reported by the script request processor, the failure is tracked. */
+                _document.TrackError(ex);
+            }
         }
 
         /// <summary>
@@ -4109,7 +4145,7 @@ namespace AngleSharp.Html.Parser
 
             if (_document.IsLoading)
             {
-                _waiting = _document.FinishLoadingAsync();
+                WaitFor(_document.FinishLoadingAsync());
             }
         }
 


### PR DESCRIPTION
`HtmlDomBuilder` keeps the task a parse still has to wait for in `_waiting`. `ParseAsync` awaits it, so an exception escaping host code on that task is rethrown out of `ParseDocumentAsync` — even though the parser itself never throws. The synchronous `Parse` never awaits that task at all, so the very same failure is dropped without a trace, leaving only a faulted task for the finalizer thread to notice.

Every assignment now goes through `WaitFor`, which wraps the task in one that observes the failure and reports it through `IConstructableDocument.TrackError` — the browsing context's `error` event carrying a `TrackEvent`, i.e. the channel `ScriptRequestProcessor` already uses for a failing scripting service. No new event type, no new public API. A task that already ran to completion is not wrapped, so a document with no scripts and no pending downloads allocates nothing extra.

## What was observed on `devel` (ff20ab6)

I built a repro for each half of the issue before writing any code, since an issue body is a hypothesis.

**The exception half is real, but not quite where the issue said.** `ScriptRequestProcessor.RunAsync` already wraps `IScriptingService.EvaluateScriptAsync` in a `try`/`catch` that calls `IBrowsingContext.TrackError`, so a service doing `await Task.Yield(); throw;` *is* reported today — 1 tracked error in all three parse shapes. What is not covered is everything else on the `_waiting` chain: the events the processor fires around the script, and `Document.FinishLoadingAsync`. With a host listener that throws:

| listener that throws | `ParseDocument` on `devel` | `ParseDocumentAsync` on `devel` |
| --- | --- | --- |
| `beforescriptexecute` | returns; **0** errors tracked | **throws** `InvalidOperationException` out of the parser |
| `afterscriptexecute` | returns; **0** errors tracked | **throws** |
| `DOMContentLoaded` | returns with `readyState == Interactive`; **0** errors tracked | **throws** |

After this change every one of those six cells returns a document and raises the context's `error` event exactly once, carrying the original exception.

One thing the sync path cannot fix: when the scripting service really is asynchronous, `ParseDocument` returns before the script has run, so the error is tracked after the call returns (measured: 0 tracked errors immediately after `ParseDocument`, 1 after 300 ms, and which of the two you see varies between runs). That is inherent to asking for a synchronous parse of an asynchronous script; the point here is only that the failure is no longer lost.

**The `readyState` half turned out to already hold, so there is no code for it.** `Document.FinishLoadingAsync` already sets `Interactive` before the deferred scripts and `DOMContentLoaded`, and `Complete` after them — `Complete` is in fact unreachable without passing through `Interactive`. Observed sequence on `devel` for `<body><script type='c-sharp'>…</script><p>text</p>`, identical for the sync and the async parse and with or without a scripting service:

```
readystatechange(Interactive) -> DOMContentLoaded -> readystatechange(Complete) -> load
```

So my third bullet in #1309 ("the document advances straight to complete during the parse") was simply wrong, and I have said so on the issue. The sequence is now pinned by a test instead, and `ReadyState` stays non-public exactly as you asked.

## Tests

Six new tests in `Library/BasicScripting.cs`, plus a `FailingScriptEngine` mock whose task faults only after yielding.

Run against unfixed `devel` first, as they should be: **four fail there** — the two synchronous ones with *"The browsing context did not track any error"*, the two asynchronous ones by `InvalidOperationException` escaping `ParseDocumentAsync`. The remaining two are characterization tests for the two premises that already held (`FailingScriptingServiceIsTrackedInsteadOfFaultingTheParse_Issue1309`, `ReadyStateBecomesInteractiveBeforeDomContentLoaded_Issue1309`); they pass on `devel` and are here to keep both contracts from regressing. All six pass with the change, on `net10.0` and on `net472`.

Full suite, Release, `net10.0`: 3798 passed / 37 failed / 2 skipped with `prefetched=false`, and 3796 / 37 / 4 with `prefetched=true`. The 37 are the `Library/FormSubmit.cs` (32) and `Library/ContextLoading.cs` (5) tests that talk to `http://anglesharp.azurewebsites.net/`, which is answering `403` at the moment; they are unrelated to this change.

## Left out

The location-setter half of #1309 — `location.host`/`pathname`/`port`/`protocol`/`search` starting a navigation on the setter's thread through the fire-and-forget `async void` in `Document.LocationChanged`. You did not agree to it, and it is arguably a host concern rather than a parser one, so it is not touched here. Happy to send it separately if you ever want it.

Fixes #1309 — although if you would rather keep the issue open for that remaining half, feel free to drop this line when merging.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01NqCcJrL3MJecCPRBMQsZyC
