### PR TITLE
Preserve HTML namespace local-name case during element creation

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,7 @@
 Released on Saturday, September 5 2026
 
 - Improved AngleSharp's test website
+- Fixed HTML-namespace element creation losing local-name case (#1327)
 - Fixed script data escaped state potentially not bouncing back correctly
 - Added the `DomSameObject` annotation for the respective IDL members (#1314) @lahma
 - Added the `DomReturnType` annotation for methods returning a different IDL type (#1318)

--- a/src/AngleSharp.Benchmarks/ElementCreationBenchmark.cs
+++ b/src/AngleSharp.Benchmarks/ElementCreationBenchmark.cs
@@ -1,0 +1,53 @@
+namespace AngleSharp.Benchmarks
+{
+    using AngleSharp.Dom;
+    using AngleSharp.Html.Parser;
+    using BenchmarkDotNet.Attributes;
+    using System;
+    using System.IO;
+
+    [MemoryDiagnoser]
+    public class ElementCreationBenchmark
+    {
+        private IDocument _document;
+        private IElement _element;
+
+        [Params("div", "title", "unknown", "DiV", "ABC")]
+        public String Name { get; set; }
+
+        [GlobalSetup]
+        public void Setup()
+        {
+            _document = new HtmlParser().ParseDocument("<!doctype html><body></body>");
+            _element = _document.CreateElement(NamespaceNames.HtmlUri, Name);
+        }
+
+        [Benchmark]
+        public IElement CreateElement() => _document.CreateElement(Name);
+
+        [Benchmark]
+        public IElement CreateElementNS() => _document.CreateElement(NamespaceNames.HtmlUri, Name);
+
+        [Benchmark]
+        public INode CloneElement() => _element.Clone(false);
+    }
+
+    [MemoryDiagnoser]
+    public class ElementCreationParserBenchmark
+    {
+        private readonly HtmlParser _parser = new HtmlParser();
+        private String _page;
+
+        [GlobalSetup]
+        public void Setup()
+        {
+            _page = File.ReadAllText("page.html");
+        }
+
+        [Benchmark]
+        public IDocument ParsePage() => _parser.ParseDocument(_page);
+
+        [Benchmark]
+        public IDocument ParseSmallDocument() => _parser.ParseDocument("<!doctype html><title>Title</title><div><span>Text</span><input><unknown>Custom</unknown></div>");
+    }
+}

--- a/src/AngleSharp.Core.Tests/Library/ElementCreation.cs
+++ b/src/AngleSharp.Core.Tests/Library/ElementCreation.cs
@@ -1,0 +1,127 @@
+namespace AngleSharp.Core.Tests.Library
+{
+    using AngleSharp.Core.Tests.Mocks;
+    using AngleSharp.Dom;
+    using AngleSharp.Html;
+    using AngleSharp.Html.Dom;
+    using AngleSharp.Text;
+    using NUnit.Framework;
+    using System;
+
+    [TestFixture]
+    public class ElementCreationTests
+    {
+        // DOM createElementNS preserves the extracted local name in every document type.
+        [Test]
+        public void HtmlNamespacePreservesLocalName(
+            [Values("I", "ABC", "DiV", "div", "title", "unknown", "X-Widget", "\u0130", "\u212A")] String name,
+            [Values(false, true)] Boolean xml,
+            [Values(null, "h")] String prefix)
+        {
+            var document = CreateDocument(xml);
+            var qualifiedName = prefix is null ? name : prefix + ":" + name;
+            var element = document.CreateElement(NamespaceNames.HtmlUri, qualifiedName);
+
+            Assert.AreEqual(name, element.LocalName);
+            Assert.AreEqual(prefix, element.Prefix);
+            Assert.AreEqual(NamespaceNames.HtmlUri, element.NamespaceUri);
+        }
+
+        // HTML's element-interface lookup uses the exact local name.
+        [TestCase("div", typeof(IHtmlDivElement))]
+        [TestCase("input", typeof(IHtmlInputElement))]
+        [TestCase("title", typeof(IHtmlTitleElement))]
+        [TestCase("DiV", typeof(IHtmlUnknownElement))]
+        [TestCase("INPUT", typeof(IHtmlUnknownElement))]
+        [TestCase("TITLE", typeof(IHtmlUnknownElement))]
+        [TestCase("ABC", typeof(IHtmlUnknownElement))]
+        public void HtmlNamespaceSelectsInterfaceByExactName(String name, Type type)
+        {
+            var document = String.Empty.ToHtmlDocument();
+            var element = document.CreateElement(NamespaceNames.HtmlUri, name);
+
+            Assert.IsInstanceOf(type, element);
+            Assert.AreEqual(name, element.LocalName);
+        }
+
+        [TestCase("DIV", "div", typeof(IHtmlDivElement))]
+        [TestCase("TITLE", "title", typeof(IHtmlTitleElement))]
+        [TestCase("ABC", "abc", typeof(IHtmlUnknownElement))]
+        [TestCase("\u0130", "\u0130", typeof(IHtmlUnknownElement))]
+        public void OrdinaryHtmlCreationStillUsesAsciiLowercase(String name, String expected, Type type)
+        {
+            var document = String.Empty.ToHtmlDocument();
+            var element = document.CreateElement(name);
+
+            Assert.AreEqual(expected, element.LocalName);
+            Assert.IsInstanceOf(type, element);
+        }
+
+        [Test]
+        public void ParserStillNormalizesHtmlNames()
+        {
+            var document = "<!doctype html><TITLE>t</TITLE><DIV><ABC></ABC></DIV>".ToHtmlDocument();
+
+            Assert.IsInstanceOf<IHtmlTitleElement>(document.Head.FirstElementChild);
+            Assert.IsInstanceOf<IHtmlDivElement>(document.Body.FirstElementChild);
+            Assert.AreEqual("div", document.Body.FirstElementChild.LocalName);
+            Assert.AreEqual("abc", document.Body.FirstElementChild.FirstElementChild.LocalName);
+        }
+
+        [Test]
+        public void CloneAndImportPreserveHtmlNamespaceIdentity(
+            [Values("I", "ABC", "DiV", "div", "title")] String name,
+            [Values(false, true)] Boolean deep)
+        {
+            var document = String.Empty.ToHtmlDocument();
+            var element = document.CreateElement(NamespaceNames.HtmlUri, "h:" + name);
+            element.SetAttribute("data-test", "value");
+            element.AppendChild(document.CreateTextNode("child"));
+            var target = String.Empty.ToHtmlDocument();
+
+            foreach (var copy in new[] { (IElement)element.Clone(deep), (IElement)target.Import(element, deep) })
+            {
+                Assert.AreEqual(name, copy.LocalName);
+                Assert.AreEqual("h", copy.Prefix);
+                Assert.AreEqual(NamespaceNames.HtmlUri, copy.NamespaceUri);
+                Assert.AreEqual(element.GetType(), copy.GetType());
+                Assert.AreEqual("value", copy.GetAttribute("data-test"));
+                Assert.AreEqual(deep ? "child" : String.Empty, copy.TextContent);
+            }
+        }
+
+        [Test]
+        public void NamespaceCreationUsesConfiguredHtmlFactory()
+        {
+            var factory = new RecordingHtmlFactory();
+            var config = Configuration.Default.WithOnly<IElementFactory<Document, HtmlElement>>(factory);
+            var document = String.Empty.ToHtmlDocument(config);
+            var element = document.CreateElement(NamespaceNames.HtmlUri, "h:DiV");
+
+            Assert.AreEqual("DiV", factory.LocalName);
+            Assert.AreEqual("h", factory.Prefix);
+            Assert.AreSame(factory.Element, element);
+        }
+
+        private static IDocument CreateDocument(Boolean xml)
+        {
+            // Core's XML-content Document base is also used by the XML plugin.
+            return xml ? new MarkdownDocument(BrowsingContext.New(), new TextSource(String.Empty)) : String.Empty.ToHtmlDocument();
+        }
+
+        private sealed class RecordingHtmlFactory : IElementFactory<Document, HtmlElement>
+        {
+            public String LocalName { get; private set; }
+            public String Prefix { get; private set; }
+            public HtmlElement Element { get; private set; }
+
+            public HtmlElement Create(Document document, String localName, String prefix = null, NodeFlags flags = NodeFlags.None)
+            {
+                LocalName = localName;
+                Prefix = prefix;
+                Element = HtmlElementFactory.Instance.Create(document, localName, prefix, flags);
+                return Element;
+            }
+        }
+    }
+}

--- a/src/AngleSharp/Dom/Internal/Document.cs
+++ b/src/AngleSharp/Dom/Internal/Document.cs
@@ -1095,7 +1095,7 @@ namespace AngleSharp.Dom
             if (localName.IsXmlName())
             {
                 var factory = _context.GetFactory<IElementFactory<Document, HtmlElement>>();
-                var element = factory.Create(this, localName);
+                var element = factory.Create(this, localName.HtmlLower());
                 element.SetupElement();
                 return element;
             }

--- a/src/AngleSharp/Html/HtmlElementFactory.cs
+++ b/src/AngleSharp/Html/HtmlElementFactory.cs
@@ -2,7 +2,6 @@ namespace AngleSharp.Html;
 
 using AngleSharp.Dom;
 using AngleSharp.Html.Dom;
-using AngleSharp.Text;
 using System;
 using System.Collections.Generic;
 #if NET8_0_OR_GREATER
@@ -18,7 +17,7 @@ sealed class HtmlElementFactory : IElementFactory<Document, HtmlElement>
 
     private delegate HtmlElement Creator(Document owner, String? prefix);
 
-    private static readonly Dictionary<String, Creator> _creatorsDict = new(StringComparer.OrdinalIgnoreCase)
+    private static readonly Dictionary<String, Creator> _creatorsDict = new(StringComparer.Ordinal)
     {
         { TagNames.Div, (document, prefix) => new HtmlDivElement(document, prefix) },
         { TagNames.A, (document, prefix) => new HtmlAnchorElement(document, prefix) },
@@ -160,7 +159,7 @@ sealed class HtmlElementFactory : IElementFactory<Document, HtmlElement>
     };
 
 #if NET8_0_OR_GREATER
-    private static readonly FrozenDictionary<String, Creator> creators = _creatorsDict.ToFrozenDictionary(StringComparer.OrdinalIgnoreCase);
+    private static readonly FrozenDictionary<String, Creator> creators = _creatorsDict.ToFrozenDictionary(StringComparer.Ordinal);
 #else
     private static readonly Dictionary<String, Creator> creators = _creatorsDict;
 #endif
@@ -215,6 +214,6 @@ sealed class HtmlElementFactory : IElementFactory<Document, HtmlElement>
             return creator.Invoke(document, prefix);
         }
 
-        return new HtmlUnknownElement(document, localName.HtmlLower(), prefix, flags);
+        return new HtmlUnknownElement(document, localName, prefix, flags);
     }
 }


