### PR TITLE
Walk CSS combinators through a struct cursor instead of a delegate

### DIFF
--- a/src/AngleSharp.Core.Tests/Css/CssSelector.cs
+++ b/src/AngleSharp.Core.Tests/Css/CssSelector.cs
@@ -58,6 +58,20 @@ namespace AngleSharp.Core.Tests.Css
         }
 
         [Test]
+        public void DeepCombinatorCrossesTheShadowBoundary()
+        {
+            var document = "<div id='host'></div><div id='other'></div>".ToHtmlDocument();
+            var host = document.QuerySelector("#host");
+            var shadowRoot = host.AttachShadow(mode: ShadowRootMode.Open);
+
+            shadowRoot.InnerHtml = "<p id='inner'>text</p>";
+
+            Assert.AreEqual(1, shadowRoot.QuerySelectorAll("#host >>> p").Length);
+            Assert.AreEqual("inner", shadowRoot.QuerySelectorAll("#host >>> p")[0].GetAttribute("id"));
+            Assert.AreEqual(0, shadowRoot.QuerySelectorAll("#other >>> p").Length);
+        }
+
+        [Test]
         public void StrangeDashSelector()
         {
             var source = @"<ul>

--- a/src/AngleSharp/Css/Dom/Internal/ComplexSelector.cs
+++ b/src/AngleSharp/Css/Dom/Internal/ComplexSelector.cs
@@ -107,7 +107,7 @@ namespace AngleSharp.Css.Dom
                 _combinators.Add(new CombinatorSelector
                 {
                     Selector = selector,
-                    Transform = null,
+                    Kind = CssCombinatorKind.None,
                     Delimiter = null
                 });
                 IsReady = true;
@@ -121,7 +121,7 @@ namespace AngleSharp.Css.Dom
                 _combinators.Add(new CombinatorSelector
                 {
                     Selector = combinator.Change(selector),
-                    Transform = combinator.Transform,
+                    Kind = combinator.Kind,
                     Delimiter = combinator.Delimiter
                 });
             }
