### PR TITLE
Fix HTML hyperlink pseudo-class classification

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,7 @@
 
 Released on Saturday, September 5 2026
 
+- Fixed HTML hyperlink pseudo-classes omitting empty `href` and matching `link` elements (#1337)
 - Improved AngleSharp's test website
 - Fixed script data escaped state potentially not bouncing back correctly
 - Added the `DomSameObject` annotation for the respective IDL members (#1314) @lahma

--- a/src/AngleSharp.Core.Tests/Css/CssLinkSelector.cs
+++ b/src/AngleSharp.Core.Tests/Css/CssLinkSelector.cs
@@ -1,0 +1,98 @@
+namespace AngleSharp.Core.Tests.Css
+{
+    using AngleSharp.Dom;
+    using NUnit.Framework;
+    using System;
+    using System.Linq;
+
+    [TestFixture]
+    public class CssLinkSelectorTests
+    {
+        // https://html.spec.whatwg.org/multipage/semantics-other.html#selector-link
+        [Test]
+        public void HtmlHyperlinksDependOnHrefPresence(
+            [Values("a", "area", "link", "div", "base")] String tagName,
+            [Values(null, "", " ", "/next")] String href)
+        {
+            var document = $"<!doctype html><{tagName} id='target'></{tagName}>".ToHtmlDocument();
+            var element = document.QuerySelector("#target");
+
+            if (href != null)
+            {
+                element.SetAttribute("href", href);
+            }
+
+            var expected = (tagName == "a" || tagName == "area") && href != null;
+
+            AssertLinkState(element, expected);
+            Assert.AreEqual(expected ? element : null, document.QuerySelector(":any-link"));
+            Assert.AreEqual(expected ? element : null, document.QuerySelector(":link"));
+            Assert.AreEqual(expected ? 1 : 0, document.QuerySelectorAll(":any-link").Length);
+            Assert.AreEqual(expected ? 1 : 0, document.QuerySelectorAll(":link").Length);
+            Assert.AreEqual(0, document.QuerySelectorAll(":visited").Length);
+        }
+
+        [TestCase("a", true)]
+        [TestCase("area", true)]
+        [TestCase("link", false)]
+        public void LinkStateTracksHrefMutation(String tagName, Boolean hyperlink)
+        {
+            var document = $"<!doctype html><{tagName} id='target'></{tagName}>".ToHtmlDocument();
+            var element = document.QuerySelector("#target");
+
+            AssertLinkState(element, false);
+            element.SetAttribute("href", String.Empty);
+            AssertLinkState(element, hyperlink);
+            element.SetAttribute("href", "/next");
+            AssertLinkState(element, hyperlink);
+            element.RemoveAttribute("href");
+            AssertLinkState(element, false);
+        }
+
+        [TestCase("a", true)]
+        [TestCase("area", true)]
+        [TestCase("link", false)]
+        public void HtmlHyperlinksRequireNoNamespaceHref(String tagName, Boolean hyperlink)
+        {
+            var document = $"<!doctype html><{tagName} id='target'></{tagName}>".ToHtmlDocument();
+            var element = document.QuerySelector("#target");
+
+            element.SetAttribute("urn:example", "href", "/namespaced");
+            AssertLinkState(element, false);
+            element.SetAttribute("href", String.Empty);
+            AssertLinkState(element, hyperlink);
+            element.RemoveAttribute(null, "href");
+            AssertLinkState(element, false);
+        }
+
+        // https://github.com/web-platform-tests/wpt/blob/master/dom/nodes/selectors.js
+        [Test]
+        public void LinkQueriesPartitionHtmlHyperlinksAndExcludeHeadLinks()
+        {
+            var document = ("<!doctype html><head><link id='stylesheet' href='/style.css'></head><body>" +
+                "<a id='a-empty' href=''></a><a id='a-full' href='/next'></a><a id='a-absent'></a>" +
+                "<map><area id='area-empty' href=''><area id='area-full' href='/map'><area id='area-absent'></map>" +
+                "<div href='/other'></div></body>").ToHtmlDocument();
+            var expected = new[] { "a-empty", "a-full", "area-empty", "area-full" };
+
+            foreach (var selector in new[] { ":any-link", ":link", ":link, :visited" })
+            {
+                CollectionAssert.AreEqual(expected, document.QuerySelectorAll(selector).Select(element => element.Id));
+                Assert.AreEqual("a-empty", document.QuerySelector(selector).Id);
+            }
+
+            Assert.AreEqual(0, document.QuerySelectorAll("head :any-link, head :link, head :visited").Length);
+            Assert.AreEqual(0, document.QuerySelectorAll(":link:visited").Length);
+            Assert.AreEqual(0, document.QuerySelectorAll(":visited").Length);
+        }
+
+        private static void AssertLinkState(IElement element, Boolean expected)
+        {
+            Assert.AreEqual(expected, element.IsLink());
+            Assert.AreEqual(expected, element.Matches(":link"));
+            Assert.AreEqual(expected, element.Matches(":any-link"));
+            Assert.IsFalse(element.IsVisited());
+            Assert.IsFalse(element.Matches(":visited"));
+        }
+    }
+}

--- a/src/AngleSharp/Dom/ElementExtensions.cs
+++ b/src/AngleSharp/Dom/ElementExtensions.cs
@@ -567,18 +567,11 @@ namespace AngleSharp.Dom
         {
             if (element is IHtmlAnchorElement anchor)
             {
-                var href = element.GetAttribute(null, AttributeNames.Href);
-                return !String.IsNullOrEmpty(href) && CheckVisited(anchor);
+                return element.HasAttribute(null, AttributeNames.Href) && CheckVisited(anchor);
             }
             else if (element is IHtmlAreaElement area)
             {
-                var href = element.GetAttribute(null, AttributeNames.Href);
-                return !String.IsNullOrEmpty(href) && CheckVisited(area);
-            }
-            else if (element is IHtmlLinkElement link)
-            {
-                var href = element.GetAttribute(null, AttributeNames.Href);
-                return !String.IsNullOrEmpty(href) && CheckVisited(link);
+                return element.HasAttribute(null, AttributeNames.Href) && CheckVisited(area);
             }
 
             return false;
@@ -617,18 +610,11 @@ namespace AngleSharp.Dom
         {
             if (element is IHtmlAnchorElement anchor)
             {
-                var href = element.GetAttribute(null, AttributeNames.Href);
-                return !String.IsNullOrEmpty(href) && !anchor.IsVisited();
+                return element.HasAttribute(null, AttributeNames.Href) && !anchor.IsVisited();
             }
             else if (element is IHtmlAreaElement area)
             {
-                var href = element.GetAttribute(null, AttributeNames.Href);
-                return !String.IsNullOrEmpty(href) && !area.IsVisited();
-            }
-            else if (element is IHtmlLinkElement link)
-            {
-                var href = element.GetAttribute(null, AttributeNames.Href);
-                return !String.IsNullOrEmpty(href) && !link.IsVisited();
+                return element.HasAttribute(null, AttributeNames.Href) && !area.IsVisited();
             }
 
             return false;


### PR DESCRIPTION
## Description

Fixes #1337.

HTML `<a href="">` and `<area href="">` currently match neither `:any-link` nor `:link`, while `<link href="style.css">` matches both. Check no-namespace `href` attribute presence in the existing anchor/area branches of `IsLink` and `IsVisited`, and remove their HTML `link` branches. This follows [HTML's link-state definition](https://html.spec.whatwg.org/multipage/semantics-other.html#selector-link) and retains the existing no-history policy: qualifying hyperlinks match `:link`, and none match `:visited`. The factory continues to define `:any-link` as their union.

The 27 regression cases cover absent, empty, whitespace, and nonempty `href`; anchor/area/link and unrelated HTML elements; attribute mutation; namespaced attributes; public predicates; `Matches`; and document queries, including the WPT link-state union/exclusion cases. Ten cases fail before the fix; all 27 pass afterward.

This is limited to HTML hyperlink classification. SVG support and enabled-state matching (#1324 / #1326) remain separate. #1326 changes a different method in `ElementExtensions.cs` and uses a separate test file; only the competing changelog additions need reconciliation if either PR lands first.

## Validation

On macOS arm64, SDK 10.0.400 / runtime 10.0.11:

- Standalone reproduction confirms the bug on NuGet 1.8.0 and `devel` commit `1b8579bea408b816891c61d047eb80152fc4f9af`, and confirms the corrected output with this change.
- Full Release/net10.0 suite: 3,905 passed, zero failures. Raw TRX records seven existing ignored/inconclusive cases.
- Full suite with `prefetched=true`: 3,903 passed, zero failures. Raw TRX records nine existing ignored/inconclusive cases, including two read-only-text-source exclusions.
- Library Release build passes for `netstandard2.0`, `net8.0`, and `net10.0`, with zero warnings/errors. Windows-only .NET Framework targets were not run on this host.
- Comparative benchmark results are pending an exclusive quiet-host slot; no performance claim is made.

## Prerequisites

- [x] I have read the **CONTRIBUTING** document
- [x] My code follows the code style of this project

## Contribution Type

- [x] Bug fix (non-breaking change which fixes an issue, please reference the issue id)
- [ ] New feature (non-breaking change which adds functionality, make sure to open an associated issue first)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [x] My change requires a change to the documentation
- [x] I have updated the documentation accordingly (changelog)
- [x] I have added tests to cover my changes
- [x] All new and existing tests passed (executed tests; exclusions described above)