### PR DESCRIPTION
# Types of Changes

## Prerequisites

- [x] I have read the **CONTRIBUTING** document
- [x] My code follows the code style of this project

## Contribution Type

- [x] Bug fix (non-breaking change which fixes an issue, please reference the issue id)
- [ ] New feature (non-breaking change which adds functionality, make sure to open an associated issue first)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] My change requires a change to the documentation
- [x] I have updated the documentation accordingly
- [x] I have added tests to cover my changes
- [x] All new and existing tests passed

## Description

Fixes #1327.

`CreateElement(NamespaceNames.HtmlUri, "DiV")` currently creates a lowercase `div` with a specialized div interface, and `"ABC"` becomes `"abc"`. Preserve the extracted local name and select HTML interfaces by exact name, as required by [DOM createElementNS](https://dom.spec.whatwg.org/#dom-document-createelementns) and the [HTML element interface algorithm](https://html.spec.whatwg.org/multipage/dom.html#elements-in-the-dom).

The HTML factory now uses ordinal lookup and passes unknown names through unchanged. Ordinary `CreateElement(name)` performs its existing ASCII lowercasing before factory dispatch. Lowercase specialization, tokenizer reference-equality fast paths, configured factory dispatch, and parser normalization remain in place. Clone uses the same factory and retains the corrected identity.

Regression tests cover HTML and XML-content document creation, prefixed and non-ASCII names, known/unknown interfaces, parser and ordinary creation controls, configured factories, and shallow/deep clone/import identity. The changelog records the behavior change. Insertion namespace mutation, namespace-aware query comparison, XML node-name casing, and import ownership are outside this fix; no blanket downstream WPT success is claimed.

### Validation

On macOS arm64, .NET SDK 10.0.400, against base `1b8579bea408b816891c61d047eb80152fc4f9af`:

- Standalone reproduction confirms the defect on 1.8.0 and unmodified devel. A separate comparison with AngleSharp.Xml 1.2.0 confirms preserved local names in both HTML and XML documents after the fix.
- The final 59 regression cases produce 26 failures on the base and all pass after the fix. Focused factory/DOM action run: 152 passed.
- Full `net10.0` suite: 3,937 passed, zero failures, seven not executed. With `prefetched=true`: 3,935 passed, zero failures, nine not executed (TRX counts include network/inconclusive and mode-specific skips).
- Release library build for `netstandard2.0;net8.0;net10.0`: zero warnings/errors. Windows framework execution was not available.
- Benchmark harness compiles in Release/net10.0. **Comparative benchmarks are prepared but have not run because the host is busy; no performance claim is made.** The harness covers ordinary and namespace-aware creation, clone, and offline small/real-page parsing. Timing and allocation comparisons will run serially on an available host.

