### PR TITLE
Cache selector specificity and the specificity-sorted selector list

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,8 @@ Released on Friday, September 11 2026
 - Fixed `Document.Forms` allocating a new collection instance per read, contradicting its own `[DomSameObject]` contract
 - Improved id/name lookup on collections (`document.forms["x"]`, `form.elements["x"]`, ...) to enumerate the underlying sequence once instead of twice
 - Improved `GetElementsByTagName` / `GetElementsByClassName` traversal to stop double-scanning each element's children
+- Improved selector specificity (`Selectors.Specificity`, `ComplexSelector.Specificity`) to be computed once instead of recomputed on every read
+- Improved `ListSelector.GetMatchingSelector` to sort its selectors once instead of on every call
 - Improved performance of parser attribute duplication check
 - Fixed vulnerability via SVG style serialization (GHSA-cgp3-27rh-pcp2)
 

--- a/src/AngleSharp.Benchmarks/QuerySelectorBenchmark.cs
+++ b/src/AngleSharp.Benchmarks/QuerySelectorBenchmark.cs
@@ -49,7 +49,14 @@ namespace AngleSharp.Benchmarks
             "#title",
             ".note",
             // No match at all: forces a complete traversal even for QuerySelector.
-            "div.no-such-class-anywhere"
+            "div.no-such-class-anywhere",
+            // A compound selector with several simple-selector parts chained on one element -
+            // exercises CompoundSelector.Match/Specificity across all four parts per candidate.
+            "a.url.fn[href]",
+            // A selector list (ListSelector) with branches of differing specificity - exercises
+            // ListSelector.Match plus, for anything that reads it (e.g. IMultiSelector.
+            // GetMatchingSelector, or a host cascade), Selectors.Specificity across every branch.
+            "h1, h2, h3, .toc, .note"
         };
 
         [Benchmark]

--- a/src/AngleSharp/Css/Dom/Internal/ComplexSelector.cs
+++ b/src/AngleSharp/Css/Dom/Internal/ComplexSelector.cs
@@ -16,6 +16,8 @@ namespace AngleSharp.Css.Dom
 
         private readonly List<CombinatorSelector> _combinators;
 
+        private Priority? _specificity;
+
         #endregion
 
         #region ctor
@@ -29,19 +31,27 @@ namespace AngleSharp.Css.Dom
 
         #region Properties
 
+        // Cached once assembled: AppendSelector/ConcludeSelector are the only mutators, both stop
+        // taking effect once IsReady is set, and both clear this so a read can never be taken
+        // before the combinator chain is complete.
         public Priority Specificity
         {
             get
             {
-                var sum = new Priority();
-                var n = _combinators.Count;
-
-                for (var i = 0; i < n; i++)
+                if (_specificity is null)
                 {
-                    sum += _combinators[i].Selector.Specificity;
+                    var sum = new Priority();
+                    var n = _combinators.Count;
+
+                    for (var i = 0; i < n; i++)
+                    {
+                        sum += _combinators[i].Selector.Specificity;
+                    }
+
+                    _specificity = sum;
                 }
 
-                return sum;
+                return _specificity.Value;
             }
         }
 
@@ -111,6 +121,7 @@ namespace AngleSharp.Css.Dom
                     Delimiter = null
                 });
                 IsReady = true;
+                _specificity = null;
             }
         }
 
@@ -124,6 +135,7 @@ namespace AngleSharp.Css.Dom
                     Kind = combinator.Kind,
                     Delimiter = combinator.Delimiter
                 });
+                _specificity = null;
             }
         }
 