@@ -134,10 +134,12 @@ namespace AngleSharp.Css.Dom
         private Boolean MatchCascade(Int32 pos, IElement element, IElement? scope)
         {
             var combinatorSelector = _combinators[pos];
-            var newElements = combinatorSelector.Transform!(element);
+            var cursor = new CombinatorCursor(combinatorSelector.Kind, element);
 
-            foreach (var newElement in newElements)
+            while (cursor.MoveNext())
             {
+                var newElement = cursor.Current;
+
                 if (combinatorSelector.Selector.Match(newElement, scope) && (pos == 0 || MatchCascade(pos - 1, newElement, scope)))
                 {
                     return true;
@@ -154,7 +156,7 @@ namespace AngleSharp.Css.Dom
         private struct CombinatorSelector
         {
             public String? Delimiter;
-            public Func<IElement, IEnumerable<IElement>>? Transform;
+            public CssCombinatorKind Kind;
             public ISelector Selector;
         }
 

--- a/src/AngleSharp/Css/Parser/CombinatorCursor.cs
+++ b/src/AngleSharp/Css/Parser/CombinatorCursor.cs
@@ -1,0 +1,229 @@
+namespace AngleSharp.Css.Parser
+{
+    using AngleSharp.Dom;
+    using System;
+    using System.Collections.Generic;
+
+    /// <summary>
+    /// The traversal a combinator performs to get from a candidate element to
+    /// the elements its left-hand side may match.
+    /// </summary>
+    enum CssCombinatorKind : Byte
+    {
+        /// <summary>
+        /// No traversal; used by the concluding selector, which has no
+        /// combinator to its right.
+        /// </summary>
+        None,
+
+        /// <summary>
+        /// The parent element (&gt;).
+        /// </summary>
+        Child,
+
+        /// <summary>
+        /// The host of the containing shadow root (&gt;&gt;&gt;).
+        /// </summary>
+        Deep,
+
+        /// <summary>
+        /// All ancestor elements (space, or alternatively &gt;&gt;).
+        /// </summary>
+        Descendant,
+
+        /// <summary>
+        /// The immediately preceding element sibling (+).
+        /// </summary>
+        AdjacentSibling,
+
+        /// <summary>
+        /// All preceding element siblings (~).
+        /// </summary>
+        Sibling,
+
+        /// <summary>
+        /// The element itself (|).
+        /// </summary>
+        Namespace,
+
+        /// <summary>
+        /// The cells sharing the element's table column (||).
+        /// </summary>
+        Column,
+    }
+
+    /// <summary>
+    /// Walks the elements a combinator connects to a candidate element.
+    /// </summary>
+    /// <remarks>
+    /// A hand-rolled state machine rather than an iterator method: selector
+    /// matching creates one cursor per candidate element per combinator
+    /// position, and a compiler-generated iterator would allocate on that path.
+    /// </remarks>
+    struct CombinatorCursor
+    {
+        #region Fields
+
+        private readonly CssCombinatorKind _kind;
+        private readonly IElement _source;
+        private IElement? _current;
+        private Boolean _started;
+
+        // Only used by Sibling / Column, which cannot be walked through a
+        // single element reference.
+        private NodeList? _siblings;
+        private List<IElement>? _cells;
+        private Int32 _index;
+
+        #endregion
+
+        #region ctor
+
+        public CombinatorCursor(CssCombinatorKind kind, IElement source)
+        {
+            _kind = kind;
+            _source = source;
+            _current = null;
+            _started = false;
+            _siblings = null;
+            _cells = null;
+            _index = 0;
+        }
+
+        #endregion
+
+        #region Properties
+
+        /// <summary>
+        /// Gets the element the cursor moved to. Only valid after MoveNext
+        /// returned true.
+        /// </summary>
+        public readonly IElement Current => _current!;
+
+        #endregion
+
+        #region Methods
+
+        /// <summary>
+        /// Moves to the next element reachable through the combinator.
+        /// </summary>
+        /// <returns>True if there was another element, otherwise false.</returns>
+        public Boolean MoveNext()
+        {
+            switch (_kind)
+            {
+                case CssCombinatorKind.Descendant:
+                    return MoveAncestor();
+                case CssCombinatorKind.Sibling:
+                    return MoveSibling();
+                case CssCombinatorKind.Column:
+                    return MoveColumn();
+                default:
+                    return MoveSingle();
+            }
+        }
+
+        #endregion
+
+        #region Helpers
+
+        // The kinds that reach at most one element. The _started check has to come
+        // before the lookup: PreviousElementSibling scans the parent's child list,
+        // and the terminating call would otherwise pay for it a second time.
+        private Boolean MoveSingle()
+        {
+            if (_started)
+            {
+                return false;
+            }
+
+            _started = true;
+            _current = _kind switch
+            {
+                CssCombinatorKind.Child => _source.ParentElement,
+                CssCombinatorKind.Deep => _source.Parent is IShadowRoot shadowRoot ? shadowRoot.Host : null,
+                CssCombinatorKind.AdjacentSibling => _source.PreviousElementSibling,
+                CssCombinatorKind.Namespace => _source,
+                _ => null,
+            };
+
+            return _current != null;
+        }
+
+        private Boolean MoveAncestor()
+        {
+            var previous = _started ? _current : _source;
+            _started = true;
+            _current = previous?.ParentElement;
+            return _current != null;
+        }
+
+        private Boolean MoveSibling()
+        {
+            if (!_started)
+            {
+                _started = true;
+
+                // Walking PreviousElementSibling repeatedly is quadratic, since each step
+                // has to locate the element in its parent again. Scan the child list once
+                // and then walk it backwards by index.
+                if (_source is Node node && node.Parent is Node parent)
+                {
+                    var children = parent.ChildNodes;
+                    _siblings = children;
+
+                    for (var i = 0; i < children.Length; i++)
+                    {
+                        if (Object.ReferenceEquals(children[i], node))
+                        {
+                            _index = i;
+                            break;
+                        }
+                    }
+                }
+                else
+                {
+                    _current = _source;
+                }
+            }
+
+            if (_siblings != null)
+            {
+                while (_index > 0)
+                {
+                    var child = _siblings[--_index];
+
+                    if (child.NodeType == NodeType.Element)
+                    {
+                        _current = (Element)child;
+                        return true;
+                    }
+                }
+
+                return false;
+            }
+
+            _current = _current?.PreviousElementSibling;
+            return _current != null;
+        }
+
+        private Boolean MoveColumn()
+        {
+            if (!_started)
+            {
+                _started = true;
+                _cells = CssCombinator.GetColumnCells(_source);
+            }
+
+            if (_cells != null && _index < _cells.Count)
+            {
+                _current = _cells[_index++];
+                return true;
+            }
+
+            return false;
+        }
+
+        #endregion
+    }
+}

--- a/src/AngleSharp/Css/Parser/CssCombinator.cs
+++ b/src/AngleSharp/Css/Parser/CssCombinator.cs
@@ -53,9 +53,11 @@ namespace AngleSharp.Css.Parser
         #region Properties
 
         /// <summary>
-        /// Gets the transformation function for the combinator.
+        /// Gets the traversal performed by the combinator. Matching walks it
+        /// through a <see cref="CombinatorCursor"/> instead of a delegate, so
+        /// that stepping over a candidate element does not allocate.
         /// </summary>
-        public Func<IElement, IEnumerable<IElement>>? Transform
+        public CssCombinatorKind Kind
         {
             get;
             protected set;
@@ -85,12 +87,176 @@ namespace AngleSharp.Css.Parser
 
         #region Helpers
 
-        protected static IEnumerable<IElement> Single(IElement? element)
+        /// <summary>
+        /// Gets the cells sharing the column of the given cell, or null if the
+        /// element is not a cell of a table column.
+        /// </summary>
+        internal static List<IElement>? GetColumnCells(IElement element)
         {
-            if (element != null)
+            var table = GetContainingTable(element);
+
+            if (table is null)
             {
-                yield return element;
+                return null;
             }
+
+            var columnIndex = GetColumnIndex(element);
+
+            if (columnIndex < 0)
+            {
+                return null;
+            }
+
+            var rows = GetTableRows(table);
+            var cells = new List<IElement>();
+
+            foreach (var row in rows)
+            {
+                var cell = GetCellAtColumn(row, columnIndex);
+
+                if (cell != null)
+                {
+                    cells.Add(cell);
+                }
+            }
+
+            return cells;
+        }
+
+        private static IElement? GetContainingTable(IElement element)
+        {
+            var current = element.ParentElement;
+
+            while (current != null)
+            {
+                if (current.LocalName == "table")
+                {
+                    return current;
+                }
+
+                current = current.ParentElement;
+            }
+
+            return null;
+        }
+
+        private static Int32 GetColumnIndex(IElement cell)
+        {
+            var tagName = cell.LocalName;
+
+            if (tagName != "td" && tagName != "th")
+            {
+                return -1;
+            }
+
+            var row = cell.ParentElement;
+
+            if (row == null)
+            {
+                return -1;
+            }
+
+            var columnIndex = 0;
+
+            foreach (var child in row.ChildNodes)
+            {
+                if (child is IElement childElement)
+                {
+                    var childTagName = childElement.LocalName;
+
+                    if (childTagName == "td" || childTagName == "th")
+                    {
+                        if (Object.ReferenceEquals(childElement, cell))
+                        {
+                            return columnIndex;
+                        }
+
+                        columnIndex += GetColumnSpan(childElement);
+                    }
+                }
+            }
+
+            return -1;
+        }
+
+        private static IElement? GetCellAtColumn(IElement row, Int32 columnIndex)
+        {
+            var tagName = row.LocalName;
+
+            if (tagName != "tr")
+            {
+                return null;
+            }
+
+            var currentIndex = 0;
+
+            foreach (var child in row.ChildNodes)
+            {
+                if (child is IElement childElement)
+                {
+                    var childTagName = childElement.LocalName;
+
+                    if (childTagName == "td" || childTagName == "th")
+                    {
+                        if (currentIndex == columnIndex)
+                        {
+                            return childElement;
+                        }
+
+                        currentIndex += GetColumnSpan(childElement);
+                    }
+                }
+            }
+
+            return null;
+        }
+
+        private static Int32 GetColumnSpan(IElement cell)
+        {
+            var colspanAttr = cell.GetAttribute("colspan");
+
+            if (!String.IsNullOrEmpty(colspanAttr) && Int32.TryParse(colspanAttr, out var parsedColspan) && parsedColspan > 0)
+            {
+                return parsedColspan;
+            }
+
+            return 1;
+        }
+
+        private static List<IElement> GetTableRows(IElement table)
+        {
+            var rows = new List<IElement>();
+
+            // Direct tr children
+            foreach (var child in table.ChildNodes)
+            {
+                if (child is IElement element && element.LocalName == "tr")
+                {
+                    rows.Add(element);
+                }
+            }
+
+            // tr children within thead, tbody, tfoot
+            var sections = new[] { "thead", "tbody", "tfoot" };
+
+            foreach (var section in sections)
+            {
+                foreach (var child in table.ChildNodes)
+                {
+                    if (child is IElement sectionElement && sectionElement.LocalName == section)
+                    {
+                        foreach (var sectionChild in sectionElement.ChildNodes)
+                        {
+                            if (sectionChild is IElement rowElement && rowElement.LocalName == "tr")
+                            {
+                                rows.Add(rowElement);
+                            }
+                        }
+                    }
+                }
+            }
+
+            return rows;
         }
 
         #endregion
@@ -102,7 +268,7 @@ namespace AngleSharp.Css.Parser
             public ChildCombinator()
             {
                 Delimiter = CombinatorSymbols.Child;
-                Transform = el => Single(el.ParentElement);
+                Kind = CssCombinatorKind.Child;
             }
         }
 
@@ -111,7 +277,7 @@ namespace AngleSharp.Css.Parser
             public DeepCombinator()
             {
                 Delimiter = CombinatorSymbols.Deep;
-                Transform = el => Single(el.Parent is IShadowRoot shadowRoot ? shadowRoot.Host : null);
+                Kind = CssCombinatorKind.Deep;
             }
         }
 
@@ -120,18 +286,7 @@ namespace AngleSharp.Css.Parser
             public DescendantCombinator()
             {
                 Delimiter = CombinatorSymbols.Descendant;
-                Transform = GetAncestors;
-            }
-
-            private static IEnumerable<IElement> GetAncestors(IElement el)
-            {
-                var parent = el.ParentElement;
-
-                while (parent != null)
-                {
-                    yield return parent;
-                    parent = parent.ParentElement;
-                }
+                Kind = CssCombinatorKind.Descendant;
             }
         }
 
@@ -140,7 +295,7 @@ namespace AngleSharp.Css.Parser
             public AdjacentSiblingCombinator()
             {
                 Delimiter = CombinatorSymbols.Adjacent;
-                Transform = el => Single(el.PreviousElementSibling);
+                Kind = CssCombinatorKind.AdjacentSibling;
             }
         }
 