--- a/src/AngleSharp/Css/Dom/Internal/ListSelector.cs
+++ b/src/AngleSharp/Css/Dom/Internal/ListSelector.cs
@@ -10,6 +10,14 @@ namespace AngleSharp.Css.Dom
     /// </summary>
     sealed class ListSelector : Selectors, ISelector, IMultiSelector
     {
+        // Lazily built, specificity-descending copy of _selectors, dropped by Invalidate()
+        // whenever the list changes. GetMatchingSelector used to re-sort on every single call -
+        // allocating an ordered enumerable, its buffer and a key array each time, on top of an
+        // O(n) specificity recompute per key - even though the list is immutable once parsed.
+        // Mirrors the precedent in AngleSharp.Css's CssStyleRule.ISelectorVisitor.List, which
+        // sorts its own selector list once for the same reason.
+        private ISelector[]? _sortedBySpecificity;
+
         public void Accept(ISelectorVisitor visitor)
         {
             visitor.List(_selectors);
@@ -30,15 +38,25 @@ namespace AngleSharp.Css.Dom
 
         public ISelector? GetMatchingSelector(IElement element, IElement? scope = null)
         {
-            foreach (var selector in _selectors.OrderByDescending(m => m.Specificity))
+            // OrderByDescending is stable, so selectors of equal specificity keep their declared
+            // order - same as when this ran unsorted-then-sorted on every call.
+            var sorted = _sortedBySpecificity ??= _selectors.OrderByDescending(m => m.Specificity).ToArray();
+
+            for (var i = 0; i < sorted.Length; i++)
             {
-                if (selector.Match(element, scope))
+                if (sorted[i].Match(element, scope))
                 {
-                    return selector;
+                    return sorted[i];
                 }
             }
 
             return null;
+        }
+
+        protected override void Invalidate()
+        {
+            base.Invalidate();
+            _sortedBySpecificity = null;
         }
 
         protected override String Stringify()

--- a/src/AngleSharp/Css/Dom/Internal/Selectors.cs
+++ b/src/AngleSharp/Css/Dom/Internal/Selectors.cs
@@ -14,6 +14,8 @@ namespace AngleSharp.Css.Dom
 
         protected readonly List<ISelector> _selectors;
 
+        private Priority? _specificity;
+
         #endregion
 
         #region ctor
@@ -27,7 +29,12 @@ namespace AngleSharp.Css.Dom
 
         #region Properties
 
-        public Priority Specificity => ComputeSpecificity();
+        // A selector is immutable once parsing has assembled it - Add/Remove below only ever run
+        // while a CssSelectorConstructor is still building this list - so the specificity can be
+        // computed once and reused. CssStyleRule.TryMatch reads Specificity on every successful
+        // match, once per matched rule per element, which made this the same recomputation
+        // repeated across an entire cascade.
+        public Priority Specificity => _specificity ??= ComputeSpecificity();
 
         public String Text => Stringify();
 
@@ -36,7 +43,11 @@ namespace AngleSharp.Css.Dom
         public ISelector this[Int32 index]
         {
             get => _selectors[index];
-            set => _selectors[index] = value;
+            set
+            {
+                _selectors[index] = value;
+                Invalidate();
+            }
         }
 
         #endregion
@@ -47,9 +58,21 @@ namespace AngleSharp.Css.Dom
 
         protected abstract String Stringify();
 
-        public void Add(ISelector selector) => _selectors.Add(selector);
+        public void Add(ISelector selector)
+        {
+            _selectors.Add(selector);
+            Invalidate();
+        }
 
-        public void Remove(ISelector selector) => _selectors.Remove(selector);
+        public void Remove(ISelector selector)
+        {
+            _selectors.Remove(selector);
+            Invalidate();
+        }
+
+        // Overridden by ListSelector, which caches a specificity-ordered copy of _selectors and
+        // must drop it whenever the underlying list changes.
+        protected virtual void Invalidate() => _specificity = null;
 
         #endregion
 


### PR DESCRIPTION
## What the profile said

`Selectors.Specificity` (`src/AngleSharp/Css/Dom/Internal/Selectors.cs`) was `=> ComputeSpecificity()` — an unconditional recompute on every read. `CompoundSelector.ComputeSpecificity` and `ListSelector.ComputeSpecificity` are `O(n)` loops over their own selector list; `ComplexSelector.Specificity` loops all its combinators separately (it does not derive from `Selectors`). In `AngleSharp.Css`, `CssStyleRule.TryMatch` reads `.Specificity` on every successful match — once per matched rule per element — so a cascade over a large document repeats this recomputation across the entire match set.

Separately, `ListSelector.GetMatchingSelector` (`src/AngleSharp/Css/Dom/Internal/ListSelector.cs`) ran `_selectors.OrderByDescending(m => m.Specificity)` on **every call**, allocating an ordered enumerable, its buffer and a key array each time — on top of the specificity recompute above for every key.

## The mechanism

A selector is immutable once a `CssSelectorConstructor` has finished assembling it. `Add`/`Remove` (via the `Selectors` base class) and `ComplexSelector`'s `AppendSelector`/`ConcludeSelector` are the only mutators, and none of them run after parsing hands the selector back to its caller — confirmed by every caller in this repo (`CssSelectorConstructor.GetResult`, `Insert`, `InsertOr`) finishing the mutation before returning, and by the existing `SelectorPriorityTests`, which all read `.Specificity` only after `ParseSelector` returns.

## What I changed

- `Selectors.Specificity` now caches the computed `Priority` in a nullable field, computed lazily on first read.
- `Add`/`Remove` (and the indexer setter, unused today but part of the same surface) invalidate that cache through a new `protected virtual Invalidate()` hook, so a hypothetical premature read can never stick even though nothing exercises that today.
- `ComplexSelector.Specificity` gets the same treatment directly (it isn't a `Selectors` subclass), invalidated from `AppendSelector`/`ConcludeSelector`.
- `ListSelector.GetMatchingSelector` now caches the specificity-sorted array the same way, overriding `Invalidate()` to drop it too. This mirrors the existing precedent in `AngleSharp.Css`'s `CssStyleRule.ISelectorVisitor.List`, which already sorts its own selector list once instead of per match, for the identical reason.

## What I did not change, and why

- **`Selectors.Text` (`Stringify()`) stays uncached.** It allocates a fresh string per read, but nothing on the match path reads it — only parse-time error/serialization code (`CssSelectorConstructor`'s `:not()`/`:host-context()` error text) and the CSSOM's own `cssText` output do. Caching it would add a field with no exercised benefit, so I left it alone per this stream's brief ("judge it on whether anything hot reads it").
- **`GetMatchingSelector` has no internal caller in either `AngleSharp` or `AngleSharp.Css` today.** `CssStyleRule` bypasses it entirely via its own pre-sorted `_selectorList` (built once in `ISelectorVisitor.List`). It's only reachable through the public `IMultiSelector` API (exercised by `SelectorPriorityTests` in this repo). So this half of the change is not expected to move a cascade benchmark — it removes a real per-call allocation for any embedder that does call `GetMatchingSelector` directly, but there is no in-repo hot loop to demonstrate it against.

## Tests

- `dotnet test -c Release src/AngleSharp.Core.Tests/AngleSharp.Core.Tests.csproj -f net10.0` — 4035 passed, 1 skipped (pre-existing, network-dependent), 0 failed.
- No new tests added: this is a caching change behind an existing, already-tested public surface (`ISelector.Specificity`, `IMultiSelector.GetMatchingSelector`) — `SelectorPriorityTests` and the broader `Css/CssSelector*` suites already cover the values these caches return, before and after.

## To be measured

`dotnet run -c Release --project src/AngleSharp.Benchmarks -f net8.0 -- --filter "*QuerySelectorBenchmark*"` — I extended this with a multi-part compound selector (`a.url.fn[href]`) and a selector list (`h1, h2, h3, .toc, .note`) for broader `CompoundSelector`/`ListSelector` matching coverage, but note this is coverage, not a demonstration of the specificity cache: `QuerySelector`/`QuerySelectorAll` never read `.Specificity`. The change this PR is actually about is best measured in `AngleSharp.Css`'s `src/AngleSharp.Performance.Css/CssCascadeBenchmarks.cs` `ComputedStyle` row (see the companion `AngleSharp.Css` PR from this same stream), since that's where `.Specificity` is read on the hot path. I ran the extended `QuerySelectorBenchmark` rows once with `--job short` to confirm they execute; no numbers from that run should be treated as meaningful.

Part of a benchmark-gated performance campaign (stream U3). A companion PR against `AngleSharp.Css` (`perf/selector-matching`) fixes a related pseudo-class matching cost in the same area.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01WQwq9NqYqG3kk9M8CKdfdJ