@@ -149,47 +304,7 @@ namespace AngleSharp.Css.Parser
             public SiblingCombinator()
             {
                 Delimiter = CombinatorSymbols.Sibling;
-                Transform = GetPreviousSiblings;
-            }
-
-            private static IEnumerable<IElement> GetPreviousSiblings(IElement element)
-            {
-                // Walking PreviousElementSibling repeatedly is quadratic, since each step
-                // has to locate the element in its parent again. Scan the child list once.
-                if (element is Node node && node.Parent is Node parent)
-                {
-                    var children = parent.ChildNodes;
-                    var index = -1;
-
-                    for (var i = 0; i < children.Length; i++)
-                    {
-                        if (Object.ReferenceEquals(children[i], node))
-                        {
-                            index = i;
-                            break;
-                        }
-                    }
-
-                    for (var i = index - 1; i >= 0; i--)
-                    {
-                        var child = children[i];
-
-                        if (child.NodeType == NodeType.Element)
-                        {
-                            yield return (Element)child;
-                        }
-                    }
-                }
-                else
-                {
-                    var sibling = element.PreviousElementSibling;
-
-                    while (sibling != null)
-                    {
-                        yield return sibling;
-                        sibling = sibling.PreviousElementSibling;
-                    }
-                }
+                Kind = CssCombinatorKind.Sibling;
             }
         }
 
@@ -198,7 +313,7 @@ namespace AngleSharp.Css.Parser
             public NamespaceCombinator()
             {
                 Delimiter = CombinatorSymbols.Pipe;
-                Transform = Single;
+                Kind = CssCombinatorKind.Namespace;
             }
 
             public override ISelector Change(ISelector selector)
@@ -218,166 +333,7 @@ namespace AngleSharp.Css.Parser
             public ColumnCombinator()
             {
                 Delimiter = CombinatorSymbols.Column;
-                Transform = el =>
-                {
-                    var cells = new List<IElement>();
-                    var table = GetContainingTable(el);
-                    
-                    if (table != null)
-                    {
-                        var columnIndex = GetColumnIndex(el);
-                        
-                        if (columnIndex >= 0)
-                        {
-                            var rows = GetTableRows(table);
-                            
-                            foreach (var row in rows)
-                            {
-                                var cell = GetCellAtColumn(row, columnIndex);
-                                if (cell != null)
-                                {
-                                    cells.Add(cell);
-                                }
-                            }
-                        }
-                    }
-                    
-                    return cells;
-                };
-            }
-
-            private static IElement? GetContainingTable(IElement element)
-            {
-                var current = element.ParentElement;
-                
-                while (current != null)
-                {
-                    if (current.LocalName == "table")
-                    {
-                        return current;
-                    }
-                    
-                    current = current.ParentElement;
-                }
-                
-                return null;
-            }
-
-            private static int GetColumnIndex(IElement cell)
-            {
-                var tagName = cell.LocalName;
-                if (tagName != "td" && tagName != "th")
-                {
-                    return -1;
-                }
-
-                var row = cell.ParentElement;
-                if (row == null)
-                {
-                    return -1;
-                }
-
-                int columnIndex = 0;
-                
-                foreach (var child in row.ChildNodes)
-                {
-                    if (child is IElement childElement)
-                    {
-                        var childTagName = childElement.LocalName;
-                        if (childTagName == "td" || childTagName == "th")
-                        {
-                            if (Object.ReferenceEquals(childElement, cell))
-                            {
-                                return columnIndex;
-                            }
-
-                            var colspanAttr = childElement.GetAttribute("colspan");
-                            var colspan = 1;
-                            
-                            if (!String.IsNullOrEmpty(colspanAttr) && Int32.TryParse(colspanAttr, out var parsedColspan) && parsedColspan > 0)
-                            {
-                                colspan = parsedColspan;
-                            }
-
-                            columnIndex += colspan;
-                        }
-                    }
-                }
-
-                return -1;
-            }
-
-            private static IElement? GetCellAtColumn(IElement row, int columnIndex)
-            {
-                var tagName = row.LocalName;
-                if (tagName != "tr")
-                {
-                    return null;
-                }
-
-                int currentIndex = 0;
-                
-                foreach (var child in row.ChildNodes)
-                {
-                    if (child is IElement childElement)
-                    {
-                        var childTagName = childElement.LocalName;
-                        if (childTagName == "td" || childTagName == "th")
-                        {
-                            if (currentIndex == columnIndex)
-                            {
-                                return childElement;
-                            }
-
-                            var colspanAttr = childElement.GetAttribute("colspan");
-                            var colspan = 1;
-                            
-                            if (!String.IsNullOrEmpty(colspanAttr) && Int32.TryParse(colspanAttr, out var parsedColspan) && parsedColspan > 0)
-                            {
-                                colspan = parsedColspan;
-                            }
-
-                            currentIndex += colspan;
-                        }
-                    }
-                }
-
-                return null;
-            }
-
-            private static List<IElement> GetTableRows(IElement table)
-            {
-                var rows = new List<IElement>();
-                
-                // Direct tr children
-                foreach (var child in table.ChildNodes)
-                {
-                    if (child is IElement element && element.LocalName == "tr")
-                    {
-                        rows.Add(element);
-                    }
-                }
-                
-                // tr children within thead, tbody, tfoot
-                var sections = new[] { "thead", "tbody", "tfoot" };
-                foreach (var section in sections)
-                {
-                    foreach (var child in table.ChildNodes)
-                    {
-                        if (child is IElement sectionElement && sectionElement.LocalName == section)
-                        {
-                            foreach (var sectionChild in sectionElement.ChildNodes)
-                            {
-                                if (sectionChild is IElement rowElement && rowElement.LocalName == "tr")
-                                {
-                                    rows.Add(rowElement);
-                                }
-                            }
-                        }
-                    }
-                }
-                
-                return rows;
+                Kind = CssCombinatorKind.Column;
             }
         }
 


### PR DESCRIPTION
# Types of Changes

## Prerequisites

Please make sure you can check the following two boxes:

- [x] I have read the **CONTRIBUTING** document
- [x] My code follows the code style of this project

## Contribution Type

What types of changes does your code introduce? Put an `x` in all the boxes that apply:

- [ ] Bug fix (non-breaking change which fixes an issue, please reference the issue id)
- [ ] New feature (non-breaking change which adds functionality, make sure to open an associated issue first)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] My change requires a change to the documentation
- [ ] I have updated the documentation accordingly
- [x] I have added tests to cover my changes
- [x] All new and existing tests passed

## Description

`CssCombinator` exposed a `Func<IElement, IEnumerable<IElement>> Transform` implemented by
`yield return` methods, and `ComplexSelector.MatchCascade` invoked it **once per candidate
element per combinator position**. Every combinator step therefore allocated a compiler-generated iterator on the hot selector-matching path.

This replaces the delegate with a `CssCombinatorKind` enum plus a `CombinatorCursor` struct holding a hand-rolled state machine, so the traversal lives on the stack:

- `Child` / `Deep` / `AdjacentSibling` / `Namespace` reach at most one element.
- `Descendant` walks `ParentElement` through a stored field.
- `Sibling` keeps the existing single-scan index walk (the non-quadratic path added
  earlier), now as an index field rather than an iterator.
- `Column` stays the only kind that materialises a list, since `||` needs the table rows
  collected in a defined order.

`Transform` was only ever consumed by `MatchCascade`, so the change is contained. The
column-cell helpers moved out of the nested `ColumnCombinator` into `CssCombinator.GetColumnCells`; while moving them I folded the duplicated colspan parsing
into one `GetColumnSpan` and normalised `int` to `Int32` per the project convention.

### Measurements

Allocations, 16k-element document, `GC.GetAllocatedBytesForCurrentThread`, net10.0:

| Selector | before | after | ratio |
|---|---|---|---|
| `p` *(control, no combinator)* | 131,476 B | 131,476 B | 1.00 |
| `div p` | 467,476 B | 131,476 B | 0.28 |
| `section div p` | 803,476 B | 131,476 B | 0.16 |
| `div > p` | 419,476 B | 131,476 B | 0.31 |
| `p + p` | 353,916 B | 65,916 B | 0.19 |
| `p ~ p` | 497,916 B | 65,916 B | 0.13 |
| `body div p span` *(0 matches)* | 112,148 B | 148 B | 0.001 |

Every multi-part selector now allocates exactly what the combinator-free control does; the
remainder is the result list, and combinator traversal contributes nothing.

| Selector | before | after | Ratio | Alloc Ratio |
|---|---|---|---|---|
| `.note` *(control)* | 17.72 us | 17.13 us | 0.97 | 1.00 |
| `div` *(control)* | 16.05 us | 15.35 us | 0.96 | 1.00 |
| `div p` | 25.88 us | 22.13 us | 0.86 | 0.19 |
| `div > p` | 22.65 us | 19.43 us | 0.86 | 0.22 |
| `div p a` | 32.46 us | 27.83 us | 0.86 | 0.02 |
| `div + p` | 52.27 us | 46.04 us | 0.88 | 0.04 |
| `div ~ p` | 55.37 us | 53.73 us | 0.97 | 0.16 |
| `h1#title + div > p` | 42.18 us | 39.21 us | 0.93 | 0.007 |

Please read the controls before the results. `div` and `.note` contain no combinator, so
both builds run identical code there, yet they measure 0.96 / 0.97 — a systematic ~3-4%
bias. Netting that out, the honest timing gain is roughly 11% for the descendant/child
selectors, ~9% for `div + p`, ~4% for `h1#title + div > p`, and parity for `div ~ p`. The
allocation column is deterministic and needs no such hedge.
